### PR TITLE
Add React login and register forms with routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,10 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,20 @@
 import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
 import LoginForm from './LoginForm';
+import RegisterForm from './RegisterForm';
 
 function App() {
   return (
-    <div className="App">
-      <LoginForm />
-    </div>
+    <Router>
+      <div className="App">
+        <Routes>
+          <Route path="/" element={<LoginForm />} />
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/register" element={<RegisterForm />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -1,38 +1,40 @@
 import React, { useState } from 'react';
+import axios from 'axios/dist/node/axios.cjs';
 import './LoginForm.css';
 
 function LoginForm() {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
-  const [mode, setMode] = useState('login');
+  const [error, setError] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const endpoint = mode === 'login' ? '/login' : '/register';
-    const resp = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    const data = await resp.json();
-    if (resp.ok) {
-      setMessage(data.message || `Token: ${data.token}`);
-    } else {
-      setMessage(data.detail || 'Error');
+    setError('');
+    try {
+      const resp = await axios.post('http://localhost:8000/login', {
+        email,
+        password,
+      });
+      const token = resp.data.token;
+      if (token) {
+        localStorage.setItem('token', token);
+        console.log('Token:', token);
+      }
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Login failed');
     }
   };
 
   return (
     <div className="login-container">
       <form className="login-form" onSubmit={handleSubmit}>
-        <h2 className="login-title">{mode === 'login' ? 'Login' : 'Register'}</h2>
-        <label htmlFor="username">Username</label>
+        <h2>Login</h2>
+        <label htmlFor="email">Email</label>
         <input
-          id="username"
-          type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
         />
         <label htmlFor="password">Password</label>
         <input
@@ -41,14 +43,8 @@ function LoginForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button type="submit">{mode === 'login' ? 'Login' : 'Register'}</button>
-        <button
-          type="button"
-          onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
-        >
-          {mode === 'login' ? 'Need an account?' : 'Have an account?'}
-        </button>
-        {message && <p>{message}</p>}
+        <button type="submit">Login</button>
+        {error && <p className="error">{error}</p>}
       </form>
     </div>
   );

--- a/frontend/src/RegisterForm.css
+++ b/frontend/src/RegisterForm.css
@@ -1,4 +1,4 @@
-.login-container {
+.register-container {
   background-color: #001f3f;
   height: 100vh;
   display: flex;
@@ -6,7 +6,7 @@
   align-items: center;
 }
 
-.login-form {
+.register-form {
   background-color: #003366;
   padding: 2rem;
   border-radius: 10px;
@@ -16,20 +16,26 @@
   width: 300px;
 }
 
-.login-form input {
+.register-form input {
   margin-bottom: 1rem;
   padding: 0.5rem;
   border-radius: 5px;
   border: none;
+  color: black;
 }
 
-.login-form button {
+.register-form button {
   background-color: #0074d9;
   color: white;
   border: none;
   padding: 0.7rem;
   border-radius: 5px;
   cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.message {
+  margin-top: 1rem;
 }
 
 .error {

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import axios from 'axios/dist/node/axios.cjs';
+import './RegisterForm.css';
+
+function RegisterForm() {
+  const [formData, setFormData] = useState({
+    email: '',
+    firstName: '',
+    lastName: '',
+    school: '',
+    password: '',
+  });
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const resp = await axios.post('http://localhost:8000/register', {
+        email: formData.email,
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+        school: formData.school,
+        password: formData.password,
+      });
+      setMessage(resp.data.message || 'Registration submitted. Awaiting admin approval');
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="register-container">
+      <form className="register-form" onSubmit={handleSubmit}>
+        <h2>Register</h2>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+        />
+        <label htmlFor="firstName">First Name</label>
+        <input
+          id="firstName"
+          name="firstName"
+          type="text"
+          value={formData.firstName}
+          onChange={handleChange}
+        />
+        <label htmlFor="lastName">Last Name</label>
+        <input
+          id="lastName"
+          name="lastName"
+          type="text"
+          value={formData.lastName}
+          onChange={handleChange}
+        />
+        <label htmlFor="school">School</label>
+        <input
+          id="school"
+          name="school"
+          type="text"
+          value={formData.school}
+          onChange={handleChange}
+        />
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          value={formData.password}
+          onChange={handleChange}
+        />
+        <button type="submit">Register</button>
+        {message && <p className="message">{message}</p>}
+        {error && <p className="error">{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default RegisterForm;


### PR DESCRIPTION
## Summary
- install axios and react-router-dom
- create standalone `RegisterForm` component
- replace `LoginForm` to only handle logging in
- add matching CSS styles for both forms
- update `App.js` with React Router routes for `/login` and `/register`

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684d9d45a3748333bc0e401e98826a44