### PR TITLE
Add filter inputs to student profiles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -224,6 +224,19 @@
   text-align: center;
 }
 
+.column-filter {
+  width: 100%;
+  padding: 4px;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+}
+
+.filter-row th {
+  background-color: #001f3f;
+}
+
 .job-subtable th,
 .job-subtable td {
   border: 1px solid #ccc;

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -23,6 +23,11 @@ function StudentProfiles() {
   const [isSaving, setIsSaving] = useState(false);
 
   const [schoolStudents, setSchoolStudents] = useState([]);
+  const [firstNameFilter, setFirstNameFilter] = useState('');
+  const [lastNameFilter, setLastNameFilter] = useState('');
+  const [emailFilter, setEmailFilter] = useState('');
+  const [codeFilter, setCodeFilter] = useState('');
+  const [placementFilter, setPlacementFilter] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [editingEmail, setEditingEmail] = useState('');
 
@@ -237,6 +242,31 @@ function StudentProfiles() {
     navigate('/login');
   };
 
+  const filteredStudents = schoolStudents.filter((s) => {
+    const firstMatch = s.first_name
+      ?.toLowerCase()
+      .includes(firstNameFilter.toLowerCase());
+    const lastMatch = s.last_name
+      ?.toLowerCase()
+      .includes(lastNameFilter.toLowerCase());
+    const emailMatch = s.email
+      ?.toLowerCase()
+      .includes(emailFilter.toLowerCase());
+    const codeMatch =
+      userRole !== 'admin'
+        ? true
+        : (s.institutional_code || '')
+            .toLowerCase()
+            .includes(codeFilter.toLowerCase());
+    const placed = Array.isArray(s.placed_jobs)
+      ? s.placed_jobs.length
+      : s.placed_jobs || 0;
+    let placementMatch = true;
+    if (placementFilter === '✅') placementMatch = placed > 0;
+    if (placementFilter === '❌') placementMatch = placed === 0;
+    return firstMatch && lastMatch && emailMatch && codeMatch && placementMatch;
+  });
+
   return (
     <div className="profiles-container">
       <div className="admin-menu">
@@ -347,16 +377,73 @@ function StudentProfiles() {
                 <thead>
                   <tr>
                     <th></th>
-                    <th>Name</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Email</th>
                     {userRole === 'admin' && <th>School</th>}
                     <th>Edit</th>
                     <th>Assigned Jobs</th>
                     <th>Placement Status</th>
                     <th>Placement Controls</th>
                   </tr>
+                  <tr className="filter-row">
+                    <th></th>
+                    <th>
+                      <input
+                        className="column-filter"
+                        type="text"
+                        value={firstNameFilter}
+                        onChange={(e) => setFirstNameFilter(e.target.value)}
+                        placeholder="Filter"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="column-filter"
+                        type="text"
+                        value={lastNameFilter}
+                        onChange={(e) => setLastNameFilter(e.target.value)}
+                        placeholder="Filter"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        className="column-filter"
+                        type="text"
+                        value={emailFilter}
+                        onChange={(e) => setEmailFilter(e.target.value)}
+                        placeholder="Filter"
+                      />
+                    </th>
+                    {userRole === 'admin' && (
+                      <th>
+                        <input
+                          className="column-filter"
+                          type="text"
+                          value={codeFilter}
+                          onChange={(e) => setCodeFilter(e.target.value)}
+                          placeholder="Filter"
+                        />
+                      </th>
+                    )}
+                    <th></th>
+                    <th></th>
+                    <th>
+                      <select
+                        className="column-filter"
+                        value={placementFilter}
+                        onChange={(e) => setPlacementFilter(e.target.value)}
+                      >
+                        <option value="">All</option>
+                        <option value="✅">✅</option>
+                        <option value="❌">❌</option>
+                      </select>
+                    </th>
+                    <th></th>
+                  </tr>
                 </thead>
                 <tbody>
-                  {schoolStudents.map((s) => {
+                  {filteredStudents.map((s) => {
                     const assigned = Array.isArray(s.assigned_jobs) ? s.assigned_jobs.length : s.assigned_jobs || 0;
                     const placed = Array.isArray(s.placed_jobs) ? s.placed_jobs.length : s.placed_jobs || 0;
                     return (
@@ -371,7 +458,9 @@ function StudentProfiles() {
                               {expandedRows[s.email] ? '–' : '+'}
                             </span>
                           </td>
-                          <td>{s.first_name} {s.last_name}</td>
+                          <td>{s.first_name}</td>
+                          <td>{s.last_name}</td>
+                          <td>{s.email}</td>
                           {userRole === 'admin' && <td>{s.institutional_code}</td>}
                           <td>
                             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary
- add column filter styles
- allow filtering by name, email, school code and placement status
- display separate table columns for first name, last name and email
- preserve expanded rows when filtering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: backend.app.main)*

------
https://chatgpt.com/codex/tasks/task_e_6862c581ee908333b15d72f665d4f23a