### PR TITLE
Add admin-aware dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.10.0",
+    "jwt-decode": "^3.1.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",

--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -1,0 +1,30 @@
+.dashboard-container {
+  background-color: #001f3f;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  width: 80%;
+  max-width: 600px;
+}
+
+.dashboard-tile {
+  background-color: white;
+  color: black;
+  text-decoration: none;
+  padding: 2rem;
+  border-radius: 10px;
+  text-align: center;
+  transition: box-shadow 0.3s, border 0.3s;
+}
+
+.dashboard-tile:hover {
+  box-shadow: 0 0 10px rgba(0, 116, 217, 0.6);
+}

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import jwtDecode from 'jwt-decode';
+import './Dashboard.css';
+
+function Dashboard() {
+  const [role, setRole] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      try {
+        const decoded = jwtDecode(token);
+        setRole(decoded.role);
+      } catch (err) {
+        console.error('Failed to decode token', err);
+      }
+    }
+  }, []);
+
+  const tiles = [
+    { label: 'Student Profiles', path: '/students', admin: false },
+    { label: 'School Metrics', path: '/metrics', admin: false },
+    { label: 'Pending Registrations', path: '/admin/pending', admin: true },
+    { label: 'Job Matching', path: '/admin/jobs', admin: true },
+  ];
+
+  return (
+    <div className="dashboard-container">
+      <div className="tile-grid">
+        {tiles
+          .filter(tile => !tile.admin || role === 'admin')
+          .map(tile => (
+            <Link key={tile.path} to={tile.path} className="dashboard-tile">
+              {tile.label}
+            </Link>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- implement `Dashboard.js` showing admin-only tiles based on JWT role
- style tiles and layout in `Dashboard.css`
- add `jwt-decode` dependency

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dd90ce7e0833388ca387ab523294a