### PR TITLE
Remove bullet lists from about pages

### DIFF
--- a/frontend/src/AboutApplicants.js
+++ b/frontend/src/AboutApplicants.js
@@ -15,12 +15,10 @@ function AboutApplicants() {
         so you're matched with jobs that fit not just your background, but your ambitions too.
       </p>
       <p><strong>Here's how it works:</strong></p>
-      <ul>
-        <li><strong>Holistic Profile:</strong> Our guided questions help you tell your story, not just your job history.</li>
-        <li><strong>AI Matching:</strong> When a new job is posted, our AI looks at your full biography and matches you to roles where you'll thrive.</li>
-        <li><strong>Custom Resumes, Instantly:</strong> For every opportunity you match with, our technology generates a custom resume—tailored to each job and ready to send (no more "one-size-fits-all" resumes).</li>
-        <li><strong>Personal Feedback:</strong> For every job match, you can download a job description that highlights your strengths and suggests areas where you could grow—so you always know how you fit and where you can improve.</li>
-      </ul>
+      <p><strong>Holistic Profile:</strong> Our guided questions help you tell your story, not just your job history.</p>
+      <p><strong>AI Matching:</strong> When a new job is posted, our AI looks at your full biography and matches you to roles where you'll thrive.</p>
+      <p><strong>Custom Resumes, Instantly:</strong> For every opportunity you match with, our technology generates a custom resume—tailored to each job and ready to send (no more "one-size-fits-all" resumes).</p>
+      <p><strong>Personal Feedback:</strong> For every job match, you can download a job description that highlights your strengths and suggests areas where you could grow—so you always know how you fit and where you can improve.</p>
       <p>
         No more selling yourself or endlessly searching. With TalentMatch AI, you're seen for your whole story—matched, supported, and empowered to grow.
       </p>

--- a/frontend/src/AboutCareerServices.js
+++ b/frontend/src/AboutCareerServices.js
@@ -13,12 +13,10 @@ function AboutCareerServices() {
         Our platform gives you the tools to support your students as whole people and deliver the outcomes your institution values most.
       </p>
       <p><strong>Here’s how it works:</strong></p>
-      <ul>
-        <li><strong>Holistic Student Profiles:</strong> Students build rich biographies that showcase their unique backgrounds, strengths, and goals—not just a list of jobs.</li>
-        <li><strong>AI-Driven Matching:</strong> As employers post new roles, our AI matches your students based on who they are and where they’re headed, ensuring better fit and better placement rates.</li>
-        <li><strong>Custom Resumes and Actionable Feedback:</strong> For every match, the platform generates tailored resumes and job match reports—highlighting each student’s strengths, plus areas for further growth.</li>
-        <li><strong>Instant Reporting:</strong> Monitor placement rates, match quality, and engagement in real time. Generate compliance and accreditation reports with just a click.</li>
-      </ul>
+      <p><strong>Holistic Student Profiles:</strong> Students build rich biographies that showcase their unique backgrounds, strengths, and goals—not just a list of jobs.</p>
+      <p><strong>AI-Driven Matching:</strong> As employers post new roles, our AI matches your students based on who they are and where they’re headed, ensuring better fit and better placement rates.</p>
+      <p><strong>Custom Resumes and Actionable Feedback:</strong> For every match, the platform generates tailored resumes and job match reports—highlighting each student’s strengths, plus areas for further growth.</p>
+      <p><strong>Instant Reporting:</strong> Monitor placement rates, match quality, and engagement in real time. Generate compliance and accreditation reports with just a click.</p>
       <p>
         With TalentMatch AI, you help students get discovered for their full potential—while easily meeting your department’s reporting and success goals.
       </p>

--- a/frontend/src/AboutPanel.js
+++ b/frontend/src/AboutPanel.js
@@ -10,23 +10,11 @@ function AboutPanel() {
       <p>
         TalentMatch-AI is a next-generation recruiting platform built for healthcare education. Our platform leverages cutting-edge artificial intelligence to transform how students, schools, and employers connect:
       </p>
-      <ul>
-        <li>
-          <strong>Intelligent Job Matching:</strong> Our advanced AI looks far beyond keywords, considering each applicant’s education, skills, experience, goals, and location—so every match is relevant and meaningful.
-        </li>
-        <li>
-          <strong>Custom Resume Creation:</strong> For every opportunity, our system automatically generates a personalized resume that showcases each candidate’s strengths for that specific role, ensuring applicants stand out.
-        </li>
-        <li>
-          <strong>AI-Generated Job Descriptions & Guidance:</strong> We break down every job posting for applicants—clearly highlighting strengths, potential fit, and personalized suggestions for areas of improvement.
-        </li>
-        <li>
-          <strong>Career Services Tracking & Reporting:</strong> Schools and career services staff get real-time placement metrics, detailed match tracking, and automated reports for accreditation and funding compliance—all in one place.
-        </li>
-        <li>
-          <strong>Geographic Filtering:</strong> TalentMatch-AI matches candidates to positions not just by skills and interests, but also by geographic preferences—helping employers find local talent and applicants discover nearby opportunities.
-        </li>
-      </ul>
+      <p><strong>Intelligent Job Matching:</strong> Our advanced AI looks far beyond keywords, considering each applicant’s education, skills, experience, goals, and location—so every match is relevant and meaningful.</p>
+      <p><strong>Custom Resume Creation:</strong> For every opportunity, our system automatically generates a personalized resume that showcases each candidate’s strengths for that specific role, ensuring applicants stand out.</p>
+      <p><strong>AI-Generated Job Descriptions & Guidance:</strong> We break down every job posting for applicants—clearly highlighting strengths, potential fit, and personalized suggestions for areas of improvement.</p>
+      <p><strong>Career Services Tracking & Reporting:</strong> Schools and career services staff get real-time placement metrics, detailed match tracking, and automated reports for accreditation and funding compliance—all in one place.</p>
+      <p><strong>Geographic Filtering:</strong> TalentMatch-AI matches candidates to positions not just by skills and interests, but also by geographic preferences—helping employers find local talent and applicants discover nearby opportunities.</p>
       <p>
         Our mission: Deliver intelligence with every placement—making healthcare hiring smarter, more personal, and built for real student and employer success.
       </p>

--- a/frontend/src/AboutRecruiters.js
+++ b/frontend/src/AboutRecruiters.js
@@ -12,12 +12,10 @@ function AboutRecruiters() {
         TalentMatch AI goes beyond keywords and job boards. Our platform uses advanced AI to match you with healthcare candidates who are more than just lists of credentials—they’re whole people with stories, potential, and real passion for the work.
       </p>
       <p><strong>Here’s how it works:</strong></p>
-      <ul>
-        <li><strong>AI-Powered Matching:</strong> When you post a job, our AI instantly reviews the entire pool of candidate biographies—not just their skills, but their interests, strengths, and aspirations.</li>
-        <li><strong>Custom Resumes for Every Match:</strong> For each strong match, TalentMatch AI generates a custom resume tailored to your role, so you see exactly how each candidate’s background aligns with your needs.</li>
-        <li><strong>See the Whole Candidate:</strong> You don’t just get bullet points—you get a complete view, including a candidate’s growth areas and strengths, as analyzed by our platform.</li>
-        <li><strong>Job Insights at a Glance:</strong> Download clear job match reports for each candidate, showing where they excel, areas for development, and why they’re a strong fit.</li>
-      </ul>
+      <p><strong>AI-Powered Matching:</strong> When you post a job, our AI instantly reviews the entire pool of candidate biographies—not just their skills, but their interests, strengths, and aspirations.</p>
+      <p><strong>Custom Resumes for Every Match:</strong> For each strong match, TalentMatch AI generates a custom resume tailored to your role, so you see exactly how each candidate’s background aligns with your needs.</p>
+      <p><strong>See the Whole Candidate:</strong> You don’t just get bullet points—you get a complete view, including a candidate’s growth areas and strengths, as analyzed by our platform.</p>
+      <p><strong>Job Insights at a Glance:</strong> Download clear job match reports for each candidate, showing where they excel, areas for development, and why they’re a strong fit.</p>
       <p>
         Spend less time sifting through generic applications, and more time connecting with candidates who are truly ready to succeed in your roles.
       </p>


### PR DESCRIPTION
## Summary
- remove `<ul>` bullet lists from About/Applicants/CareerServices/Recruiters pages
- keep same formatting by converting list items to `<p>` elements

## Testing
- `CI=true npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728c09dc008333b47a1cfeab5fbe5c