### PR TITLE
Add reject option for admin pending users

### DIFF
--- a/frontend/src/AdminPending.css
+++ b/frontend/src/AdminPending.css
@@ -33,6 +33,17 @@
   padding: 0.4rem 0.8rem;
   border-radius: 5px;
   cursor: pointer;
+  margin-right: 0.5rem;
+}
+
+.pending-table button.reject-button {
+  background-color: #ff4136;
+  color: white;
+  border-radius: 5px;
+}
+
+.pending-table button.reject-button:hover {
+  background-color: #e61900;
 }
 
 .message {

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -48,6 +48,24 @@ function AdminPending() {
     }
   };
 
+  const reject = async (email) => {
+    setToast('');
+    setError('');
+    try {
+      await axios.post(
+        'http://localhost:8000/reject',
+        { email },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setToast('User rejected!');
+      fetchPending();
+      setTimeout(() => setToast(''), 3000);
+    } catch (err) {
+      console.error('Error rejecting user:', err);
+      setError(err.response?.data?.detail || 'Rejection failed');
+    }
+  };
+
   if (!token) {
     return <p className="pending-container">Login required.</p>;
   }
@@ -73,7 +91,8 @@ function AdminPending() {
               <td>{user.school}</td>
               <td>{user.role}</td>
               <td>
-                <button onClick={() => approve(user.email)}>Approve</button>
+                <button className="approve-button" onClick={() => approve(user.email)}>Approve</button>
+                <button className="reject-button" onClick={() => reject(user.email)}>Reject</button>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- add ability for admins to reject pending users
- style new reject button

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f037a1e5c8333a1b9ae13d25bf6cb