### PR TITLE
Update dashboard tile rendering by role

### DIFF
--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -24,12 +24,7 @@ function Dashboard() {
     }
   }, []);
 
-  const tiles = [
-    { label: 'Student Profiles', path: '/students', admin: false },
-    { label: 'School Metrics', path: '/metrics', admin: false },
-    { label: 'Pending Registrations', path: '/admin/pending', admin: true },
-    { label: 'Job Matching', path: '/admin/jobs', admin: true },
-  ];
+  // Tiles are conditionally rendered based on the user's role
 
   return (
     <div className="dashboard-container">
@@ -51,13 +46,27 @@ function Dashboard() {
         </button>
       </div>
       <div className="tile-grid">
-        {tiles
-          .filter(tile => !tile.admin || role === 'admin')
-          .map(tile => (
-            <Link key={tile.path} to={tile.path} className="dashboard-tile">
-              {tile.label}
-            </Link>
-          ))}
+        {role === 'admin' && (
+          <>
+            <Link to="/students" className="dashboard-tile">Student Profiles</Link>
+            <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
+            <Link to="/admin/pending" className="dashboard-tile">Pending Registrations</Link>
+            <Link to="/admin/jobs" className="dashboard-tile">Job Matching</Link>
+          </>
+        )}
+
+        {role === 'career' && (
+          <>
+            <Link to="/students" className="dashboard-tile">Student Profiles</Link>
+            <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
+          </>
+        )}
+
+        {role === 'recruiter' && (
+          <>
+            <Link to="/admin/jobs" className="dashboard-tile">Job Matching</Link>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify Dashboard logic
- show different dashboard tiles for admin, career staff, and recruiters

## Testing
- `pytest -q` *(fails: registration_flow and others)*

------
https://chatgpt.com/codex/tasks/task_e_68600f06f5ac8333a2b4a9a0700772ca