### PR TITLE
Support role selection during registration

### DIFF
--- a/frontend/src/RegisterForm.css
+++ b/frontend/src/RegisterForm.css
@@ -24,6 +24,14 @@
   color: black;
 }
 
+.register-form select {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: none;
+  color: black;
+}
+
 .register-form button {
   background-color: #0074d9;
   color: white;

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -9,6 +9,7 @@ function RegisterForm() {
     firstName: '',
     lastName: '',
     password: '',
+    role: 'applicant',
   });
   const [institutionalCode, setInstitutionalCode] = useState('');
   const [message, setMessage] = useState('');
@@ -27,8 +28,9 @@ function RegisterForm() {
       !formData.email.trim() ||
       !formData.firstName.trim() ||
       !formData.lastName.trim() ||
-      !institutionalCode.trim() ||
-      !formData.password
+      !formData.password ||
+      ((formData.role === 'career' || formData.role === 'recruiter') &&
+        !institutionalCode.trim())
     ) {
       setError('All fields are required');
       return;
@@ -40,7 +42,8 @@ function RegisterForm() {
         first_name: formData.firstName,
         last_name: formData.lastName,
         password: formData.password,
-        institutional_code: institutionalCode,
+        institutional_code: institutionalCode || undefined,
+        role: formData.role,
       });
       setMessage('Registration submitted. Awaiting admin approval.');
       setTimeout(() => navigate('/login'), 3000);
@@ -82,6 +85,12 @@ function RegisterForm() {
           value={formData.lastName}
           onChange={handleChange}
         />
+        <label htmlFor="role">Role</label>
+        <select id="role" name="role" value={formData.role} onChange={handleChange}>
+          <option value="applicant">Applicant</option>
+          <option value="career">Career</option>
+          <option value="recruiter">Recruiter</option>
+        </select>
         <label htmlFor="institutional_code">Institutional Code</label>
         <input
           id="institutional_code"


### PR DESCRIPTION
## Summary
- let registrants choose a role in the UI
- persist chosen role in backend
- make institutional code optional except for career staff/recruiters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b815e1dc8333805b65f23ce27eeb