### PR TITLE
Toned down about pages

### DIFF
--- a/frontend/src/InfoPage.css
+++ b/frontend/src/InfoPage.css
@@ -3,31 +3,30 @@
   min-height: 100vh;
   color: white;
   padding: 2rem;
-  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 1.5rem;
-  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+  justify-content: flex-start;
+  text-align: left;
+  gap: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .info-container h2 {
   margin-top: 0;
-  font-size: 3rem;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  font-size: 2rem;
+  font-weight: 600;
 }
 
 .info-container p {
   max-width: 700px;
   line-height: 1.6;
-  font-size: 1.5rem;
-  margin: 0 1rem;
+  font-size: 1rem;
+  margin: 0.5rem 0;
 }
 
 .info-container strong {
   color: #ffdc5e;
-  font-weight: 700;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- simplify InfoPage styling so about pages are less like sales posters

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871f790a7f08333aed3ba1de758ec8e