### PR TITLE
Add register/login endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,37 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 app = FastAPI()
+
+# Simple in-memory user "database"
+users = {}
+
+
+class UserRequest(BaseModel):
+    first_name: str
+    last_name: str
+    school: str
+    password: str
 
 @app.get("/")
 def read_root():
     return {"message": "Hello, World"}
+
+
+@app.post("/register")
+def register(user: UserRequest):
+    """Register a new user."""
+    key = f"{user.first_name}-{user.last_name}-{user.school}"
+    if key in users:
+        raise HTTPException(status_code=400, detail="User already exists")
+    users[key] = user.password
+    return {"message": "User registered successfully"}
+
+
+@app.post("/login")
+def login(user: UserRequest):
+    """Login a user and return a dummy token."""
+    key = f"{user.first_name}-{user.last_name}-{user.school}"
+    if users.get(key) != user.password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"token": "dummy-token"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,3 +7,32 @@ def test_read_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello, World"}
+
+
+def test_register_and_login():
+    user = {
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "school": "Example University",
+        "password": "secret",
+    }
+
+    # Register user
+    response = client.post("/register", json=user)
+    assert response.status_code == 200
+    assert response.json() == {"message": "User registered successfully"}
+
+    # Duplicate registration should fail
+    dup_response = client.post("/register", json=user)
+    assert dup_response.status_code == 400
+
+    # Successful login
+    login_resp = client.post("/login", json=user)
+    assert login_resp.status_code == 200
+    assert login_resp.json() == {"token": "dummy-token"}
+
+    # Wrong password
+    bad_user = dict(user)
+    bad_user["password"] = "wrong"
+    bad_resp = client.post("/login", json=bad_user)
+    assert bad_resp.status_code == 401


### PR DESCRIPTION
## Summary
- create POST `/register` API to save users in an in-memory dict
- create POST `/login` API to authenticate users and return a dummy token
- test registration and login flow

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d16ea9adc8333a0c6a24015d593db