### PR TITLE
Update job summary prompt and PDF output

### DIFF
--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -1,26 +1,34 @@
 def generate_resume_text(client, student: dict, job: dict) -> str:
     """Create a tailored job summary using OpenAI"""
-    prompt = f"""
-Analyze the student's skills, experience and interests below, then read the job title and description.
-Write a clear and concise one page summary in plain professional language that:
-- Describes what the job entails
-- Explains why the student may be a good fit
-- Mentions any areas where the student might need growth or preparation
+    instructions = f"""
+You are a career advisor assistant. Create a personalized job summary for a student who has been assigned a job opportunity. Your task is to:
 
-Student Information:
+1. Summarize what the assigned job entails in plain, student-friendly language.
+2. Explain why the student may be a good fit based on their background, skills, and interests.
+3. Gently mention areas the student might need to work on or prepare for before starting.
+
+Respond with professional, friendly language. Do not format as a resume. Write clearly in paragraph form using plain language. Your audience is the student and their career advisor.
+
+Student Profile:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
+Email: {student.get('email', '')}
+Phone: {student.get('phone', '')}
+Education Level: {student.get('education_level', '')}
 Skills: {', '.join(student.get('skills', []))}
-Interests: {student.get('interests', '')}
 Experience Summary: {student.get('experience_summary', '')}
+Interests: {student.get('interests', '')}
 
-Job Title: {job.get('job_title')}
-Job Description: {job.get('job_description')}
-Required Skills: {', '.join(job.get('desired_skills', []))}
+Assigned Job:
+Title: {job.get('job_title')}
+Description: {job.get('job_description')}
+Desired Skills: {', '.join(job.get('desired_skills', []))}
+
+Begin with a short 1–2 sentence job summary, followed by a paragraph explaining the student’s fit, and end with a short paragraph highlighting potential preparation tips.
 """
 
     resp = client.chat.completions.create(
         model="gpt-4o",
-        messages=[{"role": "user", "content": prompt}],
+        messages=[{"role": "user", "content": instructions}],
         temperature=0.4,
     )
     return resp.choices[0].message.content

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -128,37 +128,31 @@ function StudentProfiles() {
     }
   };
 
-  const handleDownloadJobDescriptionPDF = async (student, job) => {
+  const handleDownloadJobDescriptionPDF = async (jobCode, studentEmail, studentName) => {
     try {
-      const resp = await api.get(`/resume/${job.job_code}/${student.email}`, {
+      const resp = await api.get(`/resume/${jobCode}/${studentEmail}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
       const text = resp.data.resume;
       const doc = new jsPDF();
 
-      doc.setFont('Helvetica', 'normal');
-      doc.setFontSize(16);
-      doc.text('Job Description Summary', 15, 20);
+      // Header: TalentMatch AI
+      doc.setFontSize(18);
+      doc.setFont('helvetica', 'bold');
+      doc.text('TalentMatch AI', 105, 20, { align: 'center' });
 
+      // Body
       doc.setFontSize(12);
-      let y = 30;
-      doc.text(`Student: ${student.first_name} ${student.last_name}`, 15, y);
-      y += 10;
-      doc.text(`Job Title: ${job.job_title}`, 15, y);
-      if (student.school_code) {
-        y += 10;
-        doc.text(`School: ${student.school_code}`, 15, y);
-      }
-      y += 10;
-
+      doc.setFont('helvetica', 'normal');
       const lines = doc.splitTextToSize(text, 180);
-      doc.text(lines, 15, y);
-      const fileName = `Job Description - ${student.first_name} ${student.last_name} - ${job.job_title}.pdf`;
+      doc.text(lines, 15, 40);
+
+      const fileName = `Job_Summary_${studentName.replace(/\s+/g, '_')}_${jobCode}.pdf`;
       doc.save(fileName);
     } catch (err) {
-      console.error('Failed to generate PDF:', err);
-      alert('Could not download job description PDF.');
+      console.error('Failed to generate job summary PDF:', err);
+      alert('Could not download job summary.');
     }
   };
 
@@ -395,7 +389,13 @@ function StudentProfiles() {
                                         <td>
                                           {userRole === 'user' && (
                                             <button
-                                              onClick={() => handleDownloadJobDescriptionPDF(s, job)}
+                                              onClick={() =>
+                                                handleDownloadJobDescriptionPDF(
+                                                  job.job_code,
+                                                  s.email,
+                                                  `${s.first_name} ${s.last_name}`
+                                                )
+                                              }
                                               style={{ background: 'none', border: 'none', cursor: 'pointer' }}
                                               title="Generate Job Description PDF"
                                             >


### PR DESCRIPTION
## Summary
- update OpenAI instructions for resume generation to produce student-facing job summary
- generate branded PDF on the front-end with header "TalentMatch AI"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ec62418648333927cd7e7528cd3e0