### PR TITLE
Allow admin creds from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ SMTP_PORT=587
 SMTP_USER=username
 SMTP_PASSWORD=secret
 EMAIL_SENDER=noreply@example.com
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=admin123
 ```
 
 ## Students Endpoint

--- a/app/main.py
+++ b/app/main.py
@@ -188,9 +188,13 @@ def school_codes():
 # ----- User Utilities ----- #
 
 def init_default_admin():
-    key = "user:admin@example.com"
+    """Seed the default admin user if it does not already exist."""
+    email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    password = os.getenv("ADMIN_PASSWORD", "admin123")
+    key = f"user:{email}"
+
     if not redis_client.exists(key):
-        hashed = bcrypt.hashpw("admin123".encode(), bcrypt.gensalt()).decode()
+        hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         redis_client.set(
             key,
             json.dumps(


### PR DESCRIPTION
## Summary
- make init_default_admin configurable via environment vars
- document ADMIN_EMAIL and ADMIN_PASSWORD in example .env

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b1d470308333a205b96dc2bf636d