### PR TITLE
Fix job detail toggle logic

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -292,11 +292,13 @@ function JobPosting() {
                   <td>
                     <span
                       className="job-title-clickable"
-                      onClick={() =>
-                        setExpandedJobDetails(
-                          expandedJobDetails === job.job_code ? null : job.job_code
-                        )
-                      }
+                      onClick={() => {
+                        if (expandedJob === job.job_code) {
+                          setExpandedJobDetails(
+                            expandedJobDetails === job.job_code ? null : job.job_code
+                          );
+                        }
+                      }}
                     >
                       {job.job_title}
                     </span>
@@ -314,7 +316,7 @@ function JobPosting() {
                     <button onClick={() => setExpandedJob(expandedJob === job.job_code ? null : job.job_code)}>Match</button>
                   </td>
                 </tr>
-                {expandedJobDetails === job.job_code && (
+                {expandedJobDetails === job.job_code && expandedJob === job.job_code && (
                   <tr className="job-details-row">
                     <td colSpan="7">
                       <div className="job-description-panel">


### PR DESCRIPTION
## Summary
- handle job title click only when row is expanded
- hide job details unless the row is expanded and selected

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856bd2883708333837b1ddd30d2468e