### PR TITLE
Update student profile layout

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -6,15 +6,31 @@
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
+  align-items: flex-start;
 }
 
-.form-section,
+.form-section {
+  background-color: #003366;
+  padding: 1rem 2rem;
+  border-radius: 10px;
+  flex: 1;
+  min-width: 300px;
+}
+
 .upload-section {
   background-color: #003366;
   padding: 1rem 2rem;
   border-radius: 10px;
-  flex: 1 1 300px;
-  max-width: 500px;
+  width: 100%;
+}
+
+.right-column {
+  display: flex;
+  flex-direction: column;
+  flex: 0.25;
+  max-width: 350px;
+  width: 100%;
+  gap: 1rem;
 }
 
 .profile-form {
@@ -130,7 +146,8 @@
   background-color: #003366;
   padding: 1rem 2rem;
   border-radius: 10px;
-  flex: 1 1 100%;
+  width: 100%;
+  margin-top: 1rem;
 }
 
 .school-table {

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -309,19 +309,20 @@ function StudentProfiles() {
         </form>
       </div>
 
-      <div className="upload-section">
-        <h2>Upload CSV</h2>
-        <input type="file" accept=".csv" onChange={handleFileChange} />
-        <button onClick={handleUpload} disabled={!csvFile}>Upload</button>
-        {uploadProgress > 0 && <p>Progress: {uploadProgress}%</p>}
-        {uploadResult && <p className="message">{uploadResult}</p>}
-        {uploadError && <p className="error">{uploadError}</p>}
-      </div>
+      <div className="right-column">
+        <div className="upload-section">
+          <h2>Upload CSV</h2>
+          <input type="file" accept=".csv" onChange={handleFileChange} />
+          <button onClick={handleUpload} disabled={!csvFile}>Upload</button>
+          {uploadProgress > 0 && <p>Progress: {uploadProgress}%</p>}
+          {uploadResult && <p className="message">{uploadResult}</p>}
+          {uploadError && <p className="error">{uploadError}</p>}
+        </div>
 
-      <div className="school-students-section">
-        <h2>Students from Your School</h2>
-        {schoolStudents.length > 0 ? (
-          <table className="school-table">
+        <div className="school-students-section">
+          <h2>Students from Your School</h2>
+          {schoolStudents.length > 0 ? (
+            <table className="school-table">
             <thead>
               <tr>
                 <th>Name</th>
@@ -356,6 +357,7 @@ function StudentProfiles() {
         ) : (
           <p>No students found for your school.</p>
         )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refactor the Student Profiles page layout
- keep Upload CSV section to ~25% width
- align student table directly under the upload box

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_685a23d6bb30833389f884402517f3f9