### PR TITLE
Improve job description HTML handling

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -595,7 +595,9 @@ def test_generate_job_description(monkeypatch):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert get_resp.status_code == 200
-    assert get_resp.json()["description"] == "done"
+    html_content = get_resp.json()["description"]
+    assert html_content.lstrip().startswith("<!DOCTYPE html>")
+    assert "done" in html_content
 
 
 def test_job_description_html_route():


### PR DESCRIPTION
## Summary
- clean OpenAI job description content to remove ```html fences
- wrap generated job descriptions in an HTML template
- adjust tests for wrapped HTML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef1b6c94483339c03d4f1fbf214a9