### PR TITLE
Add status badge styling

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -228,20 +228,33 @@
 .filter-row th {
   background-color: #001f3f;
 }
-.badge.assigned {
-  background: #f0ad4e;
-  color: #fff;
-  padding: 3px 8px;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  cursor: pointer;
+
+.status-cell {
+  text-align: center;
+  vertical-align: middle;
+  min-width: 120px;
 }
-.badge.placed {
-  background: #32CD32;
-  color: #fff;
-  padding: 3px 8px;
-  border-radius: 12px;
+
+.badge {
+  display: inline-block;
+  min-width: 100px;
+  padding: 6px 10px;
+  border-radius: 16px;
   font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.badge.assigned {
+  background-color: #f0ad4e;
+  color: white;
+}
+
+.badge.placed {
+  background-color: #5cb85c;
+  color: white;
 }
 
 .job-description-panel {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -377,7 +377,11 @@ function JobPosting() {
                   </td>
                   <td>{job.source}</td>
                   <td>{job.rate_of_pay_range}</td>
-                  <td className={expandedJob === job.job_code ? "highlight-cell" : ""}>
+                  <td
+                    className={`status-cell${
+                      expandedJob === job.job_code ? " highlight-cell" : ""
+                    }`}
+                  >
                     {job.placed_students?.length > 0 ? (
                       <span className="badge placed">
                         Placed ({job.placed_students.length})


### PR DESCRIPTION
## Summary
- style status column with `.status-cell` class
- apply consistent badge style and colors
- use new class in JobPosting list

## Testing
- `pytest -q`
- `npm install`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571b91e17483338b33b1f0cf23757c