### PR TITLE
Add resume generation in JobPosting

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -365,6 +365,19 @@
   background-color: #007bff;
   color: white;
 }
+
+.spinner {
+  font-size: 0.8rem;
+  padding-left: 0.5rem;
+  color: #999;
+}
+
+.resume-ready {
+  font-size: 0.8rem;
+  color: green;
+  padding-left: 0.5rem;
+  font-weight: bold;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- handle generating resumes for assigned students
- show a spinner and resume-ready label when generation completes
- style spinner and ready text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577ddfaf448333b83c81aeeb8fa2ad