### PR TITLE
Improve student profile spacing

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -2,7 +2,11 @@
   background-color: #001f3f;
   min-height: 100vh;
   color: white;
-  padding: 0 1.5rem 2rem 1.5rem;
+  /*
+    Add top padding so the spacing between the browser URL bar and the tab
+    bar matches the Job Matching module layout.
+  */
+  padding: 1.5rem 1.5rem 2rem;
   position: relative;
   border-radius: 1.25rem;
   max-width: 98vw;


### PR DESCRIPTION
## Summary
- adjust padding on the Student Profiles page so the tab bar spacing matches the Job Matching module

## Testing
- `pytest -q` *(fails: test_registration_flow, test_non_admin_cannot_approve, test_pending_users_endpoint, test_pending_users_forbidden_for_non_admin, test_admin_can_reject_user, test_non_admin_cannot_reject, test_students_all_forbidden_for_non_admin, test_update_student, test_delete_student_forbidden_non_admin, test_recruiter_cannot_place_student)*

------
https://chatgpt.com/codex/tasks/task_e_68644468ddbc8333a030023cdc39958c