### PR TITLE
Improve Job Posting layout

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -13,19 +13,20 @@
 
 .job-matching-layout {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
   gap: 2rem;
+  align-items: flex-start;
+  padding: 1.5rem;
 }
 
 .post-job-panel {
-  background-color: #003366;
-  padding: 1rem 2rem;
-  border-radius: 10px;
+  flex: 0 0 30%;
+  max-width: 400px;
+  background-color: #04345e;
+  padding: 1.5rem;
+  border-radius: 8px;
+  color: white;
   display: flex;
   flex-direction: column;
-  max-width: 45%;
-  flex: 0 0 45%;
   margin-bottom: 0;
   align-self: flex-start;
 }
@@ -81,12 +82,8 @@
 }
 
 .posted-jobs-panel {
-  margin-top: 0;
-  padding-top: 0;
-  flex: 1 1 55%;
-  max-width: 55%;
+  flex: 1;
   overflow-x: auto;
-  align-self: flex-start;
 }
 
 .search-input {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -244,6 +244,8 @@ function JobPosting() {
   };
 
   const renderMatches = (job) => {
+    const assignedOnly =
+      matches[job.job_code]?.filter((s) => s.status === "assigned") || [];
     return (
       <>
         {loadingMatches[job.job_code] && (
@@ -273,7 +275,7 @@ function JobPosting() {
                 </td>
               </tr>
             ) : (
-              matches[job.job_code].map((row, idx) => {
+              assignedOnly.map((row, idx) => {
                 const selectedCount = selectedRows[job.job_code]?.length || 0;
                 const checked = selectedRows[job.job_code]?.includes(row.email);
                 const disableCheckbox =


### PR DESCRIPTION
## Summary
- style job posting layout so job form is narrower and table expands
- show only assigned students in assigned subtable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572dfb96448333906df9fa142300b9