### PR TITLE
Add institution code management

### DIFF
--- a/frontend/src/AdminUsers.css
+++ b/frontend/src/AdminUsers.css
@@ -64,6 +64,14 @@
   font-weight: 600;
 }
 
+.add-code-form {
+  margin: 1rem 0;
+}
+.add-code-form input {
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
 .toast {
   position: fixed;
   top: 1rem;

--- a/frontend/src/AdminUsers.js
+++ b/frontend/src/AdminUsers.js
@@ -7,6 +7,8 @@ function AdminUsers() {
   const [users, setUsers] = useState([]);
   const [codes, setCodes] = useState([]);
   const [message, setMessage] = useState('');
+  const [newCode, setNewCode] = useState('');
+  const [newLabel, setNewLabel] = useState('');
   const token = localStorage.getItem('token');
 
   const fetchUsers = async () => {
@@ -65,12 +67,42 @@ function AdminUsers() {
     }
   };
 
+  const handleAddCode = async () => {
+    try {
+      await api.post(
+        '/admin/school-codes',
+        { code: newCode, label: newLabel },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setNewCode('');
+      setNewLabel('');
+      fetchCodes();
+    } catch (err) {
+      console.error('Failed to add code', err);
+    }
+  };
+
   return (
     <div className="users-container">
       <AdminMenu />
       <div className="users-header">
         <h2>Manage Users</h2>
         <button className="refresh-btn" onClick={fetchUsers}>Refresh</button>
+      </div>
+      <div className="add-code-form">
+        <input
+          type="text"
+          placeholder="Code"
+          value={newCode}
+          onChange={(e) => setNewCode(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Label"
+          value={newLabel}
+          onChange={(e) => setNewLabel(e.target.value)}
+        />
+        <button onClick={handleAddCode}>Add Code</button>
       </div>
       {message && <div className="toast">{message}</div>}
       <table className="users-table">

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -842,3 +842,22 @@ def test_school_codes_endpoint():
     assert "codes" in data
     assert any(c["code"] == "1001" for c in data["codes"])
 
+
+def test_add_school_code():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    login = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    )
+    token = login.json()["token"]
+
+    resp = client.post(
+        "/admin/school-codes",
+        json={"code": "SC1", "label": "School One"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    codes = client.get("/school-codes").json()["codes"]
+    assert any(c["code"] == "SC1" for c in codes)
+


### PR DESCRIPTION
## Summary
- allow admins to add new institution codes via API
- expose `all_school_codes()` and `get_school_label()` helpers
- seed default codes into Redis on startup
- update metrics to ignore school code keys
- add UI for creating codes in Manage Users
- test new admin endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868cd9ac6c88333ba3646e60d719da1