### PR TITLE
Increase text size on career staff info page

### DIFF
--- a/frontend/src/CareerStaffInfo.css
+++ b/frontend/src/CareerStaffInfo.css
@@ -13,9 +13,10 @@
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
 
+
 .career-info-container h2 {
   margin-top: 0;
-  font-size: 2.4rem;
+  font-size: 3rem;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
   animation: fadeSlide 0.6s ease forwards;
 }
@@ -23,7 +24,7 @@
 .career-info-container p {
   max-width: 700px;
   line-height: 1.6;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   margin: 0 1rem;
   animation: fadeSlide 0.6s ease forwards;
 }


### PR DESCRIPTION
## Summary
- enlarge heading and paragraph text on the CareerStaffInfo page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68659921d6488333ad9b42f714d60b8a