### PR TITLE
Add env-based API config and central Axios instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ venv/
 ENV/
 **/node_modules/
 **/package-lock.json
-.env
+!.env
+!frontend/.env

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from './api';
 import './AdminPending.css';
 
 function AdminPending() {
@@ -16,7 +16,7 @@ function AdminPending() {
   const fetchPending = async () => {
     setError('');
     try {
-      const resp = await axios.get('/pending-users', {
+      const resp = await api.get('/pending-users', {
         headers: { Authorization: `Bearer ${token}` },
       });
       setPendingUsers(resp.data);
@@ -36,7 +36,7 @@ function AdminPending() {
     setToast('');
     setError('');
     try {
-      await axios.post(
+      await api.post(
         '/approve',
         { email },
         { headers: { Authorization: `Bearer ${token}` } }
@@ -55,7 +55,7 @@ function AdminPending() {
     setToast('');
     setError('');
     try {
-      await axios.post(
+      await api.post(
         '/reject',
         { email },
         { headers: { Authorization: `Bearer ${token}` } }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,9 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 import Metrics from './Metrics';
+import api from './api';
 import axios from 'axios';
 
-jest.mock('axios');
+jest.mock('axios', () => {
+  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  mockAxios.create.mockReturnValue(mockAxios);
+  return mockAxios;
+});
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 
 test('renders login form', () => {
   render(<App />);
@@ -12,7 +25,7 @@ test('renders login form', () => {
 });
 
 test('admin metrics shows placement rate', async () => {
-  axios.get.mockResolvedValueOnce({
+  api.get.mockResolvedValueOnce({
     data: {
       total_student_profiles: 1,
       total_jobs_posted: 1,

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, Navigate } from 'react-router-dom';
 import jwtDecode from 'jwt-decode';
-import axios from 'axios';
+import api from './api';
 import './JobPosting.css';
 
 function JobPosting() {
@@ -27,7 +27,7 @@ function JobPosting() {
 
   const fetchJobs = async () => {
     try {
-      const resp = await axios.get('/jobs', {
+      const resp = await api.get('/jobs', {
         headers: { Authorization: `Bearer ${token}` }
       });
       // resp.data has shape { jobs: [...] }
@@ -58,7 +58,7 @@ function JobPosting() {
     e.preventDefault();
     setMessage('');
     try {
-      const resp = await axios.post(
+      const resp = await api.post(
         '/jobs',
         {
           job_title: formData.job_title,
@@ -88,7 +88,7 @@ function JobPosting() {
 
   const handleMatch = async (code) => {
     try {
-      const resp = await axios.post(
+      const resp = await api.post(
         '/match',
         { job_code: code },
         { headers: { Authorization: `Bearer ${token}` } }
@@ -114,7 +114,7 @@ function JobPosting() {
 
   const handleAssign = async (job, row) => {
     try {
-      await axios.post(
+      await api.post(
         '/assign',
         { student_email: row.email, job_code: job.job_code },
         { headers: { Authorization: `Bearer ${token}` } }
@@ -132,7 +132,7 @@ function JobPosting() {
 
   const handlePlace = async (job, row) => {
     try {
-      await axios.post(
+      await api.post(
         '/place',
         { student_email: row.email, job_code: job.job_code },
         { headers: { Authorization: `Bearer ${token}` } }
@@ -152,7 +152,7 @@ function JobPosting() {
     const emails = selectedRows[job.job_code] || [];
     for (const email of emails) {
       try {
-        await axios.post(
+        await api.post(
           '/assign',
           { student_email: email, job_code: job.job_code },
           { headers: { Authorization: `Bearer ${token}` } }

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from "axios";
+import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 
@@ -15,7 +15,7 @@ function LoginForm() {
     console.log('Submitting login...');
 
     try {
-      const resp = await axios.post('/login',
+      const resp = await api.post('/login',
         { email, password }
       );
 

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from './api';
 import jwtDecode from 'jwt-decode';
 import {
   BarChart,
@@ -37,7 +37,7 @@ function Metrics() {
     }
     const fetchMetrics = async () => {
       try {
-        const resp = await axios.get(`/metrics?interval=${interval}`, {
+        const resp = await api.get(`/metrics?interval=${interval}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         setMetricsData(resp.data);

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from "axios";
+import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './RegisterForm.css';
 
@@ -23,7 +23,7 @@ function RegisterForm() {
     e.preventDefault();
     setError('');
     try {
-      const resp = await axios.post('/register', {
+      const resp = await api.post('/register', {
         email: formData.email,
         first_name: formData.firstName,
         last_name: formData.lastName,

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import api from './api';
 import { Link } from 'react-router-dom';
 import './StudentProfiles.css';
 
@@ -35,7 +35,7 @@ function StudentProfiles() {
     setFormMessage('');
     setFormError('');
     try {
-      await axios.post(
+      await api.post(
         '/students',
         {
           first_name: formData.firstName,
@@ -80,7 +80,7 @@ function StudentProfiles() {
     const data = new FormData();
     data.append('file', csvFile);
     try {
-      const resp = await axios.post('/students/upload', data, {
+      const resp = await api.post('/students/upload', data, {
         headers: {
           'Content-Type': 'multipart/form-data',
           Authorization: `Bearer ${token}`

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- use `.env` file for API base URL
- create `api.js` with Axios instance
- refactor components to use the central Axios instance
- update tests to mock the new API module
- allow tracking frontend `.env` via `.gitignore`

## Testing
- `pytest -q`
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68535c4ad7e083338da27deece0ed9a7