### PR TITLE
Implement job matching tab navigation

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -401,3 +401,37 @@
     overflow-x: auto;
   }
 }
+
+.tab-bar {
+  display: flex;
+  border-bottom: 2px solid #ececec;
+  margin-bottom: 1rem;
+}
+.tab {
+  background: #f8f4ec;
+  border: 1px solid #ececec;
+  border-bottom: none;
+  padding: 0.75rem 2rem;
+  margin-right: 0.5rem;
+  border-radius: 0.75rem 0.75rem 0 0;
+  font-weight: 600;
+  cursor: pointer;
+  color: #444;
+  transition: background 0.2s;
+}
+.tab.active {
+  background: #ffe4b2;
+  color: #1a1a1a;
+  border-bottom: 2px solid #ffe4b2;
+  z-index: 1;
+}
+.tab:not(.active):hover {
+  background: #fff5dd;
+}
+.tab-content {
+  background: #fff;
+  border: 1px solid #ececec;
+  border-radius: 0 0 1.5rem 1.5rem;
+  padding: 2rem;
+}
+

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -30,6 +30,7 @@ function JobPosting() {
   const [editedJobs, setEditedJobs] = useState({});
   const [generatingResumes, setGeneratingResumes] = useState({});
   const [generatedResumes, setGeneratedResumes] = useState({});
+  const [activeTab, setActiveTab] = useState('jobs');
 
   const token = localStorage.getItem('token');
   const decoded = token ? jwtDecode(token) : {};
@@ -554,71 +555,88 @@ if (shouldRedirect) {
           </button>
         )}
       </AdminMenu>
-      <div className="job-matching-layout">
-        <div className="post-job-panel">
-          <form onSubmit={handleSubmit} className="post-job-form">
-            <h2>Post a Job</h2>
-            <div className="form-field">
-              <label htmlFor="job_title">Job Title</label>
-              <input
-                id="job_title"
-                name="job_title"
-                type="text"
-                value={formData.job_title}
-                onChange={handleChange}
-              />
-            </div>
-            <div className="form-field">
-              <label htmlFor="job_description">Job Description</label>
-              <textarea
-                id="job_description"
-                name="job_description"
-                value={formData.job_description}
-                onChange={handleChange}
-              ></textarea>
-            </div>
-            <div className="form-field">
-              <label htmlFor="desired_skills">Desired Skills (comma separated)</label>
-              <input
-                id="desired_skills"
-                name="desired_skills"
-                type="text"
-                value={formData.desired_skills}
-                onChange={handleChange}
-              />
-            </div>
-            <div className="form-field">
-              <label htmlFor="source">Source</label>
-              <input
-                id="source"
-                name="source"
-                type="text"
-                value={formData.source}
-                onChange={handleChange}
-              />
-            </div>
-            <div className="form-field">
-              <label htmlFor="rate_of_pay_range">Rate of Pay Range</label>
-              <input
-                id="rate_of_pay_range"
-                name="rate_of_pay_range"
-                type="text"
-                value={formData.rate_of_pay_range}
-                onChange={handleChange}
-              />
-            </div>
-            <button type="submit">Submit</button>
-            {message && <p className="message">{message}</p>}
-          </form>
-        </div>
+      <div className="tab-bar">
+        <button
+          className={`tab ${activeTab === 'jobs' ? 'active' : ''}`}
+          onClick={() => setActiveTab('jobs')}
+        >
+          Jobs
+        </button>
+        <button
+          className={`tab ${activeTab === 'post' ? 'active' : ''}`}
+          onClick={() => setActiveTab('post')}
+        >
+          Post a Job
+        </button>
+      </div>
+      <div className="tab-content">
+        {activeTab === 'post' && (
+          <div className="post-job-panel">
+            <form onSubmit={handleSubmit} className="post-job-form">
+              <h2>Post a Job</h2>
+              <div className="form-field">
+                <label htmlFor="job_title">Job Title</label>
+                <input
+                  id="job_title"
+                  name="job_title"
+                  type="text"
+                  value={formData.job_title}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="form-field">
+                <label htmlFor="job_description">Job Description</label>
+                <textarea
+                  id="job_description"
+                  name="job_description"
+                  value={formData.job_description}
+                  onChange={handleChange}
+                ></textarea>
+              </div>
+              <div className="form-field">
+                <label htmlFor="desired_skills">Desired Skills (comma separated)</label>
+                <input
+                  id="desired_skills"
+                  name="desired_skills"
+                  type="text"
+                  value={formData.desired_skills}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="form-field">
+                <label htmlFor="source">Source</label>
+                <input
+                  id="source"
+                  name="source"
+                  type="text"
+                  value={formData.source}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="form-field">
+                <label htmlFor="rate_of_pay_range">Rate of Pay Range</label>
+                <input
+                  id="rate_of_pay_range"
+                  name="rate_of_pay_range"
+                  type="text"
+                  value={formData.rate_of_pay_range}
+                  onChange={handleChange}
+                />
+              </div>
+              <button type="submit">Submit</button>
+              {message && <p className="message">{message}</p>}
+            </form>
+          </div>
+        )}
 
-        <div className="posted-jobs-panel">
-        <h2>Jobs</h2>
-        <table className="job-table">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Job Code</th>
+        {activeTab === 'jobs' && (
+          <div className="posted-jobs-panel">
+            <h2>Jobs</h2>
+          <table className="job-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Job Code</th>
               <th>Title</th>
               <th>Source</th>
               <th>Rate</th>
@@ -876,10 +894,11 @@ if (shouldRedirect) {
                   )
                 )}
               </React.Fragment>
-            ))}
+              ))}
           </tbody>
         </table>
-      </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement tabs for posting jobs vs viewing jobs
- style new tab UI with file folder look

## Testing
- `pytest` *(fails: ModuleNotFoundError or failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6863792f21c48333811acee8629c9f21