### PR TITLE
Improve job posting layout with column filters

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -6,6 +6,13 @@
   position: relative;
 }
 
+.job-posting-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
 .job-form {
   background-color: #003366;
   padding: 1rem 2rem;
@@ -13,7 +20,8 @@
   display: flex;
   flex-direction: column;
   max-width: 600px;
-  margin: 0 auto 2rem auto;
+  flex: 0 0 48%;
+  margin-bottom: 2rem;
 }
 
 .job-form input,
@@ -44,7 +52,9 @@
 }
 
 .jobs-section {
-  margin-top: 1rem;
+  margin-top: 0;
+  flex: 1 1 52%;
+  overflow-x: auto;
 }
 
 .search-input {
@@ -149,6 +159,18 @@
   border-radius: 8px;
   border: 1px solid #ccc;
 }
+
+.column-filter {
+  width: 100%;
+  padding: 4px;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+}
+.filter-row th {
+  background-color: #001f3f;
+}
 .badge.assigned {
   background: #f0ad4e;
   color: #fff;
@@ -164,6 +186,14 @@
   font-size: 0.75rem;
 }
 @media (max-width: 768px) {
+  .job-posting-layout {
+    flex-direction: column;
+  }
+  .job-form,
+  .jobs-section {
+    flex: 1 1 100%;
+    max-width: none;
+  }
   .match-table-row,
   .job-table {
     overflow-x: auto;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -14,7 +14,9 @@ function JobPosting() {
   });
   const [message, setMessage] = useState('');
   const [jobs, setJobs] = useState([]);
-  const [filter, setFilter] = useState('');
+  const [codeFilter, setCodeFilter] = useState('');
+  const [titleFilter, setTitleFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
   const [expandedJob, setExpandedJob] = useState(null);
   const [selectedRows, setSelectedRows] = useState({});
   const [matches, setMatches] = useState({});
@@ -163,7 +165,12 @@ function JobPosting() {
     navigate('/login');
   };
 
-  const matchFilter = (j) => [j.job_code, j.job_title, j.source].some((x) => x?.toLowerCase().includes(filter.toLowerCase()));
+  const matchFilter = (j) => {
+    const codeMatch = j.job_code?.toLowerCase().includes(codeFilter.toLowerCase());
+    const titleMatch = j.job_title?.toLowerCase().includes(titleFilter.toLowerCase());
+    const sourceMatch = j.source?.toLowerCase().includes(sourceFilter.toLowerCase());
+    return codeMatch && titleMatch && sourceMatch;
+  };
   const filteredJobs = jobs.filter(matchFilter);
 
   return (
@@ -181,7 +188,7 @@ function JobPosting() {
           </div>
         )}
       </div>
-
+      <div className="job-posting-layout">
       <form className="job-form" onSubmit={handleSubmit}>
         <h2>Post a Job</h2>
         <label htmlFor="job_title">Job Title</label>
@@ -200,7 +207,6 @@ function JobPosting() {
 
       <div className="jobs-section">
         <h2>Jobs</h2>
-        <input className="filter-box" type="text" placeholder="Filter by code, title, source" value={filter} onChange={(e) => setFilter(e.target.value)} />
         <table className="job-table">
           <thead>
             <tr>
@@ -210,6 +216,12 @@ function JobPosting() {
               <th>Rate</th>
               <th>Status</th>
               <th>Action</th>
+            </tr>
+            <tr className="filter-row">
+              <th><input className="column-filter" type="text" value={codeFilter} onChange={(e) => setCodeFilter(e.target.value)} placeholder="Filter" /></th>
+              <th><input className="column-filter" type="text" value={titleFilter} onChange={(e) => setTitleFilter(e.target.value)} placeholder="Filter" /></th>
+              <th><input className="column-filter" type="text" value={sourceFilter} onChange={(e) => setSourceFilter(e.target.value)} placeholder="Filter" /></th>
+              <th colSpan="3"></th>
             </tr>
           </thead>
           <tbody>
@@ -297,6 +309,7 @@ function JobPosting() {
             ))}
           </tbody>
         </table>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- arrange job form and jobs table side-by-side using flexbox
- add per-column filters for job code, title and source
- adjust styles for responsive panel layout and filter fields

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68543eec8c848333b2c4450e79b437a3