### PR TITLE
Add tabs to student profiles module

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -283,3 +283,55 @@
   font-size: 0.85rem;
 }
 
+/* Ensure the students table sits directly under the tab bar */
+.students-panel {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+  border-top: none !important;
+  background: transparent !important;
+}
+
+/* Tab styles copied from JobPosting */
+.tab-bar {
+  display: flex;
+  align-items: flex-end;
+  background: #032c4d !important;
+  margin-bottom: 0 !important;
+  border-bottom: none !important;
+  padding-left: 0.5rem;
+}
+
+.tab {
+  background: #032c4d !important;
+  color: #fff !important;
+  border: none !important;
+  border-bottom: none !important;
+  border-radius: 1.2rem 1.2rem 0 0 !important;
+  padding: 1rem 2.5rem 1.2rem 2.5rem !important;
+  margin-right: 0.3rem !important;
+  font-weight: 600 !important;
+  font-size: 1.1rem !important;
+  cursor: pointer;
+}
+
+.tab.active {
+  background: #fff !important;
+  color: #032c4d !important;
+  border: 1px solid #032c4d !important;
+  border-bottom: none !important;
+}
+
+.tab:not(.active):hover {
+  background: #c3c9d0 !important;
+  color: #032c4d !important;
+}
+
+.tab-content {
+  background: transparent !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -32,6 +32,8 @@ function StudentProfiles() {
   const [isEditing, setIsEditing] = useState(false);
   const [editingEmail, setEditingEmail] = useState('');
 
+  const [activeTab, setActiveTab] = useState('students');
+
   const [jobDescriptionStatus, setJobDescriptionStatus] = useState({});
 
   const [expandedRows, setExpandedRows] = useState({});
@@ -94,6 +96,7 @@ function StudentProfiles() {
       });
       setIsEditing(true);
       setEditingEmail(student.email);
+      setActiveTab('new');
     }
   };
 
@@ -289,20 +292,26 @@ function StudentProfiles() {
 
       {toast && <div className="toast">{toast}</div>}
 
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          width: '100%',
-          minHeight: '100vh',
-          gap: '2rem',
-        }}
-      >
-        <div style={{ flex: 1, maxWidth: '600px' }}>
-          <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
-          <form className="profile-form" onSubmit={handleSubmit}>
+      <div className="tab-bar">
+        <button
+          className={`tab ${activeTab === 'students' ? 'active' : ''}`}
+          onClick={() => setActiveTab('students')}
+        >
+          Students
+        </button>
+        <button
+          className={`tab ${activeTab === 'new' ? 'active' : ''}`}
+          onClick={() => setActiveTab('new')}
+        >
+          New Student Profile
+        </button>
+      </div>
+
+      <div className="tab-content">
+        {activeTab === 'new' && (
+          <div className="form-panel">
+            <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
+            <form className="profile-form" onSubmit={handleSubmit}>
             {['first_name', 'last_name', 'email', 'phone', 'education_level', 'skills', 'experience_summary', 'interests'].map((field) => (
               <React.Fragment key={field}>
                 <label htmlFor={field}>{field.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</label>
@@ -338,9 +347,10 @@ function StudentProfiles() {
             {formError && <p className="error">{formError}</p>}
           </form>
         </div>
-
+        )}
+        {activeTab === 'students' && (
         <div
-          className="rightColumn"
+          className="students-panel"
           style={{
             flex: 1,
             minWidth: '600px',
@@ -349,8 +359,7 @@ function StudentProfiles() {
             justifyContent: 'flex-start',
           }}
         >
-          <div style={{ flexGrow: 1, minHeight: 0, marginTop: '3rem' }}>
-            <h2>Students from Your School</h2>
+          <div style={{ flexGrow: 1, minHeight: 0, marginTop: '0' }}>
             {isLoading ? (
               <div className="loading-container">
                 <span className="spinner" />
@@ -562,6 +571,7 @@ function StudentProfiles() {
             )}
           </div>
         </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refactor StudentProfiles layout to use tabbed interface
- add tab styles
- remove table heading and align table under Students tab

## Testing
- `npm test --silent`
- `pytest -q` *(fails: 10 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864324c6b9483339f521583d03aebc5