### PR TITLE
Add loading states to student profiles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -174,3 +174,37 @@
   text-align: center;
 }
 
+/* Loading and toast styles */
+.spinner {
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top: 4px solid #0074d9;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.loading-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50px;
+  color: white;
+}
+
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: #2ecc40;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+}
+


### PR DESCRIPTION
## Summary
- add isLoading and isSaving states to student profile module
- show toast on save and spinner while submitting
- display centered spinner when loading students
- style spinner and toast in StudentProfiles.css

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ce23d07f08333a77679550071551e