### PR TITLE
Fix recruiter dashboard link

### DIFF
--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -64,7 +64,7 @@ function Dashboard() {
 
         {role === 'recruiter' && (
           <>
-            <Link to="/admin/jobs" className="dashboard-tile">Job Matching</Link>
+            <Link to="/recruiter/jobs" className="dashboard-tile">Job Matching</Link>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- fix recruiter tile to route to `/recruiter/jobs`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError fastapi & various test assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6860117b26908333be452a5c72cbee3a