### PR TITLE
Update registration form for school code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,12 +9,13 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.10.0",
+    "jspdf": "^3.0.1",
     "jwt-decode": "^3.1.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
-    "recharts": "^2.8.0",
     "react-scripts": "5.0.1",
+    "recharts": "^2.8.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -8,9 +8,9 @@ function RegisterForm() {
     email: '',
     firstName: '',
     lastName: '',
-    school: '',
     password: '',
   });
+  const [schoolCode, setSchoolCode] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
@@ -27,8 +27,8 @@ function RegisterForm() {
         email: formData.email,
         first_name: formData.firstName,
         last_name: formData.lastName,
-        school: formData.school,
         password: formData.password,
+        school_code: schoolCode,
       });
       setMessage('Registration submitted. Awaiting admin approval.');
       setTimeout(() => navigate('/login'), 3000);
@@ -65,14 +65,16 @@ function RegisterForm() {
           value={formData.lastName}
           onChange={handleChange}
         />
-        <label htmlFor="school">School</label>
+        <label htmlFor="school_code">Enter Your School Code (e.g. 1001)</label>
         <input
-          id="school"
-          name="school"
+          id="school_code"
+          name="school_code"
           type="text"
-          value={formData.school}
-          onChange={handleChange}
+          maxLength={4}
+          value={schoolCode}
+          onChange={(e) => setSchoolCode(e.target.value)}
         />
+        {error && <p className="error">{error}</p>}
         <label htmlFor="password">Password</label>
         <input
           id="password"
@@ -84,7 +86,6 @@ function RegisterForm() {
         <button type="submit">Register</button>
         <Link to="/login" className="login-link">Back to Login</Link>
         {message && <p className="message">{message}</p>}
-        {error && <p className="error">{error}</p>}
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- collect a new `school_code` in the registration form instead of free-text school name
- send `school_code` to the backend during registration
- include `jspdf` as a test dependency so frontend tests pass

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599be045a88333bc291f1cba0c370b