### PR TITLE
Fix /students page layout width

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -184,10 +184,10 @@ function StudentProfiles() {
         alignItems: 'flex-start',
         flexWrap: 'wrap',
         gap: '2rem',
-        maxWidth: '1200px',
-        margin: '0 auto',
         justifyContent: 'space-between',
-        width: '100%'
+        width: '100%',
+        paddingLeft: '2rem',
+        paddingRight: '2rem'
       }}
     >
       <div className="admin-menu">


### PR DESCRIPTION
## Summary
- expand StudentProfiles layout to use full width and add horizontal padding

## Testing
- `pytest -q`
- `CI=true npm test --prefix frontend -- -u`

------
https://chatgpt.com/codex/tasks/task_e_685a2ba5165c83338e59f74a4f1de3f5