### PR TITLE
Add job description generator

### DIFF
--- a/backend/app/schemas/description.py
+++ b/backend/app/schemas/description.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class DescriptionRequest(BaseModel):
+    student_email: str
+    job_code: str

--- a/backend/app/services/description.py
+++ b/backend/app/services/description.py
@@ -1,0 +1,22 @@
+"""Service to generate a job description tailored for a student."""
+
+def generate_description_text(client, student: dict, job: dict) -> str:
+    prompt = f"""
+Write a concise job description for the following position. Tailor it to the student's background when relevant.
+
+Student Information:
+Name: {student.get('first_name', '')} {student.get('last_name', '')}
+Skills: {', '.join(student.get('skills', []))}
+
+Job Title: {job.get('job_title')}
+Current Description: {job.get('job_description')}
+Required Skills: {', '.join(job.get('desired_skills', []))}
+
+Return a short, well formatted paragraph.
+"""
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+    return resp.choices[0].message.content

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -246,3 +246,10 @@
   text-align: center;
 }
 
+.desc-icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+


### PR DESCRIPTION
## Summary
- support generating job descriptions via `/generate-description`
- include job description data in student endpoints
- add button for staff to generate descriptions in student profile subtable
- style new job description button
- test API for generating description

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb7ff3a5c8333ad478586a9feae74