### PR TITLE
Return full student details in student lists

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,7 +52,11 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
             "first_name": student.get("first_name"),
             "last_name": student.get("last_name"),
             "email": email,
+            "phone": student.get("phone"),
             "education_level": student.get("education_level"),
+            "skills": student.get("skills"),
+            "experience_summary": student.get("experience_summary"),
+            "interests": student.get("interests"),
         }
 
         if email in assigned_counts:
@@ -101,7 +105,11 @@ async def get_all_students(current_user: dict = Depends(get_current_user)):
             "first_name": student.get("first_name"),
             "last_name": student.get("last_name"),
             "email": email,
+            "phone": student.get("phone"),
             "education_level": student.get("education_level"),
+            "skills": student.get("skills"),
+            "experience_summary": student.get("experience_summary"),
+            "interests": student.get("interests"),
         }
 
         if email in assigned_counts:


### PR DESCRIPTION
## Summary
- expand `/students/by-school` and `/students/all` to return all profile fields so the frontend form can be pre-filled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0bd18cb483338a22a46c29ce76b0