### PR TITLE
Add metrics dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
+    "recharts": "^2.8.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import ProtectedRoute from './ProtectedRoute';
 import AdminPending from './AdminPending';
 import StudentProfiles from './StudentProfiles';
 import JobPosting from './JobPosting';
+import Metrics from './Metrics';
 
 function App() {
   return (
@@ -46,6 +47,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <JobPosting />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/metrics"
+            element={
+              <ProtectedRoute>
+                <Metrics />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/Metrics.css
+++ b/frontend/src/Metrics.css
@@ -1,0 +1,51 @@
+.metrics-container {
+  background-color: #001F3F;
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.highlight-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.highlight-card {
+  background: #111;
+  padding: 1rem 2rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  text-align: center;
+}
+
+.highlight-card .value {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.gauge-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 200px;
+}
+
+.gauge {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: white;
+}
+
+.charts {
+  width: 100%;
+  max-width: 600px;
+}

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import jwtDecode from 'jwt-decode';
+import {
+  BarChart, Bar, LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from 'recharts';
+import './Metrics.css';
+
+function Metrics() {
+  const [data, setData] = useState(null);
+  const [role, setRole] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    try {
+      const dec = jwtDecode(token);
+      setRole(dec.role);
+    } catch {
+      return;
+    }
+    const fetchMetrics = async () => {
+      try {
+        const resp = await axios.get('/metrics', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setData(resp.data);
+      } catch (err) {
+        console.error('Error fetching metrics:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMetrics();
+  }, []);
+
+  if (loading) {
+    return <div className="metrics-container">Loading...</div>;
+  }
+  if (!data) {
+    return <div className="metrics-container">Failed to load metrics</div>;
+  }
+
+  const highlight = [
+    { label: 'Students', value: data.total_student_profiles },
+    { label: 'Jobs', value: data.total_jobs_posted },
+    { label: 'Matches', value: data.total_matches },
+  ];
+
+  const barData = [
+    {
+      name: 'Totals',
+      Students: data.total_student_profiles,
+      Jobs: data.total_jobs_posted,
+      Matches: data.total_matches,
+    },
+  ];
+
+  const avgScore = data.average_match_score ? Number(data.average_match_score) : 0;
+
+  return (
+    <div className="metrics-container">
+      <div className="highlight-grid">
+        {highlight.map((h) => (
+          <div key={h.label} className="highlight-card">
+            <div className="value">{h.value}</div>
+            <div className="label">{h.label}</div>
+          </div>
+        ))}
+      </div>
+      {role === 'admin' && (
+        <>
+          <div className="gauge-wrapper">
+            <div
+              className="gauge"
+              style={{ background: `conic-gradient(#2ecc40 ${avgScore * 100}%, #555 ${avgScore * 100}% 100%)` }}
+            >
+              <span>{avgScore.toFixed(2)}</span>
+            </div>
+          </div>
+          <div className="charts">
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={barData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" stroke="#fff" />
+                <YAxis stroke="#fff" />
+                <Tooltip />
+                <Bar dataKey="Students" fill="#0074D9" />
+                <Bar dataKey="Jobs" fill="#2ECC40" />
+                <Bar dataKey="Matches" fill="#FF851B" />
+              </BarChart>
+            </ResponsiveContainer>
+            <ResponsiveContainer width="100%" height={250}>
+              <LineChart data={[{ name: 'Latest', matches: data.total_matches }]}> 
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" stroke="#fff" />
+                <YAxis stroke="#fff" />
+                <Tooltip />
+                <Line type="monotone" dataKey="matches" stroke="#FF4136" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default Metrics;

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -25,6 +25,16 @@ class DummyRedis:
             if fnmatch(k, pattern):
                 yield k
 
+    def incr(self, key, amount=1):
+        val = int(self.store.get(key, 0)) + amount
+        self.store[key] = val
+        return val
+
+    def incrbyfloat(self, key, amount=1.0):
+        val = float(self.store.get(key, 0.0)) + amount
+        self.store[key] = val
+        return val
+
     def flushdb(self):
         self.store.clear()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,6 +30,16 @@ class DummyRedis:
             if fnmatch(k, pattern):
                 yield k
 
+    def incr(self, key, amount=1):
+        val = int(self.store.get(key, 0)) + amount
+        self.store[key] = val
+        return val
+
+    def incrbyfloat(self, key, amount=1.0):
+        val = float(self.store.get(key, 0.0)) + amount
+        self.store[key] = val
+        return val
+
     def flushdb(self):
         self.store.clear()
 
@@ -314,4 +324,54 @@ def test_upload_students(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()["count"] == 2
     assert len(stored) == 2
+
+
+def test_metrics_endpoint():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    # Seed some users
+    u1 = {
+        "first_name": "A",
+        "last_name": "B",
+        "school": "X",
+        "password": "p",
+        "role": "user",
+        "approved": True,
+        "rejected": False,
+    }
+    main_app.redis_client.set("user:user1@example.com", json.dumps(u1))
+
+    u2 = {**u1, "approved": False, "rejected": False}
+    main_app.redis_client.set("user:user2@example.com", json.dumps(u2))
+
+    u3 = {**u1, "approved": False, "rejected": True}
+    main_app.redis_client.set("user:user3@example.com", json.dumps(u3))
+
+    # Seed student profiles
+    main_app.redis_client.set("stud1@example.com", json.dumps({"email": "stud1@example.com"}))
+    main_app.redis_client.set("stud2@example.com", json.dumps({"email": "stud2@example.com"}))
+
+    # Seed jobs
+    main_app.redis_client.set("job:abc", json.dumps({"job_code": "abc"}))
+
+    # Seed metrics values
+    main_app.redis_client.set("metrics:total_matches", 2)
+    main_app.redis_client.set("metrics:total_match_score", 5.0)
+    main_app.redis_client.set("metrics:last_match_timestamp", "2020-01-01T00:00:00")
+
+    login_resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
+    token = login_resp.json()["token"]
+
+    resp = client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_users"] == 4  # including default admin
+    assert data["approved_users"] == 2  # admin + u1
+    assert data["rejected_users"] == 1
+    assert data["pending_registrations"] == 1
+    assert data["total_student_profiles"] == 2
+    assert data["total_jobs_posted"] == 1
+    assert data["total_matches"] == 2
+    assert abs(data["average_match_score"] - 2.5) < 1e-6
 


### PR DESCRIPTION
## Summary
- track match statistics and expose `GET /metrics`
- show metrics page in React with charts
- add new route to frontend router
- include metrics in dashboard nav tile
- test metrics endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524d667bcc8333844d44d0f6997681