### PR TITLE
Add Career Staff Info page

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -27,13 +27,19 @@ function AdminMenu({ children }) {
               <Link to="/dashboard">Dashboard</Link>
               <Link to="/admin/pending">Pending Approvals</Link>
               <Link to="/students">Student Profiles</Link>
+              <Link to="/career-info">Career Staff Info</Link>
               <Link to="/admin/jobs">Job Matching</Link>
             </>
           )}
           {userRole === 'recruiter' && (
             <Link to="/recruiter/jobs">Job Matching</Link>
           )}
-          {userRole === 'career' && <Link to="/students">Student Profiles</Link>}
+          {userRole === 'career' && (
+            <>
+              <Link to="/students">Student Profiles</Link>
+              <Link to="/career-info">Career Staff Info</Link>
+            </>
+          )}
           {children}
           <button onClick={handleLogout}>Logout</button>
         </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import AdminPending from './AdminPending';
 import StudentProfiles from './StudentProfiles';
 import JobPosting from './JobPosting';
 import Metrics from './Metrics';
+import CareerStaffInfo from './CareerStaffInfo';
 
 function App() {
   return (
@@ -63,6 +64,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <Metrics />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/career-info"
+            element={
+              <ProtectedRoute>
+                <CareerStaffInfo />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/CareerStaffInfo.css
+++ b/frontend/src/CareerStaffInfo.css
@@ -1,0 +1,20 @@
+.career-info-container {
+  background-color: #001f3f;
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.career-info-container h2 {
+  margin-top: 2rem;
+}
+
+.career-info-container p {
+  max-width: 600px;
+  line-height: 1.5;
+}

--- a/frontend/src/CareerStaffInfo.js
+++ b/frontend/src/CareerStaffInfo.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import jwtDecode from 'jwt-decode';
+import AdminMenu from './AdminMenu';
+import './CareerStaffInfo.css';
+
+function CareerStaffInfo() {
+  const token = localStorage.getItem('token');
+  let role = '';
+  if (token) {
+    try {
+      const dec = jwtDecode(token);
+      role = dec.role;
+    } catch {}
+  }
+
+  if (role !== 'admin' && role !== 'career') {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return (
+    <div className="career-info-container">
+      <AdminMenu />
+      <h2>Welcome Career Services Team!</h2>
+      <p>
+        TalentMatch AI helps you track student profiles and match them with great
+        job opportunities. Use the Student Profiles and Job Matching tools to
+        quickly see recommended positions for each student.
+      </p>
+      <p>
+        We hope these features make connecting your students with employers a
+        breeze. Thanks for helping them launch amazing careers!
+      </p>
+    </div>
+  );
+}
+
+export default CareerStaffInfo;

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -50,6 +50,7 @@ function Dashboard() {
           <>
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
+            <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
             <Link to="/admin/pending" className="dashboard-tile">Pending Registrations</Link>
           </>
         )}
@@ -58,6 +59,7 @@ function Dashboard() {
           <>
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
+            <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
           </>
         )}
 


### PR DESCRIPTION
## Summary
- add new `CareerStaffInfo` page
- link to the new page from admin menu and dashboard
- protect page so only admin or career roles can view it
- register route in the React router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865899c10408333a77238b6b06df308