### PR TITLE
Add admin tabs with school code management

### DIFF
--- a/frontend/src/AdminUsers.css
+++ b/frontend/src/AdminUsers.css
@@ -90,3 +90,46 @@
   padding: 0.5rem 1rem;
   border-radius: 5px;
 }
+
+/* Tab styles reused from StudentProfiles */
+.tab-bar {
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: 0;
+  border-bottom: none;
+  padding-left: 0.5rem;
+}
+
+.tab {
+  background: #032c4d;
+  color: #fff;
+  border: none;
+  border-bottom: none;
+  border-radius: 1.2rem 1.2rem 0 0;
+  padding: 1rem 2.5rem 1.2rem 2.5rem;
+  margin-right: 0.3rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.tab.active {
+  background: #fff;
+  color: #032c4d;
+  border: 1px solid #032c4d;
+  border-bottom: none;
+}
+
+.tab:not(.active):hover {
+  background: #c3c9d0;
+  color: #032c4d;
+}
+
+.tab-content {
+  background: transparent;
+  margin-top: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -862,6 +862,37 @@ def test_add_school_code():
     assert any(c["code"] == "SC1" for c in codes)
 
 
+def test_update_and_delete_school_code():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    client.post(
+        "/admin/school-codes",
+        json={"code": "SC2", "label": "School Two"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    resp = client.put(
+        "/admin/school-codes/SC2",
+        json={"label": "Updated Two"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    codes = client.get("/school-codes").json()["codes"]
+    assert any(c["code"] == "SC2" and c["label"] == "Updated Two" for c in codes)
+
+    resp = client.delete(
+        "/admin/school-codes/SC2",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    codes = client.get("/school-codes").json()["codes"]
+    assert not any(c["code"] == "SC2" for c in codes)
+
+
 def test_init_default_school_codes_updates_label():
     main_app.redis_client.flushdb()
     main_app.redis_client.set("school_code:1002", "1002-Unitek-Old")


### PR DESCRIPTION
## Summary
- add API endpoints to update and delete school codes
- implement tabbed admin interface with separate code management
- style admin tab bar
- test school code update and delete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8efef2bc83338d9e3a30fc3880b0