### PR TITLE
Add toast on approval

### DIFF
--- a/frontend/src/AdminPending.css
+++ b/frontend/src/AdminPending.css
@@ -42,3 +42,14 @@
 .error {
   color: #ff4136;
 }
+
+/* Toast style for approval message */
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: #2ecc40;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+}

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -4,7 +4,8 @@ import './AdminPending.css';
 
 function AdminPending() {
   const [pendingUsers, setPendingUsers] = useState([]);
-  const [message, setMessage] = useState('');
+  // Temporary toast message shown when a user is approved
+  const [toast, setToast] = useState('');
   const [error, setError] = useState('');
 
   const token = localStorage.getItem('token');
@@ -29,7 +30,7 @@ function AdminPending() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const approve = async (email) => {
-    setMessage('');
+    setToast('');
     setError('');
     try {
       await axios.post(
@@ -37,9 +38,10 @@ function AdminPending() {
         { email },
         { headers: { Authorization: `Bearer ${token}` } }
       );
-      setMessage(`${email} approved`);
+      setToast('User approved!');
       // refresh list
       fetchPending();
+      setTimeout(() => setToast(''), 3000);
     } catch (err) {
       console.error('Error approving user:', err);
       setError(err.response?.data?.detail || 'Approval failed');
@@ -53,7 +55,7 @@ function AdminPending() {
   return (
     <div className="pending-container">
       <h2>Pending Registrations</h2>
-      {message && <p className="message">{message}</p>}
+      {toast && <div className="toast">{toast}</div>}
       {error && <p className="error">{error}</p>}
       <table className="pending-table">
         <thead>


### PR DESCRIPTION
## Summary
- show temporary toast after approving a user

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f0067453c8333a379ebc594e89d13