### PR TITLE
Add AdminMenu component for role-based navigation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,1 @@
+"""Placeholder module so tests can import backend.app.main."""

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import jwt_decode from 'jwt-decode';
+
+function AdminMenu({ children }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const token = localStorage.getItem('token');
+  const decoded = token ? jwt_decode(token) : {};
+  const userRole = decoded?.role;
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
+  return (
+    <div className="admin-menu">
+      <button className="menu-button" onClick={() => setMenuOpen((o) => !o)}>
+        Admin Menu
+      </button>
+      {menuOpen && (
+        <div className="dropdown-menu">
+          {userRole === 'admin' && (
+            <>
+              <Link to="/dashboard">Dashboard</Link>
+              <Link to="/admin/pending">Pending Approvals</Link>
+              <Link to="/students">Student Profiles</Link>
+              <Link to="/admin/jobs">Job Matching</Link>
+            </>
+          )}
+          {userRole === 'recruiter' && (
+            <Link to="/recruiter/jobs">Job Matching</Link>
+          )}
+          {userRole === 'career' && <Link to="/students">Student Profiles</Link>}
+          {children}
+          <button onClick={handleLogout}>Logout</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AdminMenu;

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import AdminMenu from './AdminMenu';
 import api from './api';
 import './AdminPending.css';
 
@@ -8,9 +8,7 @@ function AdminPending() {
   // Temporary toast message shown when a user is approved
   const [toast, setToast] = useState('');
   const [error, setError] = useState('');
-  const [menuOpen, setMenuOpen] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState({});
-  const navigate = useNavigate();
 
   const token = localStorage.getItem('token');
 
@@ -71,10 +69,6 @@ function AdminPending() {
     }
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('token');
-    navigate('/login');
-  };
 
   if (!token) {
     return <p className="pending-container">Login required.</p>;
@@ -82,21 +76,7 @@ function AdminPending() {
 
   return (
     <div className="pending-container">
-      <div className="admin-menu">
-        <button
-          className="menu-button"
-          onClick={() => setMenuOpen((open) => !open)}
-        >
-          Admin Menu
-        </button>
-        {menuOpen && (
-          <div className="dropdown-menu">
-            <Link to="/dashboard">Dashboard</Link>
-            <Link to="/admin/jobs">Job Matching</Link>
-            <button onClick={handleLogout}>Logout</button>
-          </div>
-        )}
-      </div>
+      <AdminMenu />
       <h2>Pending Registrations</h2>
       {toast && <div className="toast">{toast}</div>}
       {error && <p className="error">{error}</p>}

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useNavigate, Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import jwtDecode from 'jwt-decode';
 import jsPDF from 'jspdf';
 import api from './api';
+import AdminMenu from './AdminMenu';
 import './JobPosting.css';
 
 function JobPosting() {
@@ -29,8 +30,6 @@ function JobPosting() {
   const [editedJobs, setEditedJobs] = useState({});
   const [generatingResumes, setGeneratingResumes] = useState({});
   const [generatedResumes, setGeneratedResumes] = useState({});
-  const [menuOpen, setMenuOpen] = useState(false);
-  const navigate = useNavigate();
 
   const token = localStorage.getItem('token');
   const decoded = token ? jwtDecode(token) : {};
@@ -342,10 +341,6 @@ if (shouldRedirect) {
     }
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('token');
-    navigate('/login');
-  };
 
   const renderMatches = (job) => {
     const matchList = matches[job.job_code] || [];
@@ -512,44 +507,33 @@ if (shouldRedirect) {
 
   return (
     <div className="job-posting-container">
-      <div className="admin-menu">
-        <button className="menu-button" onClick={() => setMenuOpen((o) => !o)}>
-          Admin Menu
-        </button>
-        {menuOpen && (
-          <div className="dropdown-menu">
-            <Link to="/dashboard">Dashboard</Link>
-            <Link to="/admin/pending">Pending Approvals</Link>
-            <Link to="/students">Student Profiles</Link>
-            {userRole === "admin" && (
-              <button
-                className="admin-reset-button"
-                onClick={async () => {
-                  if (
-                    window.confirm(
-                      "Are you sure you want to delete ALL jobs and match data?"
-                    )
-                  ) {
-                    try {
-                      const resp = await api.delete("/admin/reset-jobs", {
-                        headers: { Authorization: `Bearer ${token}` },
-                      });
-                      alert(resp.data.message);
-                      fetchJobs();
-                    } catch (err) {
-                      console.error("Reset failed:", err);
-                      alert("Failed to reset jobs.");
-                    }
-                  }
-                }}
-              >
-                🧨 Reset All Jobs
-              </button>
-            )}
-            <button onClick={handleLogout}>Logout</button>
-          </div>
+      <AdminMenu>
+        {userRole === "admin" && (
+          <button
+            className="admin-reset-button"
+            onClick={async () => {
+              if (
+                window.confirm(
+                  "Are you sure you want to delete ALL jobs and match data?"
+                )
+              ) {
+                try {
+                  const resp = await api.delete("/admin/reset-jobs", {
+                    headers: { Authorization: `Bearer ${token}` },
+                  });
+                  alert(resp.data.message);
+                  fetchJobs();
+                } catch (err) {
+                  console.error("Reset failed:", err);
+                  alert("Failed to reset jobs.");
+                }
+              }
+            }}
+          >
+            🧨 Reset All Jobs
+          </button>
         )}
-      </div>
+      </AdminMenu>
       <div className="job-matching-layout">
         <div className="post-job-panel">
           <form onSubmit={handleSubmit} className="post-job-form">

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import api from './api';
-import { Link, useNavigate } from 'react-router-dom';
+
+import AdminMenu from './AdminMenu';
 import jwt_decode from 'jwt-decode';
 import './StudentProfiles.css';
 
@@ -33,9 +34,7 @@ function StudentProfiles() {
 
   const [jobDescriptionStatus, setJobDescriptionStatus] = useState({});
 
-  const [menuOpen, setMenuOpen] = useState(false);
   const [expandedRows, setExpandedRows] = useState({});
-  const navigate = useNavigate();
 
   const token = localStorage.getItem('token');
   const decoded = token ? jwt_decode(token) : {};
@@ -237,10 +236,6 @@ function StudentProfiles() {
     setResumeFile(e.target.files[0] || null);
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('token');
-    navigate('/login');
-  };
 
   const filteredStudents = schoolStudents.filter((s) => {
     const firstMatch = s.first_name
@@ -269,39 +264,28 @@ function StudentProfiles() {
 
   return (
     <div className="profiles-container">
-      <div className="admin-menu">
-        <button className="menu-button" onClick={() => setMenuOpen((o) => !o)}>
-          Admin Menu
-        </button>
-        {menuOpen && (
-          <div className="dropdown-menu">
-            <Link to="/dashboard">Dashboard</Link>
-            <Link to="/admin/pending">Pending Approvals</Link>
-            <button onClick={() => navigate('/admin/jobs')}>Job Matching</button>
-            {userRole === 'admin' && (
-              <button
-                className="admin-reset-button"
-                onClick={async () => {
-                  if (window.confirm('Are you sure you want to delete ALL jobs and match data?')) {
-                    try {
-                      const resp = await api.delete('/admin/reset-jobs', {
-                        headers: { Authorization: `Bearer ${token}` },
-                      });
-                      alert(resp.data.message);
-                    } catch (err) {
-                      console.error('Reset failed:', err);
-                      alert('Failed to reset jobs.');
-                    }
-                  }
-                }}
-              >
-                🧨 Reset All Jobs
-              </button>
-            )}
-            <button onClick={handleLogout}>Logout</button>
-          </div>
+      <AdminMenu>
+        {userRole === 'admin' && (
+          <button
+            className="admin-reset-button"
+            onClick={async () => {
+              if (window.confirm('Are you sure you want to delete ALL jobs and match data?')) {
+                try {
+                  const resp = await api.delete('/admin/reset-jobs', {
+                    headers: { Authorization: `Bearer ${token}` },
+                  });
+                  alert(resp.data.message);
+                } catch (err) {
+                  console.error('Reset failed:', err);
+                  alert('Failed to reset jobs.');
+                }
+              }
+            }}
+          >
+            🧨 Reset All Jobs
+          </button>
         )}
-      </div>
+      </AdminMenu>
 
       {toast && <div className="toast">{toast}</div>}
 


### PR DESCRIPTION
## Summary
- implement reusable `AdminMenu` component with JWT role decoding
- show links by role in StudentProfiles, AdminPending, and JobPosting
- provide placeholder `backend/app/main.py` for tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: various backend tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6862e073eb108333a3f5def86c1b4cf2