### PR TITLE
Remove about panel from login page

### DIFF
--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -4,7 +4,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
 }
 
 .login-form {

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
-import AboutPanel from './AboutPanel';
 import TopMenu from './TopMenu';
 
 function LoginForm() {
@@ -59,7 +58,6 @@ function LoginForm() {
   return (
     <div className="login-container">
       <TopMenu />
-      <AboutPanel />
       <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
 


### PR DESCRIPTION
## Summary
- simplify login UI by removing the AboutPanel component
- clean up layout CSS to drop unused relative positioning

## Testing
- `npm test --silent -- --watchAll=false`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ee94138883339ca1466c5e1f4af3