### PR TITLE
Fix tab bar background

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -397,7 +397,6 @@
 .tab-bar {
   display: flex;
   align-items: flex-end;
-  background: #032c4d !important;
   margin-bottom: 0 !important;
   border-bottom: none !important;
   padding-left: 0.5rem;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -283,7 +283,6 @@
 .tab-bar {
   display: flex;
   align-items: flex-end;
-  background: #032c4d !important;
   margin-bottom: 0 !important;
   border-bottom: none !important;
   padding-left: 0.5rem;


### PR DESCRIPTION
## Summary
- remove background color from `.tab-bar` in JobPosting and StudentProfiles to stop blue bar stretching across the screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ad6f2580833392dbf8a23e8b11b1