### PR TITLE
Add admin menu dropdown

### DIFF
--- a/frontend/src/AdminPending.css
+++ b/frontend/src/AdminPending.css
@@ -3,6 +3,7 @@
   min-height: 100vh;
   color: white;
   padding: 2rem;
+  position: relative;
 }
 
 .pending-table {
@@ -63,4 +64,47 @@
   color: white;
   padding: 0.5rem 1rem;
   border-radius: 5px;
+}
+
+.admin-menu {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.menu-button {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 0.5rem;
+  background-color: #003366;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+  z-index: 10;
+}
+
+.dropdown-menu a,
+.dropdown-menu button {
+  color: white;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dropdown-menu a:hover,
+.dropdown-menu button:hover {
+  background-color: #001f3f;
 }

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import './AdminPending.css';
 
@@ -7,6 +8,8 @@ function AdminPending() {
   // Temporary toast message shown when a user is approved
   const [toast, setToast] = useState('');
   const [error, setError] = useState('');
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = useNavigate();
 
   const token = localStorage.getItem('token');
 
@@ -66,12 +69,32 @@ function AdminPending() {
     }
   };
 
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
   if (!token) {
     return <p className="pending-container">Login required.</p>;
   }
 
   return (
     <div className="pending-container">
+      <div className="admin-menu">
+        <button
+          className="menu-button"
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          Admin Menu
+        </button>
+        {menuOpen && (
+          <div className="dropdown-menu">
+            <Link to="/dashboard">Dashboard</Link>
+            <Link to="/admin/jobs">Job Matching</Link>
+            <button onClick={handleLogout}>Logout</button>
+          </div>
+        )}
+      </div>
       <h2>Pending Registrations</h2>
       {toast && <div className="toast">{toast}</div>}
       {error && <p className="error">{error}</p>}


### PR DESCRIPTION
## Summary
- add admin menu dropdown with links and logout
- style AdminPending dropdown menu to match dashboard theme

## Testing
- `npm test -- -u` *(fails: Jest encountered an unexpected token)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f32e17b208333a45375504543ac15