### PR TITLE
Add resume column for assigned candidates

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -378,6 +378,13 @@
   padding-left: 0.5rem;
   font-weight: bold;
 }
+
+.resume-icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -421,6 +421,7 @@ function JobPosting() {
             <th>Name</th>
             <th>Email</th>
             <th>Score</th>
+            <th>Resume</th>
             <th>Action</th>
           </tr>
         </thead>
@@ -431,21 +432,20 @@ function JobPosting() {
               <td>{row.email}</td>
               <td>{row.score?.toFixed(2)}</td>
               <td>
-                <span className="badge assigned inline">Assigned</span>
                 {generatingResumes[`${job.job_code}:${row.email}`] ? (
                   <span className="spinner">⏳</span>
                 ) : generatedResumes[`${job.job_code}:${row.email}`] ? (
-                  <span className="resume-ready">Resume Ready</span>
+                  <button className="resume-icon-button" onClick={() => downloadResume(row.email, job.job_code)}>
+                    📥
+                  </button>
                 ) : (
                   <button onClick={() => generateResume(row.email, job.job_code)}>
                     Generate Resume
                   </button>
                 )}
-                {row.status === 'assigned' && generatedResumes[`${job.job_code}:${row.email}`] && (
-                  <button onClick={() => downloadResume(row.email, job.job_code)}>
-                    📥 Download Resume
-                  </button>
-                )}
+              </td>
+              <td>
+                <span className="badge assigned inline">Assigned</span>
                 <button onClick={() => handlePlace(job, row)}>Place</button>
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- add dedicated Resume column with generation/download controls
- style resume download icon button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685817ff97788333832e8cf112862351