### PR TITLE
Fix match loader placement

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -259,11 +259,9 @@
 }
 
 .loader-bar {
-  font-size: 0.75rem;
-  padding: 6px 10px;
-  background-color: #f0f0f0;
-  border-radius: 4px;
+  font-size: 0.85rem;
   color: #555;
+  margin-bottom: 0.5rem;
 }
 
 .matched-button {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -332,22 +332,19 @@ function JobPosting() {
                     ) : null}
                   </td>
                   <td>
-                    {matches[job.job_code] ? (
-                      <button disabled className="matched-button">Matched</button>
-                    ) : loadingMatches[job.job_code] ? (
-                      <div className="loader-bar">Loading...</div>
-                    ) : (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
+                    <button
+                      disabled={!!matches[job.job_code]}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (!matches[job.job_code]) {
                           handleMatch(job.job_code);
                           setExpandedJob(job.job_code);
                           setActiveSubtab((prev) => ({ ...prev, [job.job_code]: 'matches' }));
-                        }}
-                      >
-                        Match
-                      </button>
-                    )}
+                        }
+                      }}
+                    >
+                      {matches[job.job_code] ? 'Matched' : 'Match'}
+                    </button>
                   </td>
                 </tr>
                 {expandedJob === job.job_code && (
@@ -371,6 +368,9 @@ function JobPosting() {
                   ) : (
                     <tr className="match-table-row">
                       <td colSpan="7">
+                        {loadingMatches[job.job_code] && (
+                          <div className="loader-bar">Loading matches...</div>
+                        )}
                         <button
                           disabled={(selectedRows[job.job_code]?.length || 0) === 0}
                           onClick={() => bulkAssign(job)}


### PR DESCRIPTION
## Summary
- move loader to the matches subtable
- keep Match button active until results are loaded
- update loader-bar style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cb607b0883338950c69a3d400936