### PR TITLE
Add refresh option to Manage Users

### DIFF
--- a/frontend/src/AdminUsers.css
+++ b/frontend/src/AdminUsers.css
@@ -10,6 +10,22 @@
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
 
+.users-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.refresh-btn {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
 .users-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/AdminUsers.js
+++ b/frontend/src/AdminUsers.js
@@ -42,6 +42,7 @@ function AdminUsers() {
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setMessage('Saved!');
+      fetchUsers();
       setTimeout(() => setMessage(''), 2000);
     } catch (err) {
       console.error('Save failed', err);
@@ -51,7 +52,10 @@ function AdminUsers() {
   return (
     <div className="users-container">
       <AdminMenu />
-      <h2>Manage Users</h2>
+      <div className="users-header">
+        <h2>Manage Users</h2>
+        <button className="refresh-btn" onClick={fetchUsers}>Refresh</button>
+      </div>
       {message && <div className="toast">{message}</div>}
       <table className="users-table">
         <thead>


### PR DESCRIPTION
## Summary
- add a Refresh button in the admin user management view
- update CSS for new header layout and button
- refresh user list after saving changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686886a536b08333a60801c1f258cdf9