### PR TITLE
Improve nursing news layout

### DIFF
--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -272,7 +272,7 @@ function ApplicantProfile() {
           </div>
         )}
         {activeTab === 'news' && (
-          <div className="form-panel">
+          <div className="form-panel news-panel">
             <h2>Nursing News</h2>
             <NursingNews />
           </div>

--- a/frontend/src/NursingNews.js
+++ b/frontend/src/NursingNews.js
@@ -30,9 +30,11 @@ function NursingNews() {
           <div className="news-grid">
             {feed.articles && feed.articles.map((a, idx) => (
               <div key={idx} className="news-card">
-                {a.image && (
-                  <img src={a.image} alt="" className="news-image" />
-                )}
+              <img
+                src={a.image || 'https://via.placeholder.com/400x200?text=No+Image'}
+                alt=""
+                className="news-image"
+              />
                 <a
                   href={a.link}
                   target="_blank"

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -29,6 +29,12 @@
   box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
 }
 
+/* Wider layout for the Nursing News tab */
+.news-panel {
+  max-width: 1000px;
+  width: 100%;
+}
+
 .form-section {
   background-color: #003366;
   padding: 1rem 2rem;


### PR DESCRIPTION
## Summary
- widen nursing news tab content
- show placeholder images when articles lack one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ca1fc0808333a68f645f9e935dab