### PR TITLE
Add marketing information panel to login page

### DIFF
--- a/frontend/src/AboutApplicants.js
+++ b/frontend/src/AboutApplicants.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutApplicants() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Applicants</h2>
+      <p><strong>Be Matched for Who You Are—Not Just a Resume</strong></p>
+      <p>
+        At TalentMatch AI, you're never reduced to a single page or just a list of skills.
+        Instead, you build a professional biography that lets you share your story—your education,
+        experience, goals, and what makes you unique. Our platform's AI sees the whole you,
+        so you're matched with jobs that fit not just your background, but your ambitions too.
+      </p>
+      <p><strong>Here's how it works:</strong></p>
+      <ul>
+        <li><strong>Holistic Profile:</strong> Our guided questions help you tell your story, not just your job history.</li>
+        <li><strong>AI Matching:</strong> When a new job is posted, our AI looks at your full biography and matches you to roles where you'll thrive.</li>
+        <li><strong>Custom Resumes, Instantly:</strong> For every opportunity you match with, our technology generates a custom resume—tailored to each job and ready to send (no more "one-size-fits-all" resumes).</li>
+        <li><strong>Personal Feedback:</strong> For every job match, you can download a job description that highlights your strengths and suggests areas where you could grow—so you always know how you fit and where you can improve.</li>
+      </ul>
+      <p>
+        No more selling yourself or endlessly searching. With TalentMatch AI, you're seen for your whole story—matched, supported, and empowered to grow.
+      </p>
+    </div>
+  );
+}
+
+export default AboutApplicants;

--- a/frontend/src/AboutCareerServices.js
+++ b/frontend/src/AboutCareerServices.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutCareerServices() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Career Services</h2>
+      <p><strong>Empower Student Success—With Data, Insight, and Real Opportunity</strong></p>
+      <p>
+        TalentMatch AI is designed for career services teams that want more than just job postings.
+        Our platform gives you the tools to support your students as whole people and deliver the outcomes your institution values most.
+      </p>
+      <p><strong>Here’s how it works:</strong></p>
+      <ul>
+        <li><strong>Holistic Student Profiles:</strong> Students build rich biographies that showcase their unique backgrounds, strengths, and goals—not just a list of jobs.</li>
+        <li><strong>AI-Driven Matching:</strong> As employers post new roles, our AI matches your students based on who they are and where they’re headed, ensuring better fit and better placement rates.</li>
+        <li><strong>Custom Resumes and Actionable Feedback:</strong> For every match, the platform generates tailored resumes and job match reports—highlighting each student’s strengths, plus areas for further growth.</li>
+        <li><strong>Instant Reporting:</strong> Monitor placement rates, match quality, and engagement in real time. Generate compliance and accreditation reports with just a click.</li>
+      </ul>
+      <p>
+        With TalentMatch AI, you help students get discovered for their full potential—while easily meeting your department’s reporting and success goals.
+      </p>
+    </div>
+  );
+}
+
+export default AboutCareerServices;

--- a/frontend/src/AboutPanel.css
+++ b/frontend/src/AboutPanel.css
@@ -1,0 +1,28 @@
+.about-panel {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 350px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 1rem;
+  border-radius: 8px;
+  color: #333;
+  font-size: 14px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.about-panel h2,
+.about-panel h3 {
+  color: #001f3f;
+  margin-top: 0.5rem;
+}
+
+.about-panel ul {
+  padding-left: 1.2rem;
+}
+
+.about-panel li {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/AboutPanel.js
+++ b/frontend/src/AboutPanel.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import './AboutPanel.css';
+
+function AboutPanel() {
+  return (
+    <div className="about-panel">
+      <h2>About TalentMatch AI</h2>
+      <p>
+        TalentMatch AI leverages machine learning to match healthcare students and professionals with employers. Our technology analyzes your entire profile to deliver smarter, faster, and fairer hiring results.
+      </p>
+
+      <section>
+        <h3>For Applicants</h3>
+        <p><strong>Be Matched for Who You Are—Not Just a Resume</strong></p>
+        <p>
+          At TalentMatch AI, you're never reduced to a single page or just a list of skills. Instead, you build a professional biography that lets you share your story—your education, experience, goals, and what makes you unique. Our platform's AI sees the whole you, so you're matched with jobs that fit not just your background, but your ambitions too.
+        </p>
+        <p><strong>Here's how it works:</strong></p>
+        <ul>
+          <li><strong>Holistic Profile:</strong> Our guided questions help you tell your story, not just your job history.</li>
+          <li><strong>AI Matching:</strong> When a new job is posted, our AI looks at your full biography and matches you to roles where you'll thrive.</li>
+          <li><strong>Custom Resumes, Instantly:</strong> For every opportunity you match with, our technology generates a custom resume—tailored to each job and ready to send.</li>
+          <li><strong>Personal Feedback:</strong> Download job descriptions highlighting your strengths and suggesting areas to grow.</li>
+        </ul>
+        <p>No more selling yourself or endlessly searching. With TalentMatch AI, you're seen for your whole story—matched, supported, and empowered to grow.</p>
+      </section>
+
+      <section>
+        <h3>For Recruiters</h3>
+        <p><strong>Find Talent That's More Than Just a Resume</strong></p>
+        <p>
+          TalentMatch AI goes beyond keywords and job boards. Our platform uses advanced AI to match you with healthcare candidates who are more than just lists of credentials—they're whole people with stories, potential, and real passion for the work.
+        </p>
+        <p><strong>Here's how it works:</strong></p>
+        <ul>
+          <li><strong>AI-Powered Matching:</strong> When you post a job, our AI reviews the entire pool of candidate biographies—not just their skills, but their interests, strengths, and aspirations.</li>
+          <li><strong>Custom Resumes for Every Match:</strong> For each strong match, TalentMatch AI generates a custom resume tailored to your role.</li>
+          <li><strong>See the Whole Candidate:</strong> Get a complete view including growth areas and strengths as analyzed by our platform.</li>
+          <li><strong>Job Insights at a Glance:</strong> Download clear job match reports showing where candidates excel and why they're a strong fit.</li>
+        </ul>
+        <p>Spend less time sifting through generic applications, and more time connecting with candidates who are truly ready to succeed in your roles. With TalentMatch AI, hiring is smarter, faster, and built for real results.</p>
+      </section>
+
+      <section>
+        <h3>For Career Services</h3>
+        <p><strong>Empower Student Success—With Data, Insight, and Real Opportunity</strong></p>
+        <p>
+          TalentMatch AI is designed for career services teams that want more than just job postings. Our platform gives you the tools to support your students as whole people and deliver the outcomes your institution values most.
+        </p>
+        <p><strong>Here's how it works:</strong></p>
+        <ul>
+          <li><strong>Holistic Student Profiles:</strong> Students build rich biographies that showcase their unique backgrounds, strengths, and goals.</li>
+          <li><strong>AI-Driven Matching:</strong> As employers post new roles, our AI matches your students based on who they are and where they're headed.</li>
+          <li><strong>Custom Resumes and Actionable Feedback:</strong> For every match, the platform generates tailored resumes and job match reports highlighting strengths and areas for growth.</li>
+          <li><strong>Instant Reporting:</strong> Monitor placement rates, match quality, and engagement in real time, and generate compliance reports with a click.</li>
+        </ul>
+        <p>With TalentMatch AI, you help students get discovered for their full potential—while easily meeting your department's reporting and success goals.</p>
+      </section>
+    </div>
+  );
+}
+
+export default AboutPanel;

--- a/frontend/src/AboutRecruiters.js
+++ b/frontend/src/AboutRecruiters.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutRecruiters() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Recruiters</h2>
+      <p><strong>Find Talent That’s More Than Just a Resume</strong></p>
+      <p>
+        TalentMatch AI goes beyond keywords and job boards. Our platform uses advanced AI to match you with healthcare candidates who are more than just lists of credentials—they’re whole people with stories, potential, and real passion for the work.
+      </p>
+      <p><strong>Here’s how it works:</strong></p>
+      <ul>
+        <li><strong>AI-Powered Matching:</strong> When you post a job, our AI instantly reviews the entire pool of candidate biographies—not just their skills, but their interests, strengths, and aspirations.</li>
+        <li><strong>Custom Resumes for Every Match:</strong> For each strong match, TalentMatch AI generates a custom resume tailored to your role, so you see exactly how each candidate’s background aligns with your needs.</li>
+        <li><strong>See the Whole Candidate:</strong> You don’t just get bullet points—you get a complete view, including a candidate’s growth areas and strengths, as analyzed by our platform.</li>
+        <li><strong>Job Insights at a Glance:</strong> Download clear job match reports for each candidate, showing where they excel, areas for development, and why they’re a strong fit.</li>
+      </ul>
+      <p>
+        Spend less time sifting through generic applications, and more time connecting with candidates who are truly ready to succeed in your roles.
+      </p>
+      <p>
+        With TalentMatch AI, hiring is smarter, faster, and built for real results.
+      </p>
+    </div>
+  );
+}
+
+export default AboutRecruiters;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,10 @@ import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
 import ActivityLog from './ActivityLog';
 import AdminUsers from './AdminUsers';
+import AboutApplicants from './AboutApplicants';
+import AboutRecruiters from './AboutRecruiters';
+import AboutCareerServices from './AboutCareerServices';
+import AboutPanel from './AboutPanel';
 
 function App() {
   return (
@@ -22,6 +26,10 @@ function App() {
           <Route path="/" element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/register" element={<RegisterForm />} />
+          <Route path="/about" element={<AboutPanel />} />
+          <Route path="/about/applicants" element={<AboutApplicants />} />
+          <Route path="/about/recruiters" element={<AboutRecruiters />} />
+          <Route path="/about/career-service" element={<AboutCareerServices />} />
           <Route
             path="/dashboard"
             element={

--- a/frontend/src/InfoPage.css
+++ b/frontend/src/InfoPage.css
@@ -1,0 +1,33 @@
+.info-container {
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.info-container h2 {
+  margin-top: 0;
+  font-size: 3rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+.info-container p {
+  max-width: 700px;
+  line-height: 1.6;
+  font-size: 1.5rem;
+  margin: 0 1rem;
+}
+
+.info-container strong {
+  color: #ffdc5e;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}

--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -4,6 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 }
 
 .login-form {

--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -4,7 +4,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
 }
 
 .login-form {

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
+import AboutPanel from './AboutPanel';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -56,6 +57,7 @@ function LoginForm() {
 
   return (
     <div className="login-container">
+      <AboutPanel />
       <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
 

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -3,6 +3,7 @@ import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 import AboutPanel from './AboutPanel';
+import TopMenu from './TopMenu';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -57,6 +58,7 @@ function LoginForm() {
 
   return (
     <div className="login-container">
+      <TopMenu />
       <AboutPanel />
       <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
-import AboutPanel from './AboutPanel';
 import TopMenu from './TopMenu';
 
 function LoginForm() {
@@ -59,7 +58,6 @@ function LoginForm() {
   return (
     <div className="login-container">
       <TopMenu />
-      <AboutPanel />
       <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
 

--- a/frontend/src/TopMenu.css
+++ b/frontend/src/TopMenu.css
@@ -1,0 +1,21 @@
+.top-menu {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: #003366;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  display: flex;
+  gap: 1rem;
+  z-index: 1000;
+}
+
+.top-menu a {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.top-menu a:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -5,6 +5,7 @@ import './TopMenu.css';
 function TopMenu() {
   return (
     <nav className="top-menu">
+      <Link to="/login">Home</Link>
       <Link to="/about">About TalentMatch-AI</Link>
       <Link to="/about/applicants">Applicants</Link>
       <Link to="/about/career-service">Career Service</Link>

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './TopMenu.css';
+
+function TopMenu() {
+  return (
+    <nav className="top-menu">
+      <Link to="/about">About TalentMatch-AI</Link>
+      <Link to="/about/applicants">Applicants</Link>
+      <Link to="/about/career-service">Career Service</Link>
+      <Link to="/about/recruiters">Recruiters</Link>
+    </nav>
+  );
+}
+
+export default TopMenu;


### PR DESCRIPTION
## Summary
- add `AboutPanel` component with marketing copy for applicants, recruiters and career service staff
- style the about panel and position it in the top-right of the login screen
- insert the panel into `LoginForm` and adjust layout

## Testing
- `pytest -q`
- `npm test --silent -- -u`


------
https://chatgpt.com/codex/tasks/task_e_6871be36a98c8333a31c5e0ac5494770