### PR TITLE
Fix tab content radius

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -458,7 +458,10 @@
 .tab-content,
 .posted-jobs-panel {
   background: #fff !important;
-  border-radius: 0 0 1rem 1rem;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-left-radius: 1rem !important;
+  border-bottom-right-radius: 1rem !important;
   margin-top: 0 !important;
   padding: 0 1.5rem 1.5rem 1.5rem;
   padding-top: 0 !important;


### PR DESCRIPTION
## Summary
- make job list panels meet the tab bar by removing their top border-radius

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / registration flow errors)*

------
https://chatgpt.com/codex/tasks/task_e_686421399c7c8333ae4cfb01d5c2358c