### PR TITLE
Add role selection on approval

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -119,6 +119,7 @@ class LoginRequest(BaseModel):
 
 class ApproveRequest(BaseModel):
     email: EmailStr
+    role: str  # "career" or "recruiter"
 
 class RejectRequest(BaseModel):
     email: EmailStr
@@ -228,8 +229,9 @@ def approve(req: ApproveRequest, current_user: dict = Depends(get_current_user))
         raise HTTPException(status_code=404, detail="User not found")
     user = json.loads(raw)
     user["approved"] = True
+    user["role"] = req.role
     redis_client.set(key, json.dumps(user))
-    return {"message": f"{req.email} approved"}
+    return {"message": f"{req.email} approved as {req.role}"}
 
 @app.post("/reject")
 def reject(req: RejectRequest, current_user: dict = Depends(get_current_user)):

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -9,6 +9,7 @@ function AdminPending() {
   const [toast, setToast] = useState('');
   const [error, setError] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [selectedRoles, setSelectedRoles] = useState({});
   const navigate = useNavigate();
 
   const token = localStorage.getItem('token');
@@ -32,13 +33,14 @@ function AdminPending() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const approve = async (email) => {
+  const handleApprove = async (email) => {
     setToast('');
     setError('');
     try {
+      const role = selectedRoles[email] || 'career';
       await api.post(
         '/approve',
-        { email },
+        { email, role },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setToast('User approved!');
@@ -51,7 +53,7 @@ function AdminPending() {
     }
   };
 
-  const reject = async (email) => {
+  const handleReject = async (email) => {
     setToast('');
     setError('');
     try {
@@ -114,8 +116,22 @@ function AdminPending() {
               <td>{user.school}</td>
               <td>{user.role}</td>
               <td>
-                <button className="approve-button" onClick={() => approve(user.email)}>Approve</button>
-                <button className="reject-button" onClick={() => reject(user.email)}>Reject</button>
+                <select
+                  value={selectedRoles[user.email] || 'career'}
+                  onChange={(e) =>
+                    setSelectedRoles((prev) => ({ ...prev, [user.email]: e.target.value }))
+                  }
+                  style={{
+                    padding: '4px 8px',
+                    marginRight: '10px',
+                    borderRadius: '4px',
+                  }}
+                >
+                  <option value="career">Career Service Staff</option>
+                  <option value="recruiter">Recruiter</option>
+                </select>
+                <button className="approve-button" onClick={() => handleApprove(user.email)}>Approve</button>
+                <button className="reject-button" onClick={() => handleReject(user.email)}>Reject</button>
               </td>
             </tr>
           ))}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,7 +105,7 @@ def test_registration_flow():
     # Approve user using admin token
     approve_resp = client.post(
         "/approve",
-        json={"email": user_data["email"]},
+        json={"email": user_data["email"], "role": "career"},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert approve_resp.status_code == 200
@@ -119,7 +119,7 @@ def test_registration_flow():
     assert token
     payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
     assert payload["sub"] == user_data["email"]
-    assert payload["role"] == "user"
+    assert payload["role"] == "career"
 
 
 def test_non_admin_cannot_approve():
@@ -153,7 +153,7 @@ def test_non_admin_cannot_approve():
 
     resp = client.post(
         "/approve",
-        json={"email": target["email"]},
+        json={"email": target["email"], "role": "career"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add a role dropdown for each pending user in AdminPending
- send selected role with `/approve` request
- allow `/approve` endpoint to accept a role
- update tests for approval flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f24e7e43c8333b0ea4caf6a48ebd8