### PR TITLE
Fix /match scanning

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -805,9 +805,7 @@ def match_job(req: JobCodeRequest, current_user: dict = Depends(get_current_user
         raise HTTPException(status_code=500, detail=f"Embedding failed: {str(e)}")
 
     matches = []
-    for key in redis_client.scan_iter("*"):
-        if str(key).startswith("job:") or str(key).startswith("user:"):
-            continue
+    for key in redis_client.scan_iter("student:*"):
         student_raw = redis_client.get(key)
         if not student_raw:
             continue


### PR DESCRIPTION
## Summary
- only iterate student keys when matching jobs to avoid wrong Redis type

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687025f6f99883339daa0914857602ae