### PR TITLE
Add school code API, dropdown UI, and match email

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Create a `.env` file with these example values:
 REACT_APP_API_URL=http://127.0.0.1:8000
 REACT_APP_GOOGLE_KEY=frontend_key
 GOOGLE_KEY=backend_key
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASSWORD=secret
+EMAIL_SENDER=noreply@example.com
 ```
 
 ## Students Endpoint

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -834,3 +834,11 @@ def test_admin_user_management_flow():
     )
     assert login.status_code == 403
 
+
+def test_school_codes_endpoint():
+    resp = client.get("/school-codes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "codes" in data
+    assert any(c["code"] == "1001" for c in data["codes"])
+


### PR DESCRIPTION
## Summary
- expose `/school-codes` endpoint
- add SMTP helpers and send emails for match results
- update admin user management to use dropdown of school codes
- document SMTP env vars
- test school codes API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c8ad5fdc8333a7ff80eb926081d0