### PR TITLE
Update badge styling for matches

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -247,6 +247,14 @@
   line-height: 1.4;
 }
 
+/* For subtable (match row) next to Place button */
+.badge.inline {
+  padding: 4px 8px;
+  font-size: 0.7rem;
+  min-width: auto;
+  border-radius: 12px;
+}
+
 .badge.assigned {
   background-color: #f0ad4e;
   color: white;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -493,10 +493,10 @@ function JobPosting() {
                                     <td>{row.score.toFixed(2)}</td>
                                     <td>
                                       {row.status === 'placed' ? (
-                                        <span className="badge placed">Placed</span>
+                                        <span className="badge placed inline">Placed</span>
                                       ) : row.status === 'assigned' ? (
                                         <>
-                                          <span className="badge assigned">Assigned</span>
+                                          <span className="badge assigned inline">Assigned</span>
                                           <button onClick={() => handlePlace(job, row)}>Place</button>
                                         </>
                                       ) : (


### PR DESCRIPTION
## Summary
- tweak `.badge` styles in JobPosting.css and add `.badge.inline`
- use new small badge style in match rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571e7c4dcc83339bd7b064a4faf888