### PR TITLE
Implement applicant profile and institutional matching

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -42,6 +42,9 @@ function AdminMenu({ children }) {
               <Link to="/career-info">Career Staff Info</Link>
             </>
           )}
+          {userRole === 'applicant' && (
+            <Link to="/applicant/profile">My Profile</Link>
+          )}
           {children}
           <button onClick={handleLogout}>Logout</button>
         </div>

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -109,6 +109,7 @@ function AdminPending() {
                 >
                   <option value="career">Career Service Staff</option>
                   <option value="recruiter">Recruiter</option>
+                  <option value="applicant">Applicant</option>
                 </select>
                 <button className="approve-button" onClick={() => handleApprove(user.email)}>Approve</button>
                 <button className="reject-button" onClick={() => handleReject(user.email)}>Reject</button>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import JobPosting from './JobPosting';
 import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
 import ActivityLog from './ActivityLog';
+import ApplicantProfile from './ApplicantProfile';
 
 function App() {
   return (
@@ -81,6 +82,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <CareerStaffInfo />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/applicant/profile"
+            element={
+              <ProtectedRoute>
+                <ApplicantProfile />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import AdminMenu from './AdminMenu';
+import api from './api';
+import './StudentProfiles.css';
+
+function ApplicantProfile() {
+  const [profile, setProfile] = useState(null);
+  const [matches, setMatches] = useState([]);
+  const token = localStorage.getItem('token');
+
+  const fetchProfile = async () => {
+    try {
+      const resp = await api.get('/students/me', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setProfile(resp.data.student);
+    } catch (err) {
+      console.error('Failed to load profile', err);
+    }
+  };
+
+  const fetchMatches = async () => {
+    try {
+      const resp = await api.get('/my-matches', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMatches(resp.data.matches || []);
+    } catch (err) {
+      console.error('Failed to load matches', err);
+    }
+  };
+
+  useEffect(() => {
+    if (token) {
+      fetchProfile();
+      fetchMatches();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!token) {
+    return <p className="profiles-container">Login required.</p>;
+  }
+
+  return (
+    <div className="profiles-container">
+      <AdminMenu />
+      <h2>My Profile</h2>
+      {profile && (
+        <div className="form-panel">
+          <p><strong>Name:</strong> {profile.first_name} {profile.last_name}</p>
+          <p><strong>Email:</strong> {profile.email}</p>
+          <p><strong>Institution:</strong> {profile.institutional_code}</p>
+        </div>
+      )}
+      <h3>Matched Jobs</h3>
+      {matches.length > 0 ? (
+        <table className="pending-table">
+          <thead>
+            <tr>
+              <th>Job Code</th>
+              <th>Job Title</th>
+              <th>Score</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matches.map((m, idx) => (
+              <tr key={idx}>
+                <td>{m.job_code}</td>
+                <td>{m.job_title}</td>
+                <td>{m.score?.toFixed(2)}</td>
+                <td>{m.status || ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No matches found.</p>
+      )}
+    </div>
+  );
+}
+
+export default ApplicantProfile;

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -49,6 +49,11 @@ function Dashboard() {
             <div className="dashboard-tile">Job Matching</div>
           </Link>
         ) : null}
+        {role === 'applicant' && (
+          <Link to="/applicant/profile" className="dashboard-tile">
+            My Profile
+          </Link>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow applicant role approval
- save job poster institution code and filter matches by it
- add profile/match endpoints for applicants
- extend frontend with Applicant Profile page and routing
- update admin pending role list and dashboard menu
- test applicant approval and institution-aware matching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686809ca5b588333a32bfc1d8b41662f