### PR TITLE
Add admin pending user page

### DIFF
--- a/frontend/src/AdminPending.css
+++ b/frontend/src/AdminPending.css
@@ -1,0 +1,44 @@
+.pending-container {
+  background-color: #001f3f;
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+}
+
+.pending-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.pending-table th,
+.pending-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.pending-table th {
+  background-color: #003366;
+}
+
+.pending-table td {
+  background-color: white;
+  color: black;
+}
+
+.pending-table button {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.message {
+  color: #2ecc40;
+}
+
+.error {
+  color: #ff4136;
+}

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import './AdminPending.css';
+
+function AdminPending() {
+  const [pendingUsers, setPendingUsers] = useState([]);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const token = localStorage.getItem('token');
+
+  const fetchPending = async () => {
+    setError('');
+    try {
+      const resp = await axios.get('http://localhost:8000/pending-users', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setPendingUsers(resp.data);
+    } catch (err) {
+      console.error('Error fetching pending users:', err);
+      setError(err.response?.data?.detail || 'Failed to fetch');
+    }
+  };
+
+  useEffect(() => {
+    if (token) {
+      fetchPending();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const approve = async (email) => {
+    setMessage('');
+    setError('');
+    try {
+      await axios.post(
+        'http://localhost:8000/approve',
+        { email },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setMessage(`${email} approved`);
+      // refresh list
+      fetchPending();
+    } catch (err) {
+      console.error('Error approving user:', err);
+      setError(err.response?.data?.detail || 'Approval failed');
+    }
+  };
+
+  if (!token) {
+    return <p className="pending-container">Login required.</p>;
+  }
+
+  return (
+    <div className="pending-container">
+      <h2>Pending Registrations</h2>
+      {message && <p className="message">{message}</p>}
+      {error && <p className="error">{error}</p>}
+      <table className="pending-table">
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>School</th>
+            <th>Role</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pendingUsers.map((user) => (
+            <tr key={user.email}>
+              <td>{user.email}</td>
+              <td>{user.school}</td>
+              <td>{user.role}</td>
+              <td>
+                <button onClick={() => approve(user.email)}>Approve</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default AdminPending;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
 import Dashboard from './Dashboard';
 import ProtectedRoute from './ProtectedRoute';
+import AdminPending from './AdminPending';
 
 function App() {
   return (
@@ -19,6 +20,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/pending"
+            element={
+              <ProtectedRoute>
+                <AdminPending />
               </ProtectedRoute>
             }
           />


### PR DESCRIPTION
## Summary
- add AdminPending component to view and approve pending users
- style with AdminPending.css matching dashboard theme
- add route in App.js to serve admin pending page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efe3b53b08333a1a9a5d24858f37c