### PR TITLE
Add expand toggle to student table

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -214,6 +214,15 @@
   margin-top: 0.5rem;
 }
 
+.expand-toggle {
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 1.25rem;
+  padding-left: 4px;
+  padding-right: 4px;
+  text-align: center;
+}
+
 .job-subtable th,
 .job-subtable td {
   border: 1px solid #ccc;

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -270,6 +270,7 @@ function StudentProfiles() {
               <table className="school-table">
                 <thead>
                   <tr>
+                    <th></th>
                     <th>Name</th>
                     {userRole === 'admin' && <th>School</th>}
                     <th>Edit</th>
@@ -285,22 +286,18 @@ function StudentProfiles() {
                     return (
                       <React.Fragment key={s.email}>
                         <tr>
+                          <td>
+                            <span
+                              className="expand-toggle"
+                              onClick={() => toggleRow(s.email)}
+                              title={expandedRows[s.email] ? 'Collapse' : 'Expand'}
+                            >
+                              {expandedRows[s.email] ? '–' : '+'}
+                            </span>
+                          </td>
                           <td>{s.first_name} {s.last_name}</td>
                           {userRole === 'admin' && <td>{s.school_code}</td>}
                           <td>
-                            <button
-                              onClick={() => toggleRow(s.email)}
-                              style={{
-                                background: 'none',
-                                border: 'none',
-                                cursor: 'pointer',
-                                fontSize: '1.2rem',
-                                marginRight: '0.5rem',
-                              }}
-                              title={expandedRows[s.email] ? 'Collapse' : 'Expand'}
-                            >
-                              {expandedRows[s.email] ? '🔼' : '🔽'}
-                            </button>
                             <button onClick={() => handleEdit(s.email)} style={{
                               background: 'none',
                               border: 'none',


### PR DESCRIPTION
## Summary
- show plus/minus expand toggle column in the student list
- keep edit icon separate in edit column
- style expand toggle similar to job matching module

## Testing
- `pytest -q`
- `cd frontend && CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ead1d91208333ac7febf541baa948