### PR TITLE
Enhance expand toggles

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -191,10 +191,22 @@
 .expand-toggle {
   cursor: pointer;
   font-weight: bold;
-  font-size: 1.25rem;
-  padding-left: 4px;
-  padding-right: 4px;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 50%;
+  background-color: #007bff;
+  color: #fff;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.expand-toggle:hover,
+.expand-toggle:focus {
+  background-color: #0056b3;
 }
 .job-details-row {
   background-color: #f8f8f8;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -732,7 +732,8 @@ if (shouldRedirect) {
               <React.Fragment key={job.job_code}>
                 <tr>
                   <td>
-                    <span
+                    <button
+                      type="button"
                       className="expand-toggle"
                       onClick={(e) => {
                         e.stopPropagation();
@@ -747,7 +748,7 @@ if (shouldRedirect) {
                       }}
                     >
                       {expandedJob === job.job_code ? '–' : '+'}
-                    </span>
+                    </button>
                   </td>
                   <td>{job.job_code}</td>
                   <td

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -204,10 +204,22 @@
 .expand-toggle {
   cursor: pointer;
   font-weight: bold;
-  font-size: 1.25rem;
-  padding-left: 4px;
-  padding-right: 4px;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 50%;
+  background-color: #007bff;
+  color: #fff;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.expand-toggle:hover,
+.expand-toggle:focus {
+  background-color: #0056b3;
 }
 
 .column-filter {

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -566,13 +566,14 @@ function StudentProfiles() {
                       <React.Fragment key={s.email}>
                         <tr>
                           <td>
-                            <span
+                            <button
                               className="expand-toggle"
                               onClick={() => toggleRow(s.email, s.assigned_jobs)}
                               title={expandedRows[s.email] ? 'Collapse' : 'Expand'}
+                              type="button"
                             >
                               {expandedRows[s.email] ? '–' : '+'}
-                            </span>
+                            </button>
                           </td>
                           <td>{s.first_name}</td>
                           <td>{s.last_name}</td>


### PR DESCRIPTION
## Summary
- use `<button>` for expandable rows
- style expand buttons with circle background and hover color

## Testing
- `CI=true npm test --prefix frontend --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711d1fd6448333aebd5495b74d18a3