### PR TITLE
Update job description PDF flow

### DIFF
--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -1,18 +1,21 @@
 def generate_resume_text(client, student: dict, job: dict) -> str:
-    """Create a resume using OpenAI"""
+    """Create a tailored job summary using OpenAI"""
     prompt = f"""
-Write a professional resume for the following student, tailored to the job description below.
+Analyze the student's skills, experience and interests below, then read the job title and description.
+Write a clear and concise one page summary in plain professional language that:
+- Describes what the job entails
+- Explains why the student may be a good fit
+- Mentions any areas where the student might need growth or preparation
 
 Student Information:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
-Email: {student.get('email', '')}
 Skills: {', '.join(student.get('skills', []))}
+Interests: {student.get('interests', '')}
+Experience Summary: {student.get('experience_summary', '')}
 
 Job Title: {job.get('job_title')}
 Job Description: {job.get('job_description')}
 Required Skills: {', '.join(job.get('desired_skills', []))}
-
-The resume should be concise, modern, and use a consistent format.
 """
 
     resp = client.chat.completions.create(

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -128,9 +128,9 @@ function StudentProfiles() {
     }
   };
 
-  const handleDownloadJobDescriptionPDF = async (jobCode, studentEmail) => {
+  const handleDownloadJobDescriptionPDF = async (student, job) => {
     try {
-      const resp = await api.get(`/resume/${jobCode}/${studentEmail}`, {
+      const resp = await api.get(`/resume/${job.job_code}/${student.email}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
@@ -138,12 +138,24 @@ function StudentProfiles() {
       const doc = new jsPDF();
 
       doc.setFont('Helvetica', 'normal');
+      doc.setFontSize(16);
+      doc.text('Job Description Summary', 15, 20);
+
       doc.setFontSize(12);
+      let y = 30;
+      doc.text(`Student: ${student.first_name} ${student.last_name}`, 15, y);
+      y += 10;
+      doc.text(`Job Title: ${job.job_title}`, 15, y);
+      if (student.school_code) {
+        y += 10;
+        doc.text(`School: ${student.school_code}`, 15, y);
+      }
+      y += 10;
 
       const lines = doc.splitTextToSize(text, 180);
-      doc.text(lines, 15, 20);
-
-      doc.save(`Job_Description_${jobCode}_${studentEmail}.pdf`);
+      doc.text(lines, 15, y);
+      const fileName = `Job Description - ${student.first_name} ${student.last_name} - ${job.job_title}.pdf`;
+      doc.save(fileName);
     } catch (err) {
       console.error('Failed to generate PDF:', err);
       alert('Could not download job description PDF.');
@@ -381,14 +393,16 @@ function StudentProfiles() {
                                         <td>{job.job_code}</td>
                                         <td>{job.source}</td>
                                         <td>
-                                          <button
-                                            onClick={() => handleDownloadJobDescriptionPDF(job.job_code, s.email)}
-                                            style={{ background: 'none', border: 'none', cursor: 'pointer' }}
-                                            title="Download Job Description (PDF)"
-                                          >
-                                            📄
-                                          </button>
-                                          {userRole !== 'recruiter' && (
+                                          {userRole === 'user' && (
+                                            <button
+                                              onClick={() => handleDownloadJobDescriptionPDF(s, job)}
+                                              style={{ background: 'none', border: 'none', cursor: 'pointer' }}
+                                              title="Generate Job Description PDF"
+                                            >
+                                              📄
+                                            </button>
+                                          )}
+                                          {userRole === 'user' && (
                                             generatingDescriptions[`${job.job_code}:${s.email}`] ? (
                                               <div style={{ display: 'flex', justifyContent: 'center' }}>
                                                 <span className="spinner" />


### PR DESCRIPTION
## Summary
- tweak resume generation prompt to output a job summary instead
- create student/job specific PDF in StudentProfiles
- restrict PDF generation icon to career services staff

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685ec45e55d483339d1825a0300ec65e