### PR TITLE
Enable recruiter Job Matching link

### DIFF
--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -93,7 +93,7 @@ function AdminPending() {
         {menuOpen && (
           <div className="dropdown-menu">
             <Link to="/dashboard">Dashboard</Link>
-            <Link to="/admin/jobs">Job Matching</Link>
+            <Link to="/jobs">Job Matching</Link>
             <button onClick={handleLogout}>Logout</button>
           </div>
         )}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -43,7 +43,7 @@ function App() {
             }
           />
           <Route
-            path="/admin/jobs"
+            path="/jobs"
             element={
               <ProtectedRoute>
                 <JobPosting />

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -22,7 +22,7 @@ function Dashboard() {
     { label: 'Student Profiles', path: '/students', roles: ['admin', 'career'] },
     { label: 'School Metrics', path: '/metrics', roles: ['admin', 'career'] },
     { label: 'Pending Registrations', path: '/admin/pending', roles: ['admin'] },
-    { label: 'Job Matching', path: '/admin/jobs', roles: ['admin', 'recruiter'] },
+    { label: 'Job Matching', path: '/jobs', roles: ['admin', 'recruiter'] },
   ];
 
   return (

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -25,7 +25,7 @@ function JobPosting() {
 
   const token = localStorage.getItem('token');
   const { role } = token ? jwtDecode(token) : {};
-  if (role !== 'admin') return <Navigate to="/dashboard" />;
+  if (!['admin', 'recruiter'].includes(role)) return <Navigate to="/dashboard" />;
 
   const fetchJobs = async () => {
     try {


### PR DESCRIPTION
## Summary
- show Job Matching tile linking to `/jobs`
- route `/jobs` loads JobPosting
- allow recruiters into JobPosting component
- update admin menu link for Job Matching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ca7b2dec8333a4d779f1820ee13e