### PR TITLE
Load matches when expanding job row

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -45,6 +45,15 @@ function JobPosting() {
     if (token) fetchJobs();
   }, []);
 
+  useEffect(() => {
+    if (
+      expandedJob &&
+      !matches[expandedJob]
+    ) {
+      loadMatchResults(expandedJob);
+    }
+  }, [expandedJob]);
+
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -299,9 +308,6 @@ function JobPosting() {
                           setExpandedJob(null);
                         } else {
                           setExpandedJob(job.job_code);
-                          if (!matches[job.job_code]) {
-                            loadMatchResults(job.job_code);
-                          }
                         }
                       }}
                     >


### PR DESCRIPTION
## Summary
- load matches from backend when a job row is expanded
- rely on effect instead of click handler to fetch stored matches

## Testing
- `npm test --prefix frontend -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856d489393083339a8b8502bd16648b