### PR TITLE
Add expand toggle to job code

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -195,6 +195,11 @@
   border: 1px solid #ccc;
   box-sizing: border-box;
 }
+.expand-icon {
+  margin-right: 6px;
+  font-weight: bold;
+  cursor: pointer;
+}
 .filter-row th {
   background-color: #001f3f;
 }

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -269,7 +269,18 @@ function JobPosting() {
             {filteredJobs.map((job) => (
               <React.Fragment key={job.job_code}>
                 <tr>
-                  <td>{job.job_code}</td>
+                  <td>
+                    <span
+                      className="expand-icon"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setExpandedJob(expandedJob === job.job_code ? null : job.job_code);
+                      }}
+                    >
+                      {expandedJob === job.job_code ? '–' : '+'}
+                    </span>{' '}
+                    {job.job_code}
+                  </td>
                   <td>{job.job_title}</td>
                   <td>{job.source}</td>
                   <td>{job.rate_of_pay_range}</td>


### PR DESCRIPTION
## Summary
- allow quick expanding of match table right from Job Code column
- style expand icon for easy use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685646b4176083339c2017069f9e3ac6