### PR TITLE
Ensure dashboard link appears across modules

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -23,9 +23,9 @@ function AdminMenu({ children }) {
       </button>
       {menuOpen && (
         <div className="dropdown-menu">
+          <Link to="/dashboard">Dashboard</Link>
           {userRole === 'admin' && (
             <>
-              <Link to="/dashboard">Dashboard</Link>
               <Link to="/admin/pending">Pending Approvals</Link>
               <Link to="/students">Student Profiles</Link>
               <Link to="/career-info">Career Staff Info</Link>

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from './api';
 import jwtDecode from 'jwt-decode';
+import AdminMenu from './AdminMenu';
 import {
   BarChart,
   Bar,
@@ -51,10 +52,20 @@ function Metrics() {
   }, []);
 
   if (loading) {
-    return <div className="metrics-container">Loading...</div>;
+    return (
+      <div className="metrics-container">
+        <AdminMenu />
+        Loading...
+      </div>
+    );
   }
   if (!metricsData) {
-    return <div className="metrics-container">Failed to load metrics</div>;
+    return (
+      <div className="metrics-container">
+        <AdminMenu />
+        Failed to load metrics
+      </div>
+    );
   }
 
   const highlight = [
@@ -94,6 +105,7 @@ function Metrics() {
 
   return (
     <div className="metrics-container">
+      <AdminMenu />
       <div className="metric-grid">
         {highlight.map((h) => (
           <div key={h.label} className="highlight-card">


### PR DESCRIPTION
## Summary
- show Dashboard link for all roles in AdminMenu
- add AdminMenu to Metrics page so navigation is available even when loading or failing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865af6122648333a6b1631187025fb4