### PR TITLE
Update job match presence handling

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -46,7 +46,7 @@ function JobPosting() {
     }
   };
 
-  const checkMatchesForJobs = async () => {
+  const checkMatchFlags = async () => {
     const result = {};
     for (const job of jobs) {
       try {
@@ -67,18 +67,19 @@ function JobPosting() {
 
   useEffect(() => {
     if (jobs.length > 0) {
-      checkMatchesForJobs();
+      checkMatchFlags();
     }
   }, [jobs]);
 
   useEffect(() => {
     if (
       expandedJob &&
+      matchPresence[expandedJob] === true &&
       !matches[expandedJob]
     ) {
       loadMatchResults(expandedJob);
     }
-  }, [expandedJob]);
+  }, [expandedJob, matchPresence]);
 
 
   const handleChange = (e) => {
@@ -139,7 +140,6 @@ function JobPosting() {
       }));
       setMatches((prev) => ({ ...prev, [code]: matchResults }));
       setMatchLoaded((prev) => ({ ...prev, [code]: true }));
-      setMatchPresence((prev) => ({ ...prev, [code]: true }));
     } catch (err) {
       console.error(`Error loading stored matches for ${code}:`, err);
     }
@@ -604,9 +604,9 @@ function JobPosting() {
                   </td>
                   <td>
                     {(() => {
-                      const isMatched = matchPresence[job.job_code];
+                      const hasMatchInRedis = matchPresence[job.job_code] === true;
 
-                      return isMatched ? (
+                      return hasMatchInRedis ? (
                         <button
                           onClick={(e) => {
                             e.stopPropagation();


### PR DESCRIPTION
## Summary
- add `checkMatchFlags` for checking match status from Redis
- only fetch stored matches when data exists
- show **Match** button until actual results are present

## Testing
- `npm test --silent`
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685757600eb48333a9d4750da5184bd6