### PR TITLE
Add highlight for expanded job rows

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -6,6 +6,11 @@
   position: relative;
 }
 
+.highlight-cell {
+  background-color: #e9f2ff;
+  transition: background-color 0.2s ease-in-out;
+}
+
 .job-matching-layout {
   display: flex;
   flex-direction: row;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -289,7 +289,13 @@ function JobPosting() {
                     </span>
                   </td>
                   <td>{job.job_code}</td>
-                  <td>
+                  <td
+                    className={
+                      expandedJobDetails === job.job_code && expandedJob === job.job_code
+                        ? "highlight-cell"
+                        : ""
+                    }
+                  >
                     <span
                       className="job-title-clickable"
                       onClick={() => {
@@ -305,7 +311,7 @@ function JobPosting() {
                   </td>
                   <td>{job.source}</td>
                   <td>{job.rate_of_pay_range}</td>
-                  <td>
+                  <td className={expandedJob === job.job_code ? "highlight-cell" : ""}>
                     {job.placed_students?.length > 0 ? (
                       <span className="badge placed">Placed</span>
                     ) : job.assigned_students?.length > 0 ? (


### PR DESCRIPTION
## Summary
- highlight job title and status when rows expand
- style highlight-cell class for table cells

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c033e228833396c889248107f412