### PR TITLE
Add applicant role and profile matching

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -36,6 +36,9 @@ function AdminMenu({ children }) {
           {userRole === 'recruiter' && (
             <Link to="/recruiter/jobs">Job Matching</Link>
           )}
+          {userRole === 'applicant' && (
+            <Link to="/applicant/profile">Applicant Profile</Link>
+          )}
           {userRole === 'career' && (
             <>
               <Link to="/students">Student Profiles</Link>

--- a/frontend/src/AdminPending.js
+++ b/frontend/src/AdminPending.js
@@ -109,6 +109,7 @@ function AdminPending() {
                 >
                   <option value="career">Career Service Staff</option>
                   <option value="recruiter">Recruiter</option>
+                  <option value="applicant">Applicant</option>
                 </select>
                 <button className="approve-button" onClick={() => handleApprove(user.email)}>Approve</button>
                 <button className="reject-button" onClick={() => handleReject(user.email)}>Reject</button>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import Dashboard from './Dashboard';
 import ProtectedRoute from './ProtectedRoute';
 import AdminPending from './AdminPending';
 import StudentProfiles from './StudentProfiles';
+import ApplicantProfile from './ApplicantProfile';
 import JobPosting from './JobPosting';
 import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
@@ -33,6 +34,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <StudentProfiles />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/applicant/profile"
+            element={
+              <ProtectedRoute>
+                <ApplicantProfile />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -1,0 +1,185 @@
+import React, { useState, useEffect } from 'react';
+import api from './api';
+import jwtDecode from 'jwt-decode';
+import AdminMenu from './AdminMenu';
+import './StudentProfiles.css';
+
+function ApplicantProfile() {
+  const token = localStorage.getItem('token');
+  const decoded = token ? jwtDecode(token) : {};
+  const email = decoded.sub;
+
+  const [formData, setFormData] = useState({
+    first_name: '',
+    last_name: '',
+    email: email || '',
+    phone: '',
+    education_level: '',
+    skills: '',
+    experience_summary: '',
+    interests: '',
+    city: '',
+    state: '',
+    lat: '',
+    lng: '',
+    max_travel: ''
+  });
+  const [assignedJobs, setAssignedJobs] = useState([]);
+  const [isEditing, setIsEditing] = useState(false);
+  const [jobDescriptionStatus, setJobDescriptionStatus] = useState({});
+  const [loadingJobDescriptions, setLoadingJobDescriptions] = useState({});
+
+  useEffect(() => {
+    if (token) {
+      fetchProfile();
+    }
+  }, [token]);
+
+  const fetchProfile = async () => {
+    try {
+      const resp = await api.get('/students/me', { headers: { Authorization: `Bearer ${token}` } });
+      const data = resp.data;
+      setFormData({
+        first_name: data.first_name || '',
+        last_name: data.last_name || '',
+        email: data.email || email,
+        phone: data.phone || '',
+        education_level: data.education_level || '',
+        skills: Array.isArray(data.skills) ? data.skills.join(', ') : data.skills || '',
+        experience_summary: data.experience_summary || '',
+        interests: Array.isArray(data.interests) ? data.interests.join(', ') : data.interests || '',
+        city: data.city || '',
+        state: data.state || '',
+        lat: data.lat || '',
+        lng: data.lng || '',
+        max_travel: data.max_travel || ''
+      });
+      setAssignedJobs(data.assigned_jobs || []);
+      setIsEditing(true);
+    } catch (err) {
+      // no profile yet
+      setIsEditing(false);
+    }
+  };
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      ...formData,
+      skills: formData.skills.split(',').map(s => s.trim()),
+      max_travel: parseFloat(formData.max_travel || 0)
+    };
+    try {
+      if (isEditing) {
+        await api.put(`/students/${email}`, payload, { headers: { Authorization: `Bearer ${token}` } });
+      } else {
+        await api.post('/students', payload, { headers: { Authorization: `Bearer ${token}` } });
+        setIsEditing(true);
+      }
+      fetchProfile();
+    } catch (err) {
+      console.error('Save failed', err);
+    }
+  };
+
+  const fetchJobDescriptionStatus = async (jobCode) => {
+    try {
+      const resp = await api.get(`/job-description/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
+      if (resp.data.status === 'success') {
+        setJobDescriptionStatus(prev => ({ ...prev, [jobCode]: 'ready' }));
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const generateJobDescription = async (jobCode) => {
+    setLoadingJobDescriptions(prev => ({ ...prev, [jobCode]: true }));
+    try {
+      await api.post('/generate-job-description', { job_code: jobCode, student_email: email }, { headers: { Authorization: `Bearer ${token}` } });
+      setJobDescriptionStatus(prev => ({ ...prev, [jobCode]: 'ready' }));
+    } catch (err) {
+      console.error('Generation failed', err);
+    } finally {
+      setLoadingJobDescriptions(prev => ({ ...prev, [jobCode]: false }));
+    }
+  };
+
+  const viewJobDescription = async (jobCode) => {
+    try {
+      const resp = await api.get(`/job-description-html/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write(resp.data);
+        newWindow.document.close();
+      }
+    } catch (err) {
+      alert('Failed to load job description');
+    }
+  };
+
+  useEffect(() => {
+    assignedJobs.forEach(j => fetchJobDescriptionStatus(j.job_code));
+  }, [assignedJobs]);
+
+  return (
+    <div className="profiles-container">
+      <AdminMenu />
+      <div className="form-panel">
+        <h2>Applicant Profile</h2>
+        <form className="profile-form" onSubmit={handleSubmit}>
+          {['first_name','last_name','email','phone','education_level','skills','experience_summary','interests','city','state','max_travel'].map(field => (
+            <React.Fragment key={field}>
+              <label htmlFor={field}>{field.replace(/_/g, ' ').replace(/\b\w/g,l=>l.toUpperCase())}</label>
+              {field === 'experience_summary' ? (
+                <textarea id={field} name={field} value={formData[field]} onChange={handleChange} />
+              ) : (
+                <input id={field} name={field} type={field==='max_travel'?'number':'text'} value={formData[field]} onChange={handleChange} disabled={field==='email'} />
+              )}
+            </React.Fragment>
+          ))}
+          <button type="submit">{isEditing ? 'Update Profile' : 'Save Profile'}</button>
+        </form>
+      </div>
+      {assignedJobs.length > 0 && (
+        <div style={{marginTop:'2rem'}}>
+          <h3>Matched Jobs</h3>
+          <table className="job-subtable">
+            <thead>
+              <tr>
+                <th>Job Title</th>
+                <th>Rate</th>
+                <th>Source</th>
+                <th>Job Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assignedJobs.map((job, idx) => (
+                <tr key={idx}>
+                  <td>{job.job_title}</td>
+                  <td>{job.min_pay && job.max_pay ? `${job.min_pay} - ${job.max_pay}` : 'N/A'}</td>
+                  <td>{job.source || 'N/A'}</td>
+                  <td style={{textAlign:'center'}}>
+                    {loadingJobDescriptions[job.job_code] ? (
+                      <span>Generating...</span>
+                    ) : jobDescriptionStatus[job.job_code] === 'ready' ? (
+                      <button onClick={() => viewJobDescription(job.job_code)}>View</button>
+                    ) : (
+                      <button onClick={() => generateJobDescription(job.job_code)}>Generate</button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ApplicantProfile;

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -44,6 +44,10 @@ function Dashboard() {
           </>
         )}
 
+        {role === 'applicant' && (
+          <Link to="/applicant/profile" className="dashboard-tile">Applicant Profile</Link>
+        )}
+
         {role === 'admin' || role === 'recruiter' ? (
           <Link to={role === 'admin' ? '/admin/jobs' : '/recruiter/jobs'}>
             <div className="dashboard-tile">Job Matching</div>


### PR DESCRIPTION
## Summary
- introduce an `applicant` user role and restrict matching by institutional code
- allow admins to select the applicant role for pending users
- add Applicant Profile UI and routing
- link applicant profile from dashboard and menu
- expose `/students/me` endpoint
- add tests for applicant profile endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868343cb3a08333b614843ecd6f243d