### PR TITLE
Implement per-job match loading state

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -257,6 +257,23 @@
 .job-description-panel h3 {
   margin-top: 0;
 }
+
+.loader-bar {
+  font-size: 0.75rem;
+  padding: 6px 10px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  color: #555;
+}
+
+.matched-button {
+  background-color: #d3d3d3;
+  color: #666;
+  cursor: not-allowed;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add `loadingMatches` state tracking
- show a loader while match results load and disable button afterward
- ensure fetched match results contain a status field
- add loader and disabled styles

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6856c8b4b23c8333aa9689948b417334