### PR TITLE
Update OpenAI embedding usage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from jose import jwt, JWTError
 from dotenv import load_dotenv
 import bcrypt
 import openai
-openai.api_key = os.getenv("OPENAI_API_KEY")
+from openai import OpenAI
 import redis
 
 # Load environment variables

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,14 +252,12 @@ def test_upload_students(monkeypatch):
     def fake_set(key, value):
         stored[key] = value
 
-    class DummyOpenAI:
-        class embeddings:
-            @staticmethod
-            def create(input, model):
-                return FakeResp()
+    def fake_create(input, model):
+        return FakeResp()
 
-    monkeypatch.setattr(main_app, "openai", DummyOpenAI)
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
+    monkeypatch.setattr(main_app.redis_client, "exists", lambda key: False)
 
     csv_data = (
         "first_name,last_name,email,phone,education_level,skills,experience_summary,interests\n"


### PR DESCRIPTION
## Summary
- use the v1 `OpenAI` client and remove old `openai.api_key`
- patch tests for the new client-based embedding calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c881e9688333a9c0a8dd054684f0