### PR TITLE
Add informational pages

### DIFF
--- a/frontend/src/AboutApplicants.js
+++ b/frontend/src/AboutApplicants.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutApplicants() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Applicants</h2>
+      <p><strong>Be Matched for Who You Are—Not Just a Resume</strong></p>
+      <p>
+        At TalentMatch AI, you're never reduced to a single page or just a list of skills.
+        Instead, you build a professional biography that lets you share your story—your education,
+        experience, goals, and what makes you unique. Our platform's AI sees the whole you,
+        so you're matched with jobs that fit not just your background, but your ambitions too.
+      </p>
+      <p><strong>Here's how it works:</strong></p>
+      <ul>
+        <li><strong>Holistic Profile:</strong> Our guided questions help you tell your story, not just your job history.</li>
+        <li><strong>AI Matching:</strong> When a new job is posted, our AI looks at your full biography and matches you to roles where you'll thrive.</li>
+        <li><strong>Custom Resumes, Instantly:</strong> For every opportunity you match with, our technology generates a custom resume—tailored to each job and ready to send (no more "one-size-fits-all" resumes).</li>
+        <li><strong>Personal Feedback:</strong> For every job match, you can download a job description that highlights your strengths and suggests areas where you could grow—so you always know how you fit and where you can improve.</li>
+      </ul>
+      <p>
+        No more selling yourself or endlessly searching. With TalentMatch AI, you're seen for your whole story—matched, supported, and empowered to grow.
+      </p>
+    </div>
+  );
+}
+
+export default AboutApplicants;

--- a/frontend/src/AboutCareerServices.js
+++ b/frontend/src/AboutCareerServices.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutCareerServices() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Career Services</h2>
+      <p><strong>Empower Student Success—With Data, Insight, and Real Opportunity</strong></p>
+      <p>
+        TalentMatch AI is designed for career services teams that want more than just job postings.
+        Our platform gives you the tools to support your students as whole people and deliver the outcomes your institution values most.
+      </p>
+      <p><strong>Here’s how it works:</strong></p>
+      <ul>
+        <li><strong>Holistic Student Profiles:</strong> Students build rich biographies that showcase their unique backgrounds, strengths, and goals—not just a list of jobs.</li>
+        <li><strong>AI-Driven Matching:</strong> As employers post new roles, our AI matches your students based on who they are and where they’re headed, ensuring better fit and better placement rates.</li>
+        <li><strong>Custom Resumes and Actionable Feedback:</strong> For every match, the platform generates tailored resumes and job match reports—highlighting each student’s strengths, plus areas for further growth.</li>
+        <li><strong>Instant Reporting:</strong> Monitor placement rates, match quality, and engagement in real time. Generate compliance and accreditation reports with just a click.</li>
+      </ul>
+      <p>
+        With TalentMatch AI, you help students get discovered for their full potential—while easily meeting your department’s reporting and success goals.
+      </p>
+    </div>
+  );
+}
+
+export default AboutCareerServices;

--- a/frontend/src/AboutRecruiters.js
+++ b/frontend/src/AboutRecruiters.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TopMenu from './TopMenu';
+import './InfoPage.css';
+
+function AboutRecruiters() {
+  return (
+    <div className="info-container">
+      <TopMenu />
+      <h2>For Recruiters</h2>
+      <p><strong>Find Talent That’s More Than Just a Resume</strong></p>
+      <p>
+        TalentMatch AI goes beyond keywords and job boards. Our platform uses advanced AI to match you with healthcare candidates who are more than just lists of credentials—they’re whole people with stories, potential, and real passion for the work.
+      </p>
+      <p><strong>Here’s how it works:</strong></p>
+      <ul>
+        <li><strong>AI-Powered Matching:</strong> When you post a job, our AI instantly reviews the entire pool of candidate biographies—not just their skills, but their interests, strengths, and aspirations.</li>
+        <li><strong>Custom Resumes for Every Match:</strong> For each strong match, TalentMatch AI generates a custom resume tailored to your role, so you see exactly how each candidate’s background aligns with your needs.</li>
+        <li><strong>See the Whole Candidate:</strong> You don’t just get bullet points—you get a complete view, including a candidate’s growth areas and strengths, as analyzed by our platform.</li>
+        <li><strong>Job Insights at a Glance:</strong> Download clear job match reports for each candidate, showing where they excel, areas for development, and why they’re a strong fit.</li>
+      </ul>
+      <p>
+        Spend less time sifting through generic applications, and more time connecting with candidates who are truly ready to succeed in your roles.
+      </p>
+      <p>
+        With TalentMatch AI, hiring is smarter, faster, and built for real results.
+      </p>
+    </div>
+  );
+}
+
+export default AboutRecruiters;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,10 @@ import Metrics from './Metrics';
 import CareerStaffInfo from './CareerStaffInfo';
 import ActivityLog from './ActivityLog';
 import AdminUsers from './AdminUsers';
+import AboutApplicants from './AboutApplicants';
+import AboutRecruiters from './AboutRecruiters';
+import AboutCareerServices from './AboutCareerServices';
+import AboutPanel from './AboutPanel';
 
 function App() {
   return (
@@ -22,6 +26,10 @@ function App() {
           <Route path="/" element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/register" element={<RegisterForm />} />
+          <Route path="/about" element={<AboutPanel />} />
+          <Route path="/about/applicants" element={<AboutApplicants />} />
+          <Route path="/about/recruiters" element={<AboutRecruiters />} />
+          <Route path="/about/career-service" element={<AboutCareerServices />} />
           <Route
             path="/dashboard"
             element={

--- a/frontend/src/InfoPage.css
+++ b/frontend/src/InfoPage.css
@@ -1,0 +1,33 @@
+.info-container {
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  min-height: 100vh;
+  color: white;
+  padding: 2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.info-container h2 {
+  margin-top: 0;
+  font-size: 3rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+.info-container p {
+  max-width: 700px;
+  line-height: 1.6;
+  font-size: 1.5rem;
+  margin: 0 1rem;
+}
+
+.info-container strong {
+  color: #ffdc5e;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -5,6 +5,7 @@ import './TopMenu.css';
 function TopMenu() {
   return (
     <nav className="top-menu">
+      <Link to="/login">Home</Link>
       <Link to="/about">About TalentMatch-AI</Link>
       <Link to="/about/applicants">Applicants</Link>
       <Link to="/about/career-service">Career Service</Link>


### PR DESCRIPTION
## Summary
- create About pages for applicants, recruiters, and career services
- add shared InfoPage styling
- link new pages in the app router and navigation menu

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f25db7a88333af2225af09762ee6