### PR TITLE
Fix frontend requests via proxy and extend CORS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,9 +29,21 @@ ALGORITHM = "HS256"
 
 app = FastAPI()
 
+# Simple request logging for debugging
+@app.middleware("http")
+async def log_requests(request, call_next):
+    print(f"Incoming {request.method} {request.url}")
+    response = await call_next(request)
+    print(f"Response status: {response.status_code}")
+    return response
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://localhost:3001"],
+    allow_origins=[
+        "http://localhost:3000",
+        "http://localhost:3001",
+        "http://localhost:3002",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -16,7 +16,7 @@ function AdminPending() {
   const fetchPending = async () => {
     setError('');
     try {
-      const resp = await axios.get('http://localhost:8000/pending-users', {
+      const resp = await axios.get('/pending-users', {
         headers: { Authorization: `Bearer ${token}` },
       });
       setPendingUsers(resp.data);
@@ -37,7 +37,7 @@ function AdminPending() {
     setError('');
     try {
       await axios.post(
-        'http://localhost:8000/approve',
+        '/approve',
         { email },
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -56,7 +56,7 @@ function AdminPending() {
     setError('');
     try {
       await axios.post(
-        'http://localhost:8000/reject',
+        '/reject',
         { email },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -22,7 +22,7 @@ function JobPosting() {
 
   const fetchJobs = async () => {
     try {
-      const resp = await axios.get('http://localhost:8000/jobs', {
+      const resp = await axios.get('/jobs', {
         headers: { Authorization: `Bearer ${token}` }
       });
       // resp.data has shape { jobs: [...] }
@@ -48,7 +48,7 @@ function JobPosting() {
     setMessage('');
     try {
       const resp = await axios.post(
-        'http://localhost:8000/jobs',
+        '/jobs',
         {
           job_title: formData.job_title,
           job_description: formData.job_description,
@@ -78,7 +78,7 @@ function JobPosting() {
   const handleMatch = async (code) => {
     try {
       const resp = await axios.post(
-        'http://localhost:8000/match',
+        '/match',
         { job_code: code },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -15,13 +15,8 @@ function LoginForm() {
     console.log('Submitting login...');
 
     try {
-      const resp = await axios.post('http://localhost:8000/login',
-        { email, password },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+      const resp = await axios.post('/login',
+        { email, password }
       );
 
       console.log('Response data:', resp.data);

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -23,7 +23,7 @@ function RegisterForm() {
     e.preventDefault();
     setError('');
     try {
-      const resp = await axios.post('http://localhost:8000/register', {
+      const resp = await axios.post('/register', {
         email: formData.email,
         first_name: formData.firstName,
         last_name: formData.lastName,

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -36,7 +36,7 @@ function StudentProfiles() {
     setFormError('');
     try {
       await axios.post(
-        'http://localhost:8000/students',
+        '/students',
         {
           first_name: formData.firstName,
           last_name: formData.lastName,
@@ -80,7 +80,7 @@ function StudentProfiles() {
     const data = new FormData();
     data.append('file', csvFile);
     try {
-      const resp = await axios.post('http://localhost:8000/students/upload', data, {
+      const resp = await axios.post('/students/upload', data, {
         headers: {
           'Content-Type': 'multipart/form-data',
           Authorization: `Bearer ${token}`


### PR DESCRIPTION
## Summary
- add request logging middleware
- allow frontend port 3002 via CORS
- configure CRA proxy for FastAPI
- use proxy paths in axios calls

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517c277824833395ff5620e74e5b39