### PR TITLE
Handle AI HTML pages in resume generation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1243,6 +1243,16 @@ def generate_resume(req: ResumeRequest, current_user: dict = Depends(get_current
     if raw_html.endswith("```"):
         raw_html = raw_html.rsplit("```", 1)[0].strip()
 
+    lower_html = raw_html.lower()
+    if "<!doctype" in lower_html or "<html" in lower_html:
+        body_match = re.search(r"<body[^>]*>(.*?)</body>", raw_html, re.IGNORECASE | re.DOTALL)
+        if body_match:
+            raw_html = body_match.group(1).strip()
+        else:
+            html_match = re.search(r"<html[^>]*>(.*?)</html>", raw_html, re.IGNORECASE | re.DOTALL)
+            if html_match:
+                raw_html = html_match.group(1).strip()
+
     full_html = f"""
 <!DOCTYPE html>
 <html lang=\"en\">

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -711,6 +711,53 @@ def test_generate_resume_html(monkeypatch):
     assert "resume" in html_resp.text.lower()
 
 
+def test_generate_resume_full_html(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    main_app.redis_client.set(
+        "student:stud@example.com",
+        json.dumps({"first_name": "Stud", "last_name": "S", "skills": ["python"]})
+    )
+    main_app.redis_client.set(
+        "job:coder",
+        json.dumps({"job_code": "coder", "job_title": "Dev", "job_description": "desc", "desired_skills": ["python"]})
+    )
+
+    html_page = (
+        "<!DOCTYPE html>"
+        "<html><head><title>Title</title></head>"
+        "<body><div>resume</div></body></html>"
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": html_page})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/generate-resume",
+        json={"student_email": "stud@example.com", "job_code": "coder"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    html_resp = client.get(
+        "/resume-html/coder/stud@example.com",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert html_resp.status_code == 200
+    assert html_resp.text.lower().count("<html") == 1
+    assert "resume" in html_resp.text.lower()
+
+
 def test_resume_html_route():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- strip outer HTML when OpenAI returns a full HTML page
- test that full HTML responses do not produce nested tags

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877248e49388333a3ba1d19d86190a4