### PR TITLE
Add admin activity log UI

### DIFF
--- a/frontend/src/ActivityLog.css
+++ b/frontend/src/ActivityLog.css
@@ -1,0 +1,48 @@
+.activity-log-container {
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  position: relative;
+  border-radius: 1.25rem;
+  max-width: 98vw;
+  margin: 0 auto;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.download-btn {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.log-table th,
+.log-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.log-table th {
+  background-color: #003366;
+  color: white;
+  font-weight: 600;
+}
+
+.log-table td {
+  background-color: white;
+  color: black;
+}
+
+.error {
+  color: #ff4136;
+}

--- a/frontend/src/ActivityLog.js
+++ b/frontend/src/ActivityLog.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import jwtDecode from 'jwt-decode';
+import AdminMenu from './AdminMenu';
+import api from './api';
+import './ActivityLog.css';
+
+function ActivityLog() {
+  const [entries, setEntries] = useState([]);
+  const [error, setError] = useState('');
+
+  const token = localStorage.getItem('token');
+  let role = '';
+  if (token) {
+    try {
+      const dec = jwtDecode(token);
+      role = dec.role;
+    } catch {}
+  }
+
+  useEffect(() => {
+    const fetchLog = async () => {
+      try {
+        const resp = await api.get('/activity-log?limit=100', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setEntries(resp.data.entries || []);
+      } catch (err) {
+        console.error('Failed to load log:', err);
+        setError(err.response?.data?.detail || 'Failed to load log');
+      }
+    };
+    if (token) fetchLog();
+  }, [token]);
+
+  if (role !== 'admin') {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const downloadCSV = () => {
+    const header = 'timestamp,method,path,user';
+    const rows = entries.map(e =>
+      `${e.timestamp},${e.method},${e.path},${e.user}`
+    );
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'activity_log.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div className="activity-log-container">
+      <AdminMenu />
+      <h2>Activity Log</h2>
+      {error && <p className="error">{error}</p>}
+      <button className="download-btn" onClick={downloadCSV}>
+        Download CSV
+      </button>
+      <table className="log-table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Method</th>
+            <th>Path</th>
+            <th>User</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e, idx) => (
+            <tr key={idx}>
+              <td>{e.timestamp}</td>
+              <td>{e.method}</td>
+              <td>{e.path}</td>
+              <td>{e.user}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ActivityLog;

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -30,6 +30,7 @@ function AdminMenu({ children }) {
               <Link to="/students">Student Profiles</Link>
               <Link to="/career-info">Career Staff Info</Link>
               <Link to="/admin/jobs">Job Matching</Link>
+              <Link to="/admin/activity-log">Activity Log</Link>
             </>
           )}
           {userRole === 'recruiter' && (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import StudentProfiles from './StudentProfiles';
 import JobPosting from './JobPosting';
 import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
+import ActivityLog from './ActivityLog';
 
 function App() {
   return (
@@ -48,6 +49,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <JobPosting />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/activity-log"
+              element={
+                <ProtectedRoute>
+                  <ActivityLog />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -32,6 +32,7 @@ function Dashboard() {
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
             <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
             <Link to="/admin/pending" className="dashboard-tile">Pending Registrations</Link>
+            <Link to="/admin/activity-log" className="dashboard-tile">Activity Log</Link>
           </>
         )}
 


### PR DESCRIPTION
## Summary
- create ActivityLog component so admins can download logs
- add ActivityLog page to routes and navigation
- show Activity Log tile on the Dashboard

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6865eab79cbc833389ccb4c1c8b5d23c