### PR TITLE
Handle no assigned jobs in profiles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -240,3 +240,9 @@
   text-align: center;
 }
 
+.no-jobs-row td {
+  background-color: #f0f0f0;
+  font-style: italic;
+  text-align: center;
+}
+

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -327,13 +327,19 @@ function StudentProfiles() {
                                   </tr>
                                 </thead>
                                 <tbody>
-                                  {(s.assigned_jobs || []).map((job, index) => (
-                                    <tr key={index}>
-                                      <td>{job.job_title}</td>
-                                      <td>{job.job_code}</td>
-                                      <td>{job.source}</td>
+                                  {s.assigned_jobs && s.assigned_jobs.length > 0 ? (
+                                    s.assigned_jobs.map((job, index) => (
+                                      <tr key={index}>
+                                        <td>{job.job_title}</td>
+                                        <td>{job.job_code}</td>
+                                        <td>{job.source}</td>
+                                      </tr>
+                                    ))
+                                  ) : (
+                                    <tr className="no-jobs-row">
+                                      <td colSpan="3">No jobs assigned by recruiters.</td>
                                     </tr>
-                                  ))}
+                                  )}
                                 </tbody>
                               </table>
                             </td>


### PR DESCRIPTION
## Summary
- show fallback row when a student has no assigned jobs
- style fallback message with gray background and italics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb145558c83338e91a7feac513d21