### PR TITLE
Add role assignment during user approval

### DIFF
--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -19,17 +19,17 @@ function Dashboard() {
   }, []);
 
   const tiles = [
-    { label: 'Student Profiles', path: '/students', admin: false },
-    { label: 'School Metrics', path: '/metrics', admin: false },
-    { label: 'Pending Registrations', path: '/admin/pending', admin: true },
-    { label: 'Job Matching', path: '/admin/jobs', admin: true },
+    { label: 'Student Profiles', path: '/students', roles: ['admin', 'career'] },
+    { label: 'School Metrics', path: '/metrics', roles: ['admin', 'career'] },
+    { label: 'Pending Registrations', path: '/admin/pending', roles: ['admin'] },
+    { label: 'Job Matching', path: '/admin/jobs', roles: ['admin', 'recruiter'] },
   ];
 
   return (
     <div className="dashboard-container">
       <div className="tile-grid">
         {tiles
-          .filter(tile => !tile.admin || role === 'admin')
+          .filter(tile => tile.roles.includes(role))
           .map(tile => (
             <Link key={tile.path} to={tile.path} className="dashboard-tile">
               {tile.label}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,4 +5,7 @@ const api = axios.create({
   baseURL: process.env.REACT_APP_API_URL || "http://localhost:8000"
 });
 
+export const approveUser = (email, role, config = {}) =>
+  api.post("/approve", { email, role }, config);
+
 export default api;

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,7 +104,7 @@ def test_registration_flow():
     # Approve user using admin token
     approve_resp = client.post(
         "/approve",
-        json={"email": user_data["email"]},
+        json={"email": user_data["email"], "role": "career"},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert approve_resp.status_code == 200
@@ -118,7 +118,7 @@ def test_registration_flow():
     assert token
     payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
     assert payload["sub"] == user_data["email"]
-    assert payload["role"] == "user"
+    assert payload["role"] == "career"
 
 
 def test_non_admin_cannot_approve():
@@ -152,7 +152,7 @@ def test_non_admin_cannot_approve():
 
     resp = client.post(
         "/approve",
-        json={"email": target["email"]},
+        json={"email": target["email"], "role": "career"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- support role selection when approving users
- pass selected role from the admin UI
- show dashboard tiles based on role
- expose approveUser API helper
- test registration flow with roles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c7d8119083338029bd5f0d71aa92