### PR TITLE
Fix job description toggle display

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -231,6 +231,20 @@
   border-radius: 12px;
   font-size: 0.75rem;
 }
+
+.job-description-panel {
+  text-align: left;
+  padding: 1rem 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #fff;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.job-description-panel h3 {
+  margin-top: 0;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -277,7 +277,12 @@ function JobPosting() {
                       className="expand-toggle"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setExpandedJob(expandedJob === job.job_code ? null : job.job_code);
+                        if (expandedJob === job.job_code) {
+                          setExpandedJob(null);
+                          setExpandedJobDetails(null);
+                        } else {
+                          setExpandedJob(job.job_code);
+                        }
                       }}
                     >
                       {expandedJob === job.job_code ? '–' : '+'}
@@ -312,16 +317,18 @@ function JobPosting() {
                 {expandedJobDetails === job.job_code && (
                   <tr className="job-details-row">
                     <td colSpan="7">
-                      <strong>{job.job_title}</strong>
-                      <p>{job.job_description}</p>
-                      {job.desired_skills && (
-                        <p>
-                          Skills: {Array.isArray(job.desired_skills) ? job.desired_skills.join(', ') : job.desired_skills}
-                        </p>
-                      )}
-                      <p>Source: {job.source}</p>
-                      <p>Rate of Pay: {job.rate_of_pay_range}</p>
-                      <button>Edit</button>
+                      <div className="job-description-panel">
+                        <h3>{job.job_title}</h3>
+                        <p>{job.job_description}</p>
+                        {job.desired_skills && (
+                          <p>
+                            Skills: {Array.isArray(job.desired_skills) ? job.desired_skills.join(', ') : job.desired_skills}
+                          </p>
+                        )}
+                        <p>Source: {job.source}</p>
+                        <p>Rate of Pay: {job.rate_of_pay_range}</p>
+                        <button>Edit</button>
+                      </div>
                     </td>
                   </tr>
                 )}


### PR DESCRIPTION
## Summary
- hide description when collapsing a job
- make job title show description panel on click
- left-align description panel styling
- add job-description-panel styles

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68564e6c00108333b2343b60baf79145