### PR TITLE
Add resume HTML generation and viewing

### DIFF
--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -1,13 +1,13 @@
 def generate_resume_text(client, student: dict, job: dict) -> str:
-    """Create a tailored job summary using OpenAI"""
+    """Create an HTML resume tailored to the student and job."""
     instructions = f"""
-You are a career advisor assistant. Create a personalized job summary for a student who has been assigned a job opportunity. Your task is to:
+You are generating a professional resume in HTML format. Use the information
+provided to craft a short resume with these sections:
 
-1. Summarize what the assigned job entails in plain, student-friendly language.
-2. Explain why the student may be a good fit based on their background, skills, and interests.
-3. Gently mention areas the student might need to work on or prepare for before starting.
-
-Respond with professional, friendly language. Do not format as a resume. Write clearly in paragraph form using plain language. Your audience is the student and their career advisor.
+1. **Name and Contact Information** - include email and phone.
+2. **Skills** - highlight relevant skills from the student profile.
+3. **Experience Summary / Job History** - summarise the student's background
+   and how it relates to the assigned job.
 
 Student Profile:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
@@ -23,7 +23,7 @@ Title: {job.get('job_title')}
 Description: {job.get('job_description')}
 Desired Skills: {', '.join(job.get('desired_skills', []))}
 
-Begin with a short 1–2 sentence job summary, followed by a paragraph explaining the student’s fit, and end with a short paragraph highlighting potential preparation tips.
+Return only valid HTML.
 """
 
     resp = client.chat.completions.create(

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Navigate } from 'react-router-dom';
 import jwtDecode from 'jwt-decode';
-import jsPDF from 'jspdf';
 import api from './api';
 import AdminMenu from './AdminMenu';
 import loadGoogleMaps from './utils/loadGoogleMaps';
@@ -374,33 +373,19 @@ if (shouldRedirect) {
     }
   };
 
-  const downloadResume = async (studentEmail, jobCode) => {
+  const viewResume = async (studentEmail, jobCode) => {
     try {
-      const resp = await api.get(`/resume/${jobCode}/${studentEmail}`, {
-        headers: { Authorization: `Bearer ${token}` }
+      const resp = await api.get(`/resume-html/${jobCode}/${studentEmail}`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
-
-      const resumeText = resp.data.resume;
-      const doc = new jsPDF();
-
-      // Add header
-      doc.setFontSize(16);
-      doc.text('TalenMatch AI Resume', 15, 20);
-
-      // Add watermark footer
-      doc.setFontSize(10);
-      doc.text('Tailored by TalenMatch AI', 15, 285);
-
-      // Resume body
-      doc.setFontSize(12);
-      const lines = doc.splitTextToSize(resumeText, 180);
-      doc.text(lines, 15, 40);
-
-      // Save as PDF
-      doc.save(`resume-${studentEmail}-${jobCode}.pdf`);
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write(resp.data);
+        newWindow.document.close();
+      }
     } catch (err) {
-      console.error('Resume download failed', err);
-      alert('Unable to download resume');
+      console.error('Resume load failed', err);
+      alert('Unable to load resume');
     }
   };
 
@@ -513,7 +498,7 @@ if (shouldRedirect) {
                 {generatingResumes[`${job.job_code}:${row.email}`] ? (
                   <span className="spinner">⏳</span>
                 ) : generatedResumes[`${job.job_code}:${row.email}`] ? (
-                  <button className="resume-icon-button" onClick={() => downloadResume(row.email, job.job_code)}>
+                  <button className="resume-icon-button" onClick={() => viewResume(row.email, job.job_code)}>
                     📥
                   </button>
                 ) : (


### PR DESCRIPTION
## Summary
- create full resume prompts returning HTML
- clean and store generated resume as HTML
- expose `/resume-html` endpoint
- open resumes in new window from JobPosting page
- test resume HTML generation and route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771ae2ca748333ad5303a6d3f359af