### PR TITLE
Add default admin user

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,23 @@ app.add_middleware(
 users = {}
 
 
+def init_default_admin():
+    """Create the default admin account if it doesn't exist."""
+    if "admin@example.com" not in users:
+        hashed = bcrypt.hashpw("admin123".encode(), bcrypt.gensalt())
+        users["admin@example.com"] = {
+            "first_name": "Admin",
+            "last_name": "User",
+            "school": "Admin School",
+            "password": hashed,
+            "role": "admin",
+            "approved": True,
+        }
+
+
+init_default_admin()
+
+
 class RegisterRequest(BaseModel):
     email: EmailStr
     first_name: str


### PR DESCRIPTION
## Summary
- add init_default_admin function and call it on startup
- add tests for default admin
- adjust registration flow test to use built-in admin

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da18f84dc83339fa4ca677145bcba