### PR TITLE
Ensure school code labels seed correctly

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,10 +34,11 @@ from backend.app.school_codes import SCHOOL_CODE_MAP
 
 
 def init_default_school_codes():
-    """Seed redis with default school codes if not present."""
+    """Ensure Redis contains the default school codes with current labels."""
     for code, label in SCHOOL_CODE_MAP.items():
         key = f"school_code:{code}"
-        if not redis_client.exists(key):
+        existing = redis_client.get(key)
+        if existing != label:
             redis_client.set(key, label)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -861,3 +861,12 @@ def test_add_school_code():
     codes = client.get("/school-codes").json()["codes"]
     assert any(c["code"] == "SC1" for c in codes)
 
+
+def test_init_default_school_codes_updates_label():
+    main_app.redis_client.flushdb()
+    main_app.redis_client.set("school_code:1002", "1002-Unitek-Old")
+    main_app.init_default_school_codes()
+    assert (
+        main_app.redis_client.get("school_code:1002") == "1002-Unitek-SanJose"
+    )
+


### PR DESCRIPTION
## Summary
- fix `init_default_school_codes` so existing codes get updated to the latest labels
- test that outdated school code labels are corrected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a043b85b483338c2edcf65e4c595e