### PR TITLE
Add match flag checks and simplify assignment/placement

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -604,10 +604,9 @@ function JobPosting() {
                   </td>
                   <td>
                     {(() => {
-                      const matchList = matches[job.job_code];
-                      const hasMatchData = Array.isArray(matchList) && matchList.length > 0;
+                      const isMatched = matchPresence[job.job_code];
 
-                      return hasMatchData ? (
+                      return isMatched ? (
                         <button
                           onClick={(e) => {
                             e.stopPropagation();


### PR DESCRIPTION
## Summary
- simplify `/assign` and `/place` endpoints so jobs track assigned and placed students
- keep match presence for jobs on frontend
- use `matchPresence` when determining whether to show **Match** or **View Matches**

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685754d271108333a3224afbebbaa3b6