### PR TITLE
Improve dashboard design

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "recharts": "^2.8.0",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -1,5 +1,5 @@
 .dashboard-container {
-  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  background: linear-gradient(135deg, #1b2b4f, #344f7d 50%, #506fa3);
   min-height: 100vh;
   color: white;
   padding: 2rem;
@@ -17,6 +17,7 @@
   margin-top: 0;
   font-size: 3rem;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  font-family: 'Montserrat', sans-serif;
   animation: fadeSlide 0.6s ease forwards;
 }
 
@@ -36,13 +37,22 @@
   border-radius: 10px;
   text-align: center;
   font-weight: 600;
+  font-family: 'Montserrat', sans-serif;
   animation: fadeSlide 0.6s ease forwards;
   transition: transform 0.3s, box-shadow 0.3s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .dashboard-tile:hover {
   transform: translateY(-4px);
   box-shadow: 0 6px 15px rgba(0, 116, 217, 0.6);
+}
+
+.tile-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
 .tile-grid a:nth-child(1) { animation-delay: 0.2s; }

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import {
+  FaUsers,
+  FaChartLine,
+  FaUserTie,
+  FaCheckCircle,
+  FaListUl,
+  FaUserCog,
+  FaBriefcase,
+} from 'react-icons/fa';
 import jwtDecode from 'jwt-decode';
 import AdminMenu from './AdminMenu';
 import './Dashboard.css';
@@ -28,30 +37,61 @@ function Dashboard() {
       <div className="tile-grid">
         {role === 'admin' && (
           <>
-            <Link to="/students" className="dashboard-tile">Student Profiles</Link>
-            <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
-            <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
-            <Link to="/admin/pending" className="dashboard-tile">Pending Registrations</Link>
-            <Link to="/admin/activity-log" className="dashboard-tile">Activity Log</Link>
-            <Link to="/admin/users" className="dashboard-tile">Manage Users</Link>
+            <Link to="/students" className="dashboard-tile">
+              <FaUsers className="tile-icon" />
+              <span>Student Profiles</span>
+            </Link>
+            <Link to="/metrics" className="dashboard-tile">
+              <FaChartLine className="tile-icon" />
+              <span>School Metrics</span>
+            </Link>
+            <Link to="/career-info" className="dashboard-tile">
+              <FaUserTie className="tile-icon" />
+              <span>Career Staff Information</span>
+            </Link>
+            <Link to="/admin/pending" className="dashboard-tile">
+              <FaCheckCircle className="tile-icon" />
+              <span>Pending Registrations</span>
+            </Link>
+            <Link to="/admin/activity-log" className="dashboard-tile">
+              <FaListUl className="tile-icon" />
+              <span>Activity Log</span>
+            </Link>
+            <Link to="/admin/users" className="dashboard-tile">
+              <FaUserCog className="tile-icon" />
+              <span>Manage Users</span>
+            </Link>
           </>
         )}
 
         {role === 'career' && (
           <>
-            <Link to="/students" className="dashboard-tile">Student Profiles</Link>
-            <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
-            <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
+            <Link to="/students" className="dashboard-tile">
+              <FaUsers className="tile-icon" />
+              <span>Student Profiles</span>
+            </Link>
+            <Link to="/metrics" className="dashboard-tile">
+              <FaChartLine className="tile-icon" />
+              <span>School Metrics</span>
+            </Link>
+            <Link to="/career-info" className="dashboard-tile">
+              <FaUserTie className="tile-icon" />
+              <span>Career Staff Information</span>
+            </Link>
           </>
         )}
 
         {role === 'applicant' && (
-          <Link to="/applicant/profile" className="dashboard-tile">Applicant Profile</Link>
+          <Link to="/applicant/profile" className="dashboard-tile">
+            <FaUserTie className="tile-icon" />
+            <span>Applicant Profile</span>
+          </Link>
         )}
 
         {role === 'admin' || role === 'recruiter' ? (
-          <Link to={role === 'admin' ? '/admin/jobs' : '/recruiter/jobs'}>
-            <div className="dashboard-tile">Job Matching</div>
+          <Link to={role === 'admin' ? '/admin/jobs' : '/recruiter/jobs'} className="dashboard-tile">
+            <FaBriefcase className="tile-icon" />
+            <span>Job Matching</span>
           </Link>
         ) : null}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,9 @@
 body {
   margin: 0;
   background: #032c4d;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- style dashboard tiles with icons and Montserrat font
- tweak dashboard color scheme
- load Montserrat font in index.html

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687065b33ed48333b8767664fa14a02e