### PR TITLE
Change menu label

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -18,7 +18,7 @@ function AdminMenu({ children }) {
   return (
     <div className="admin-menu">
       <button className="menu-button" onClick={() => setMenuOpen((o) => !o)}>
-        Admin Menu
+        Menu
       </button>
       {menuOpen && (
         <div className="dropdown-menu">


### PR DESCRIPTION
## Summary
- rename the navigation button label from 'Admin Menu' to 'Menu'

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `tests/test_main.py::test_registration_flow - assert 422 == 200` and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_686441c2bf548333948430a851860266