### PR TITLE
Fix jobs array extraction in JobPosting

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -26,7 +26,8 @@ function JobPosting() {
       const resp = await axios.get('http://localhost:8000/jobs', {
         headers: { Authorization: `Bearer ${token}` }
       });
-      setJobs(resp.data || []);
+      // resp.data has shape { jobs: [...] }
+      setJobs(resp.data.jobs || []);
     } catch (err) {
       console.error('Error fetching jobs:', err);
       setJobs([]);


### PR DESCRIPTION
## Summary
- fetch `/jobs` correctly by storing the `jobs` array from the response

## Testing
- `pip install -r requirements.txt`
- `export OPENAI_API_KEY=dummy`
- `export REDIS_URL=redis://localhost:6379/0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cc8c9c788333ad89b772a0b6b98f