### PR TITLE
Implement secure JWT auth system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 fastapi
 uvicorn
+bcrypt
+python-jose[cryptography]
+httpx
+pydantic[email]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
-from app.main import app
+from jose import jwt
+from app.main import app, JWT_SECRET, ALGORITHM
 
 client = TestClient(app)
 
@@ -11,29 +12,40 @@ def test_read_root():
 
 
 def test_registration_flow():
-    user = {"username": "jane", "password": "secret"}
+    user_data = {
+        "email": "jane@example.com",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "school": "Test University",
+        "password": "secret",
+    }
 
     # Register
-    resp = client.post("/register", json=user)
+    resp = client.post("/register", json=user_data)
     assert resp.status_code == 200
-    assert "awaiting approval" in resp.json()["message"]
+    assert "Awaiting admin approval" in resp.json()["message"]
 
     # Duplicate registration
-    dup_resp = client.post("/register", json=user)
+    dup_resp = client.post("/register", json=user_data)
     assert dup_resp.status_code == 400
 
     # Login before approval should fail
-    login_before = client.post("/login", json=user)
+    login_before = client.post(
+        "/login", json={"email": user_data["email"], "password": user_data["password"]}
+    )
     assert login_before.status_code == 403
 
     # Approve user
-    approve_resp = client.post(
-        "/admin/approve/jane",
-        json={"admin_username": "admin", "admin_password": "adminpass"},
-    )
+    approve_resp = client.post("/approve", json={"email": user_data["email"]})
     assert approve_resp.status_code == 200
 
     # Login after approval
-    login_after = client.post("/login", json=user)
+    login_after = client.post(
+        "/login", json={"email": user_data["email"], "password": user_data["password"]}
+    )
     assert login_after.status_code == 200
-    assert login_after.json() == {"token": "dummy-token"}
+    token = login_after.json().get("token")
+    assert token
+    payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+    assert payload["sub"] == user_data["email"]
+    assert payload["role"] == "user"


### PR DESCRIPTION
## Summary
- replace placeholder login endpoints with bcrypt password hashing
- issue JWT tokens on login with 1 hour expiry
- add CORS middleware and pydantic models
- update tests for new flows and add required deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9baf85cc8333905685e70096b90c