### PR TITLE
Add pay range support

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -513,7 +513,11 @@ function StudentProfiles() {
                                     s.assigned_jobs.map((job, index) => (
                                       <tr key={index}>
                                         <td>{job.job_title}</td>
-                                        <td>{job.rate_of_pay_range || 'N/A'}</td>
+                                        <td>
+                                          {job.min_pay && job.max_pay
+                                            ? `${job.min_pay} - ${job.max_pay}`
+                                            : 'N/A'}
+                                        </td>
                                         <td>{job.source || 'N/A'}</td>
                                         <td style={{ textAlign: 'center' }}>
                                           {loadingJobDescriptions[job.job_code] ? (

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -127,7 +127,8 @@ def test_create_job_and_match(monkeypatch):
         "desired_skills": ["python"],
         "job_code": "ABC123",
         "source": "test",
-        "rate_of_pay_range": "$1-$2",
+        "min_pay": 1.0,
+        "max_pay": 2.0,
     }
 
     resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})


### PR DESCRIPTION
## Summary
- accept `school_code` alias on registration and keep when updating students
- track minimum and maximum pay for jobs with validation
- display pay range in job posting UI and student job lists
- adjust job update route to validate new fields
- update tests for pay range

## Testing
- `pytest -q`
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_686446ef98f083339f46366fa4f4a323