### PR TITLE
Add register link and router routes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import './App.css';
 import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
@@ -9,7 +9,7 @@ function App() {
     <Router>
       <div className="App">
         <Routes>
-          <Route path="/" element={<LoginForm />} />
+          <Route path="/" element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/register" element={<RegisterForm />} />
         </Routes>

--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -36,3 +36,10 @@
   margin-top: 1rem;
   color: #ff4136;
 }
+
+.register-link {
+  margin-top: 1rem;
+  color: #61dafb;
+  text-align: center;
+  display: block;
+}

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios/dist/node/axios.cjs';
+import { Link } from 'react-router-dom';
 import './LoginForm.css';
 
 function LoginForm() {
@@ -44,6 +45,7 @@ function LoginForm() {
           onChange={(e) => setPassword(e.target.value)}
         />
         <button type="submit">Login</button>
+        <Link to="/register" className="register-link">Register</Link>
         {error && <p className="error">{error}</p>}
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add `/login` and `/register` routes with redirect
- link to registration from login page
- minor CSS for register link

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684da0eac0e08333a58436cd72e15502