### PR TITLE
Add admin user management UI and API

### DIFF
--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -31,6 +31,7 @@ function AdminMenu({ children }) {
               <Link to="/career-info">Career Staff Info</Link>
               <Link to="/admin/jobs">Job Matching</Link>
               <Link to="/admin/activity-log">Activity Log</Link>
+              <Link to="/admin/users">Manage Users</Link>
             </>
           )}
           {userRole === 'recruiter' && (

--- a/frontend/src/AdminUsers.css
+++ b/frontend/src/AdminUsers.css
@@ -1,0 +1,59 @@
+.users-container {
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  position: relative;
+  border-radius: 1.25rem;
+  max-width: 98vw;
+  margin: 0 auto;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.users-table th,
+.users-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.users-table th {
+  background-color: #003366;
+  color: white;
+  font-weight: 600;
+}
+
+.users-table td {
+  background-color: white;
+  color: black;
+}
+
+.users-table input[type='text'],
+.users-table select {
+  width: 100%;
+}
+
+.users-table button {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: #2ecc40;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+}

--- a/frontend/src/AdminUsers.js
+++ b/frontend/src/AdminUsers.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import AdminMenu from './AdminMenu';
+import api from './api';
+import './AdminUsers.css';
+
+function AdminUsers() {
+  const [users, setUsers] = useState([]);
+  const [message, setMessage] = useState('');
+  const token = localStorage.getItem('token');
+
+  const fetchUsers = async () => {
+    try {
+      const resp = await api.get('/admin/users', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setUsers(resp.data.users || []);
+    } catch (err) {
+      console.error('Failed to fetch users', err);
+    }
+  };
+
+  useEffect(() => {
+    if (token) fetchUsers();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleChange = (email, field, value) => {
+    setUsers((prev) =>
+      prev.map((u) => (u.email === email ? { ...u, [field]: value } : u))
+    );
+  };
+
+  const handleSave = async (user) => {
+    setMessage('');
+    try {
+      await api.put(
+        `/admin/users/${user.email}`,
+        {
+          role: user.role,
+          school_code: user.institutional_code,
+          active: user.active
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setMessage('Saved!');
+      setTimeout(() => setMessage(''), 2000);
+    } catch (err) {
+      console.error('Save failed', err);
+    }
+  };
+
+  return (
+    <div className="users-container">
+      <AdminMenu />
+      <h2>Manage Users</h2>
+      {message && <div className="toast">{message}</div>}
+      <table className="users-table">
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>School</th>
+            <th>Role</th>
+            <th>Active</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.email}>
+              <td>{u.email}</td>
+              <td>{u.first_name}</td>
+              <td>{u.last_name}</td>
+              <td>
+                <input
+                  type="text"
+                  value={u.institutional_code || ''}
+                  onChange={(e) =>
+                    handleChange(u.email, 'institutional_code', e.target.value)
+                  }
+                />
+              </td>
+              <td>
+                <select
+                  value={u.role}
+                  onChange={(e) => handleChange(u.email, 'role', e.target.value)}
+                >
+                  <option value="admin">Admin</option>
+                  <option value="career">Career</option>
+                  <option value="recruiter">Recruiter</option>
+                  <option value="applicant">Applicant</option>
+                </select>
+              </td>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={u.active !== false}
+                  onChange={(e) =>
+                    handleChange(u.email, 'active', e.target.checked)
+                  }
+                />
+              </td>
+              <td>
+                <button onClick={() => handleSave(u)}>Save</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default AdminUsers;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import JobPosting from './JobPosting';
 import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
 import ActivityLog from './ActivityLog';
+import AdminUsers from './AdminUsers';
 
 function App() {
   return (
@@ -61,19 +62,27 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            <Route
-              path="/admin/activity-log"
-              element={
-                <ProtectedRoute>
-                  <ActivityLog />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/recruiter/jobs"
-              element={
-                <ProtectedRoute>
-                  <JobPosting />
+          <Route
+            path="/admin/activity-log"
+            element={
+              <ProtectedRoute>
+                <ActivityLog />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/users"
+            element={
+              <ProtectedRoute>
+                <AdminUsers />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/recruiter/jobs"
+            element={
+              <ProtectedRoute>
+                <JobPosting />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -33,6 +33,7 @@ function Dashboard() {
             <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
             <Link to="/admin/pending" className="dashboard-tile">Pending Registrations</Link>
             <Link to="/admin/activity-log" className="dashboard-tile">Activity Log</Link>
+            <Link to="/admin/users" className="dashboard-tile">Manage Users</Link>
           </>
         )}
 


### PR DESCRIPTION
## Summary
- allow admin to manage users with new API endpoints
- check user `active` status on login
- add React UI for editing users
- expose user management links in dashboard and menu
- test admin user management flow

## Testing
- `pytest -q`
- `cd frontend && npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_686883ac5714833398a2f9c2bb18060f