### PR TITLE
Add expandable column for JobPosting

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -195,10 +195,13 @@
   border: 1px solid #ccc;
   box-sizing: border-box;
 }
-.expand-icon {
-  margin-right: 6px;
-  font-weight: bold;
+.expand-toggle {
   cursor: pointer;
+  font-weight: bold;
+  font-size: 1.25rem;
+  padding-left: 4px;
+  padding-right: 4px;
+  text-align: center;
 }
 .filter-row th {
   background-color: #001f3f;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -251,6 +251,7 @@ function JobPosting() {
         <table className="job-table">
           <thead>
             <tr>
+              <th></th>
               <th>Job Code</th>
               <th>Title</th>
               <th>Source</th>
@@ -259,6 +260,7 @@ function JobPosting() {
               <th>Action</th>
             </tr>
             <tr className="filter-row">
+              <th></th>
               <th><input className="column-filter" type="text" value={codeFilter} onChange={(e) => setCodeFilter(e.target.value)} placeholder="Filter" /></th>
               <th><input className="column-filter" type="text" value={titleFilter} onChange={(e) => setTitleFilter(e.target.value)} placeholder="Filter" /></th>
               <th><input className="column-filter" type="text" value={sourceFilter} onChange={(e) => setSourceFilter(e.target.value)} placeholder="Filter" /></th>
@@ -271,16 +273,16 @@ function JobPosting() {
                 <tr>
                   <td>
                     <span
-                      className="expand-icon"
+                      className="expand-toggle"
                       onClick={(e) => {
                         e.stopPropagation();
                         setExpandedJob(expandedJob === job.job_code ? null : job.job_code);
                       }}
                     >
                       {expandedJob === job.job_code ? '–' : '+'}
-                    </span>{' '}
-                    {job.job_code}
+                    </span>
                   </td>
+                  <td>{job.job_code}</td>
                   <td>{job.job_title}</td>
                   <td>{job.source}</td>
                   <td>{job.rate_of_pay_range}</td>
@@ -297,7 +299,7 @@ function JobPosting() {
                 </tr>
                 {expandedJob === job.job_code && (
                   <tr className="match-table-row">
-                    <td colSpan="6">
+                    <td colSpan="7">
                       <button
                         disabled={(selectedRows[job.job_code]?.length || 0) === 0}
                         onClick={() => bulkAssign(job)}


### PR DESCRIPTION
## Summary
- add a dedicated expand/collapse column before the job code
- show `+` or `–` toggle in the new column
- adjust colspan for expanded row
- update styles with `.expand-toggle`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564a640a0c8333af897c677c468f11