### PR TITLE
Fix outer padding around jobs table

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -2,11 +2,11 @@
   background: #032c4d;
   color: white;
   min-height: 100vh;
-  padding: 1rem 1.5rem 2rem 1.5rem;
+  padding: 0 1.5rem 2rem 1.5rem;
   position: relative;
   border-radius: 1.25rem;
   max-width: 98vw;
-  margin: 2rem auto 0 auto;
+  margin: 0 auto;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.07);
 }
 
@@ -16,7 +16,7 @@
   border-radius: 1.25rem;
   padding: 1.5rem;
   max-width: 98vw;
-  margin: 2rem auto 0 auto;
+  margin: 0 auto;
 }
 
 .highlight-cell {
@@ -87,8 +87,7 @@
   margin-top: 0.5rem;
 }
 
-.post-job-panel h2,
-.posted-jobs-panel h2 {
+.post-job-panel h2 {
   font-size: 1.5rem;
   margin: 0 !important;
   margin-top: 0 !important;
@@ -114,44 +113,68 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0 !important;
-  border-top: none !important;
+  border: none !important;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .job-table th,
 .job-table td {
-  border: 1px solid #ccc;
-  padding: 0.5rem;
+  border: none !important;
+  padding: 0.6rem 0.5rem;
 }
 
 .job-table th {
   background-color: #003366;
+  color: #fff;
 }
 
 .job-table td {
   background-color: white;
   color: black;
+}
+
+.job-table tr:nth-child(even) td {
+  background-color: #f1f5fa;
+}
+
+.job-table tr:hover td {
+  background-color: #e7eef6;
 }
 
 .matches-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  border: none !important;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .matches-table th,
 .matches-table td {
-  border: 1px solid #ccc;
-  padding: 0.4rem;
+  border: none !important;
+  padding: 0.5rem;
 }
 
 .matches-table th {
   background-color: #003366;
-  color: white;
+  color: #fff;
 }
 
 .matches-table td {
   background-color: white;
   color: black;
+}
+
+.matches-table tr:nth-child(even) td {
+  background-color: #f1f5fa;
+}
+
+.matches-table tr:hover td {
+  background-color: #e7eef6;
 }
 
 .admin-menu {
@@ -426,12 +449,14 @@
   margin-bottom: 0 !important;
   border-bottom: none !important;
   padding-left: 0.5rem;
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Active/inactive tab colors */
 .tab {
-  background: #e9ecef !important;
-  color: #032c4d !important;
+  background: #032c4d !important;
+  color: #fff !important;
   border: none !important;
   border-bottom: none !important;
   border-radius: 1.2rem 1.2rem 0 0 !important;
@@ -440,33 +465,31 @@
   font-weight: 600 !important;
   font-size: 1.1rem !important;
   cursor: pointer;
+  transition: background 0.2s ease;
 }
 
 .tab.active {
-  background: #032c4d !important;
-  color: #fff !important;
-  border: none !important;
+  background: #fff !important;
+  color: #032c4d !important;
+  border: 1px solid #032c4d !important;
   border-bottom: none !important;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.15);
 }
 
 .tab:not(.active):hover {
-  background: #c3c9d0 !important;
-  color: #032c4d !important;
+  background: #004b80 !important;
+  color: #fff !important;
 }
 
 /* Remove all margin and border above the jobs table */
 .tab-content,
 .posted-jobs-panel {
-  background: #fff !important;
-  border-top-left-radius: 0 !important;
-  border-top-right-radius: 0 !important;
-  border-bottom-left-radius: 1rem !important;
-  border-bottom-right-radius: 1rem !important;
+  background: transparent !important;
   margin-top: 0 !important;
-  padding: 0 1.5rem 1.5rem 1.5rem;
-  padding-top: 0 !important;
-  border-top: none !important;
-  box-shadow: none;
+  padding: 0 !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 /* Ensure no spacing above the jobs table */
@@ -485,14 +508,13 @@
   margin-top: 0 !important;
   padding-top: 0 !important;
   border-top: none !important;
-  background: #fff !important;
+  background: transparent !important;
 }
 
 .tab-content h1,
 .tab-content h2,
 .tab-content h3,
 .posted-jobs-panel h1,
-.posted-jobs-panel h2,
 .posted-jobs-panel h3 {
   margin-top: 0 !important;
   padding-top: 0 !important;
@@ -503,9 +525,7 @@
   padding-top: 0 !important;
 }
 
-.posted-jobs-panel h2 {
-  margin-bottom: 0.5rem !important;
-}
+
 
 
 @media (max-width: 900px) {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -631,8 +631,7 @@ if (shouldRedirect) {
 
         {activeTab === 'jobs' && (
           <div className="posted-jobs-panel">
-            <h2>Jobs</h2>
-          <table className="job-table">
+            <table className="job-table">
             <thead>
               <tr>
                 <th></th>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background: #032c4d;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
## Summary
- remove duplicate jobs header from JobPosting component
- eliminate top margin above jobs module so tabs sit at the top
- set app background color to match tab panels
- modernize job and matches tables
- refine tab bar styling

## Testing
- `pytest -q` *(fails: 10 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686423e13508833380779215ce990766