### PR TITLE
Replace Job Description icons with buttons

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -247,10 +247,17 @@
   text-align: center;
 }
 
-.desc-icon-button {
-  background: none;
+.desc-button {
+  background-color: #0074d9;
+  color: white;
   border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
   cursor: pointer;
-  font-size: 1.2rem;
+  margin-right: 0.5rem;
+}
+
+.desc-button:hover {
+  background-color: #005fa3;
 }
 

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -445,20 +445,27 @@ function StudentProfiles() {
                                         <td style={{ textAlign: 'center' }}>
                                           {jobDescriptionStatus[job.job_code] === 'ready' ? (
                                             <button
+                                              className="desc-button"
                                               onClick={() => handleViewJobDescription(job.job_code, s.email)}
-                                              style={{ marginRight: '0.5rem' }}
                                               title="View Job Description"
                                             >
-                                              📄 View
+                                              View Job Description
                                             </button>
                                           ) : (
                                             <button
+                                              className="desc-button"
                                               onClick={() => generateJobDescription(job.job_code, s.email)}
                                               disabled={loadingJobDescriptions[job.job_code]}
-                                              style={{ marginRight: '0.5rem' }}
                                               title="Generate Job Description"
                                             >
-                                              {loadingJobDescriptions[job.job_code] ? '⏳' : '🧾'}
+                                              {loadingJobDescriptions[job.job_code] ? (
+                                                <>
+                                                  <span className="spinner" style={{ marginRight: '0.25rem' }} />
+                                                  Generating...
+                                                </>
+                                              ) : (
+                                                'Load Job Description'
+                                              )}
                                             </button>
                                           )}
                                         </td>


### PR DESCRIPTION
## Summary
- switch job description buttons to text variants
- add styling for the new buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f18877a848333a5fbe0a8fa33dbe4