### PR TITLE
Fix interests submission

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -70,7 +70,7 @@ function StudentProfiles() {
       education_level: formData.education_level,
       skills: formData.skills.split(',').map((s) => s.trim()),
       experience_summary: formData.experience_summary,
-      interests: formData.interests.split(',').map((i) => i.trim()),
+      interests: formData.interests.trim(),
     };
     try {
       await api.post('/students', studentData, {


### PR DESCRIPTION
## Summary
- send the student's `interests` as a trimmed string when submitting a new student profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac5601c7883339705a168cd25c9aa