### PR TITLE
Implement toggle via Assigned badge

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -234,6 +234,7 @@
   padding: 3px 8px;
   border-radius: 12px;
   font-size: 0.75rem;
+  cursor: pointer;
 }
 .badge.placed {
   background: #32CD32;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -316,7 +316,17 @@ function JobPosting() {
                     {job.placed_students?.length > 0 ? (
                       <span className="badge placed">Placed</span>
                     ) : job.assigned_students?.length > 0 ? (
-                      <span className="badge assigned">Assigned</span>
+                      <span
+                        className="badge assigned"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setExpandedJob(
+                            expandedJob === job.job_code ? null : job.job_code
+                          );
+                        }}
+                      >
+                        Assigned
+                      </span>
                     ) : null}
                   </td>
                   <td>


### PR DESCRIPTION
## Summary
- allow clicking the Assigned badge to expand/collapse the match table
- improve cursor feedback for the Assigned badge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c4ea5fcc8333aa47754ae68da141