### PR TITLE
Enhance job title click behaviour

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -219,6 +219,12 @@
   color: #007bff;
   text-decoration: underline;
 }
+
+.job-title-clickable:hover,
+.job-title-clickable:active {
+  color: #0056b3;
+  text-decoration: none;
+}
 .filter-row th {
   background-color: #001f3f;
 }

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -298,7 +298,8 @@ function JobPosting() {
                   >
                     <span
                       className="job-title-clickable"
-                      onClick={() => {
+                      onClick={(e) => {
+                        e.stopPropagation();
                         if (expandedJob === job.job_code) {
                           setExpandedJobDetails(
                             expandedJobDetails === job.job_code ? null : job.job_code


### PR DESCRIPTION
## Summary
- stop event bubbling when clicking job title
- add hover/active styling for clickable job titles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856c39ee5008333854f54e4f921bd03