### PR TITLE
Add admin placement metrics UI

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,34 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import Metrics from './Metrics';
+import axios from 'axios';
+
+jest.mock('axios');
 
 test('renders login form', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /login/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('admin metrics shows placement rate', async () => {
+  axios.get.mockResolvedValueOnce({
+    data: {
+      total_student_profiles: 1,
+      total_jobs_posted: 1,
+      total_matches: 1,
+      average_match_score: 0.8,
+      placement_rate: 0.72,
+      avg_time_to_placement_days: 14.2,
+      license_breakdown: {},
+      rematch_rate: 0.06,
+    },
+  });
+
+  const payload = { role: 'admin', exp: Math.floor(Date.now() / 1000) + 1000 };
+  const token = `header.${btoa(JSON.stringify(payload))}.sig`;
+  localStorage.setItem('token', token);
+  render(<Metrics />);
+  expect(await screen.findByText(/Placement Rate/i)).toBeInTheDocument();
+  localStorage.clear();
 });

--- a/frontend/src/Metrics.css
+++ b/frontend/src/Metrics.css
@@ -9,10 +9,11 @@
   gap: 2rem;
 }
 
-.highlight-grid {
-  display: flex;
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1rem;
-  flex-wrap: wrap;
+  width: 100%;
 }
 
 .highlight-card {
@@ -43,6 +44,25 @@
   justify-content: center;
   font-size: 1.5rem;
   color: white;
+}
+
+.avg-time {
+  font-weight: bold;
+}
+
+.visual-section {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .visual-section {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 .charts {

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -2,14 +2,29 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import jwtDecode from 'jwt-decode';
 import {
-  BarChart, Bar, LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+  RadialBarChart,
+  RadialBar,
+  Legend,
 } from 'recharts';
 import './Metrics.css';
 
 function Metrics() {
-  const [data, setData] = useState(null);
+  const [metricsData, setMetricsData] = useState(null);
   const [role, setRole] = useState('');
   const [loading, setLoading] = useState(true);
+  const [interval] = useState('all');
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -22,10 +37,10 @@ function Metrics() {
     }
     const fetchMetrics = async () => {
       try {
-        const resp = await axios.get('/metrics', {
+        const resp = await axios.get(`/metrics?interval=${interval}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        setData(resp.data);
+        setMetricsData(resp.data);
       } catch (err) {
         console.error('Error fetching metrics:', err);
       } finally {
@@ -38,30 +53,48 @@ function Metrics() {
   if (loading) {
     return <div className="metrics-container">Loading...</div>;
   }
-  if (!data) {
+  if (!metricsData) {
     return <div className="metrics-container">Failed to load metrics</div>;
   }
 
   const highlight = [
-    { label: 'Students', value: data.total_student_profiles },
-    { label: 'Jobs', value: data.total_jobs_posted },
-    { label: 'Matches', value: data.total_matches },
+    { label: 'Students', value: metricsData.total_student_profiles },
+    { label: 'Jobs', value: metricsData.total_jobs_posted },
+    { label: 'Matches', value: metricsData.total_matches },
   ];
+
+  if (role === 'admin') {
+    highlight.push({
+      label: 'Placement Rate',
+      value: `${(metricsData.placement_rate * 100).toFixed(0)} %`,
+    });
+    highlight.push({
+      label: 'Rematch Rate',
+      value: `${(metricsData.rematch_rate * 100).toFixed(0)} %`,
+    });
+  }
 
   const barData = [
     {
       name: 'Totals',
-      Students: data.total_student_profiles,
-      Jobs: data.total_jobs_posted,
-      Matches: data.total_matches,
+      Students: metricsData.total_student_profiles,
+      Jobs: metricsData.total_jobs_posted,
+      Matches: metricsData.total_matches,
     },
   ];
 
-  const avgScore = data.average_match_score ? Number(data.average_match_score) : 0;
+  const avgScore = metricsData.average_match_score
+    ? Number(metricsData.average_match_score)
+    : 0;
+
+  const licenseData = Object.entries(
+    metricsData.license_breakdown || {}
+  ).map(([name, value]) => ({ name, value }));
+  const colors = ['#00BFFF', '#32CD32', '#FF69B4', '#FFA500', '#9370DB'];
 
   return (
     <div className="metrics-container">
-      <div className="highlight-grid">
+      <div className="metric-grid">
         {highlight.map((h) => (
           <div key={h.label} className="highlight-card">
             <div className="value">{h.value}</div>
@@ -70,7 +103,29 @@ function Metrics() {
         ))}
       </div>
       {role === 'admin' && (
-        <>
+        <div className="avg-time"><strong>Average Time to Placement: {metricsData.avg_time_to_placement_days} days</strong></div>
+      )}
+      <div className="visual-section">
+        {role === 'admin' ? (
+          <ResponsiveContainer width={200} height={200}>
+            <RadialBarChart
+              innerRadius="80%"
+              outerRadius="100%"
+              data={[{ name: 'rate', value: metricsData.placement_rate * 100 }]}
+            >
+              <RadialBar dataKey="value" fill="#00BFFF" cornerRadius={10} />
+              <text
+                x="50%"
+                y="50%"
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#fff"
+              >
+                {(metricsData.placement_rate * 100).toFixed(0)}%
+              </text>
+            </RadialBarChart>
+          </ResponsiveContainer>
+        ) : (
           <div className="gauge-wrapper">
             <div
               className="gauge"
@@ -79,29 +134,44 @@ function Metrics() {
               <span>{avgScore.toFixed(2)}</span>
             </div>
           </div>
-          <div className="charts">
-            <ResponsiveContainer width="100%" height={250}>
-              <BarChart data={barData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" stroke="#fff" />
-                <YAxis stroke="#fff" />
-                <Tooltip />
-                <Bar dataKey="Students" fill="#0074D9" />
-                <Bar dataKey="Jobs" fill="#2ECC40" />
-                <Bar dataKey="Matches" fill="#FF851B" />
-              </BarChart>
-            </ResponsiveContainer>
-            <ResponsiveContainer width="100%" height={250}>
-              <LineChart data={[{ name: 'Latest', matches: data.total_matches }]}> 
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" stroke="#fff" />
-                <YAxis stroke="#fff" />
-                <Tooltip />
-                <Line type="monotone" dataKey="matches" stroke="#FF4136" />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        </>
+        )}
+        {role === 'admin' && (
+          <ResponsiveContainer width={250} height={250}>
+            <PieChart>
+              <Pie dataKey="value" data={licenseData} outerRadius={80}>
+                {licenseData.map((entry, index) => (
+                  <Cell key={`c-${index}`} fill={colors[index % colors.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+      {role === 'admin' && (
+        <div className="charts">
+          <ResponsiveContainer width="100%" height={250}>
+            <BarChart data={barData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" stroke="#fff" />
+              <YAxis stroke="#fff" />
+              <Tooltip />
+              <Bar dataKey="Students" fill="#0074D9" />
+              <Bar dataKey="Jobs" fill="#2ECC40" />
+              <Bar dataKey="Matches" fill="#FF851B" />
+            </BarChart>
+          </ResponsiveContainer>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={[{ name: 'Latest', matches: metricsData.total_matches }]}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" stroke="#fff" />
+              <YAxis stroke="#fff" />
+              <Tooltip />
+              <Line type="monotone" dataKey="matches" stroke="#FF4136" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show extra metrics from `/metrics` endpoint
- add placement rate gauge and license breakdown pie chart
- support responsive metric grid layout and stacking of charts
- allow admin-only metrics rendering and update tests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68533785afa8833380b558a3e54a6432