### PR TITLE
Add redirect after login

### DIFF
--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import axios from "axios";
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -20,6 +21,7 @@ function LoginForm() {
       if (token) {
         localStorage.setItem('token', token);
         console.log('Token:', token);
+        navigate('/dashboard');
       }
     } catch (err) {
       setError(err.response?.data?.detail || 'Login failed');


### PR DESCRIPTION
## Summary
- store JWT in localStorage
- redirect to `/dashboard` after successful login

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd829d2b88333bcd34007f209f90b