### PR TITLE
Improve career staff info page styling

### DIFF
--- a/frontend/src/CareerStaffInfo.css
+++ b/frontend/src/CareerStaffInfo.css
@@ -1,5 +1,5 @@
 .career-info-container {
-  background-color: #001f3f;
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
   min-height: 100vh;
   color: white;
   padding: 2rem;
@@ -7,14 +7,103 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
 
 .career-info-container h2 {
-  margin-top: 2rem;
+  margin-top: 0;
+  font-size: 2rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  animation: fadeSlide 0.6s ease forwards;
 }
 
 .career-info-container p {
-  max-width: 600px;
-  line-height: 1.5;
+  max-width: 700px;
+  line-height: 1.6;
+  font-size: 1.1rem;
+  margin: 0 1rem;
+  animation: fadeSlide 0.6s ease forwards;
+}
+
+.career-info-container strong {
+  color: #ffdc5e;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.career-info-container p:nth-of-type(1) {
+  animation-delay: 0.2s;
+}
+
+.career-info-container p:nth-of-type(2) {
+  animation-delay: 0.4s;
+}
+
+.career-info-container p:nth-of-type(3) {
+  animation-delay: 0.6s;
+}
+
+.career-info-container p:nth-of-type(4) {
+  animation-delay: 0.8s;
+}
+
+.career-info-container p:nth-of-type(5) {
+  animation-delay: 1s;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.admin-menu {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.menu-button {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 0.5rem;
+  background-color: #003366;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+  z-index: 10;
+}
+
+.dropdown-menu a,
+.dropdown-menu button {
+  color: white;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dropdown-menu a:hover,
+.dropdown-menu button:hover {
+  background-color: #001f3f;
 }

--- a/frontend/src/CareerStaffInfo.js
+++ b/frontend/src/CareerStaffInfo.js
@@ -23,9 +23,22 @@ function CareerStaffInfo() {
       <AdminMenu />
       <h2>Welcome Career Services Team!</h2>
       <p>
-        TalentMatch AI helps you track student profiles and match them with great
-        job opportunities. Use the Student Profiles and Job Matching tools to
-        quickly see recommended positions for each student.
+        <strong>TalentMatch AI</strong> helps you track student profiles and match
+        them with great job opportunities. Use the Student Profiles and Job
+        Matching tools to quickly see recommended positions for each student.
+      </p>
+      <p>
+        <strong>AI-driven matching</strong> surfaces personalized recommendations
+        so every student is presented with openings that fit their unique
+        skills.
+      </p>
+      <p>
+        <strong>Real-time analytics</strong> highlight placement rates and
+        licensing progress so you can focus your efforts where they matter most.
+      </p>
+      <p>
+        <strong>Automated outreach</strong> keeps students engaged while ensuring
+        employers see the very best from your talent pipeline.
       </p>
       <p>
         We hope these features make connecting your students with employers a


### PR DESCRIPTION
## Summary
- add gradient background and centered layout
- animate intro text
- style AdminMenu consistently with rest of app
- expand selling points of platform with bold highlights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68658f48e6fc8333861d117875ba6b5e