### PR TITLE
Fix tab styles and remove table borders

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -114,12 +114,12 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0 !important;
-  border-top: none !important;
+  border: none !important;
 }
 
 .job-table th,
 .job-table td {
-  border: 1px solid #ccc;
+  border: none !important;
   padding: 0.5rem;
 }
 
@@ -136,11 +136,12 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  border: none !important;
 }
 
 .matches-table th,
 .matches-table td {
-  border: 1px solid #ccc;
+  border: none !important;
   padding: 0.4rem;
 }
 
@@ -430,8 +431,8 @@
 
 /* Active/inactive tab colors */
 .tab {
-  background: #e9ecef !important;
-  color: #032c4d !important;
+  background: #032c4d !important;
+  color: #fff !important;
   border: none !important;
   border-bottom: none !important;
   border-radius: 1.2rem 1.2rem 0 0 !important;
@@ -443,9 +444,9 @@
 }
 
 .tab.active {
-  background: #032c4d !important;
-  color: #fff !important;
-  border: none !important;
+  background: #fff !important;
+  color: #032c4d !important;
+  border: 1px solid #032c4d !important;
   border-bottom: none !important;
 }
 


### PR DESCRIPTION
## Summary
- update JobPosting styles so the active tab is white and inactive tabs blue
- remove borders around job tables so they blend with the tabs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686423e13508833380779215ce990766