### PR TITLE
Enhance dashboard styling

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -1,30 +1,63 @@
 .dashboard-container {
-  background-color: #001f3f;
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   color: white;
+  padding: 2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  text-align: center;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.dashboard-heading {
+  margin-top: 0;
+  font-size: 3rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  animation: fadeSlide 0.6s ease forwards;
 }
 
 .tile-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  width: 80%;
-  max-width: 600px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 90%;
+  max-width: 800px;
 }
 
 .dashboard-tile {
-  background-color: white;
-  color: black;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #002244;
   text-decoration: none;
-  padding: 2rem;
+  padding: 1.5rem;
   border-radius: 10px;
   text-align: center;
-  transition: box-shadow 0.3s, border 0.3s;
+  font-weight: 600;
+  animation: fadeSlide 0.6s ease forwards;
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 
 .dashboard-tile:hover {
-  box-shadow: 0 0 10px rgba(0, 116, 217, 0.6);
+  transform: translateY(-4px);
+  box-shadow: 0 6px 15px rgba(0, 116, 217, 0.6);
+}
+
+.tile-grid a:nth-child(1) { animation-delay: 0.2s; }
+.tile-grid a:nth-child(2) { animation-delay: 0.4s; }
+.tile-grid a:nth-child(3) { animation-delay: 0.6s; }
+.tile-grid a:nth-child(4) { animation-delay: 0.8s; }
+.tile-grid a:nth-child(5) { animation-delay: 1s; }
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -24,6 +24,7 @@ function Dashboard() {
   return (
     <div className="dashboard-container">
       <AdminMenu />
+      <h2 className="dashboard-heading">Dashboard</h2>
       <div className="tile-grid">
         {role === 'admin' && (
           <>


### PR DESCRIPTION
## Summary
- add a heading to the dashboard
- restyle dashboard with gradient background, animations, and refined tiles

## Testing
- `CI=true npm --prefix frontend test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a5197a6c8333830ce568aad5dc73