### PR TITLE
Add career staff info page and button

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Create a `.env` file with these example values:
 REACT_APP_API_URL=http://127.0.0.1:8000
 REACT_APP_GOOGLE_KEY=frontend_key
 GOOGLE_KEY=backend_key
+REACT_APP_CAREER_BTN_TEXT="Learn the TalentMatch API"
+REACT_APP_CAREER_INFO_HTML="<h2>Welcome career staff</h2><p>Here is how to use the API...</p>"
 ```
 
 ## Students Endpoint

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -9,6 +9,7 @@ function AdminMenu({ children }) {
   const token = localStorage.getItem('token');
   const decoded = token ? jwt_decode(token) : {};
   const userRole = decoded?.role;
+  const careerLabel = process.env.REACT_APP_CAREER_BTN_TEXT || "Career Staff";
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -17,6 +18,11 @@ function AdminMenu({ children }) {
 
   return (
     <div className="admin-menu">
+      {userRole === "career" && (
+        <Link className="career-button" to="/career-info">
+          {careerLabel}
+        </Link>
+      )}
       <button className="menu-button" onClick={() => setMenuOpen((o) => !o)}>
         Menu
       </button>

--- a/frontend/src/AdminPending.css
+++ b/frontend/src/AdminPending.css
@@ -81,6 +81,17 @@
   cursor: pointer;
 }
 
+.career-button {
+  background-color: #2ecc40;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  text-decoration: none;
+}
+
 .dropdown-menu {
   position: absolute;
   right: 0;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import AdminPending from './AdminPending';
 import StudentProfiles from './StudentProfiles';
 import JobPosting from './JobPosting';
 import Metrics from './Metrics';
+import CareerInfo from './CareerInfo';
 
 function App() {
   return (
@@ -58,6 +59,14 @@ function App() {
                 </ProtectedRoute>
               }
             />
+          <Route
+            path="/career-info"
+            element={
+              <ProtectedRoute>
+                <CareerInfo />
+              </ProtectedRoute>
+            }
+          />
           <Route
             path="/metrics"
             element={

--- a/frontend/src/CareerInfo.js
+++ b/frontend/src/CareerInfo.js
@@ -1,0 +1,14 @@
+import React from "react";
+import AdminMenu from "./AdminMenu";
+
+function CareerInfo() {
+  const infoHtml = process.env.REACT_APP_CAREER_INFO_HTML || "";
+  return (
+    <div className="career-info">
+      <AdminMenu />
+      <div dangerouslySetInnerHTML={{ __html: infoHtml }} />
+    </div>
+  );
+}
+
+export default CareerInfo;

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -175,6 +175,17 @@
   cursor: pointer;
 }
 
+.career-button {
+  background-color: #2ecc40;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  text-decoration: none;
+}
+
 .dropdown-menu {
   position: absolute;
   right: 0;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -122,6 +122,17 @@
   cursor: pointer;
 }
 
+.career-button {
+  background-color: #2ecc40;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  text-decoration: none;
+}
+
 .dropdown-menu {
   position: absolute;
   right: 0;


### PR DESCRIPTION
## Summary
- add `CareerInfo` component to display HTML from env var
- add `/career-info` route and conditional career button
- expose env vars for career staff in README
- style new career button across pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686583ef134c83338cc8e718eec90790