### PR TITLE
Check for existing match data on job load

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -411,6 +411,12 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         print(f"❌ Failed to load match results for {job_code}: {e}")
         return {"matches": []}
 
+
+@app.get("/has-match/{job_code}")
+def has_match_data(job_code: str):
+    exists = redis_client.exists(f"match_results:{job_code}")
+    return {"has_match": bool(exists)}
+
 @app.get("/jobs")
 def list_jobs(current_user: dict = Depends(get_current_user)):
     jobs = []


### PR DESCRIPTION
## Summary
- add `/has-match/{job_code}` route in backend to check for match result presence
- fetch match flags when loading jobs in `JobPosting`
- keep flag in state when match results are fetched
- update button logic to use flag for `View Matches` display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685716f438b08333bb1c1515e1b80a8c