### PR TITLE
Fix table overlap with admin menu

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -338,7 +338,7 @@ function StudentProfiles() {
 
           <div
             className="school-students-section"
-            style={{ flexGrow: 1, minHeight: 0 }}
+            style={{ flexGrow: 1, minHeight: 0, marginTop: '3rem' }}
           >
             <h2>Students from Your School</h2>
             {schoolStudents.length > 0 ? (


### PR DESCRIPTION
## Summary
- add top margin to the "Students from Your School" section so the table doesn't overlap the Admin Menu

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3db0ef8c8333abab8026cd7a3d4f