### PR TITLE
Add basic form validation to login

### DIFF
--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -14,6 +14,11 @@ function LoginForm() {
     setError('');
     console.log('Submitting login...');
 
+    if (!email.trim() || !password) {
+      setError('Invalid credentials');
+      return;
+    }
+
     try {
       const resp = await api.post('/login',
         { email, password }
@@ -41,7 +46,11 @@ function LoginForm() {
       }
     } catch (err) {
       console.error('Login error:', err);
-      setError(err.response?.data?.detail || 'Login failed');
+      if (err.response && (err.response.status === 401 || err.response.status === 422)) {
+        setError('Invalid credentials');
+      } else {
+        setError(err.response?.data?.detail || 'Login failed');
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- validate blank login credentials before sending request
- handle HTTP 422 errors like invalid credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704392cf4c83338e372848c963aa63