### PR TITLE
Add FastAPI backend and simple React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# airecruiting
+# Air Recruiting Full-Stack App
+
+This repository contains a basic full-stack application with a FastAPI backend and a React frontend.
+
+## Backend
+
+The backend uses [FastAPI](https://fastapi.tiangolo.com/). The entry point is `app/main.py`.
+Run it with:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Frontend
+
+The frontend is a minimal React application located in the `frontend` folder. Open `frontend/index.html` in a browser to see the app.
+
+## Tests
+
+Tests use `pytest`. Run them with:
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from FastAPI"}
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Frontend</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,8 @@
+const e = React.createElement;
+
+function App() {
+  return e('div', null, 'Hello from React');
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(e(App));

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello from FastAPI"}


### PR DESCRIPTION
## Summary
- add FastAPI backend in `app` with a root endpoint
- add simple React frontend files
- add pytest test for the backend
- document how to run the app

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ca1ac7e688333b351914a6861bdbf