### PR TITLE
Update job description HTML generation

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -145,19 +145,11 @@ function StudentProfiles() {
     }
   };
 
-  const viewJobDescription = async (jobCode, studentEmail) => {
-    try {
-      const resp = await api.get(`/job-description-html/${jobCode}/${studentEmail}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const html = resp.data;
-
-      const newWindow = window.open('', '_blank');
-      newWindow.document.write(html);
-      newWindow.document.close();
-    } catch (err) {
-      alert('Failed to load job description.');
-    }
+  const viewJobDescription = (jobCode, studentEmail) => {
+    window.open(
+      `http://localhost:8000/job-description-html/${jobCode}/${studentEmail}`,
+      '_blank'
+    );
   };
 
   const handleSubmit = async (e) => {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -603,7 +603,7 @@ def test_job_description_html_route():
     init_default_admin()
 
     main_app.redis_client.set(
-        "resume:codeh:stud@example.com",
+        "jobdesc:codeh:stud@example.com",
         "html desc",
     )
 


### PR DESCRIPTION
## Summary
- generate detailed job description HTML when calling `/generate-job-description`
- store generated HTML and expose via `/job-description-html`
- open job description HTML in new tab on the frontend
- adjust unit tests for new HTML key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee8ab64ac8333b13c9f17f0eb2d4b