### PR TITLE
Implement resume retrieval

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -640,6 +640,24 @@ def generate_resume(req: ResumeRequest, current_user: dict = Depends(get_current
     return {"status": "success", "message": "Resume stored in Redis"}
 
 
+@app.get("/resume/{job_code}/{student_email}")
+def get_resume(job_code: str, student_email: str, current_user: dict = Depends(get_current_user)):
+    key = f"resume:{job_code}:{student_email}"
+    print(f"\U0001F4E5 Download request for resume: {job_code} - {student_email}")
+    resume = redis_client.get(key)
+
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+
+    print("\u2705 Resume found and returned as plain text")
+    return {
+        "status": "success",
+        "job_code": job_code,
+        "student_email": student_email,
+        "resume": resume if isinstance(resume, str) else resume.decode("utf-8"),
+    }
+
+
 
 
 


### PR DESCRIPTION
## Summary
- implement GET `/resume/{job_code}/{student_email}` to fetch generated resume text
- log resume retrieval requests and successes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857806263f48333adc3fdfe3af7cec9