### PR TITLE
Enhance resume generation format

### DIFF
--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -2,12 +2,17 @@ def generate_resume_text(client, student: dict, job: dict) -> str:
     """Create an HTML resume tailored to the student and job."""
     instructions = f"""
 You are generating a professional resume in HTML format. Use the information
-provided to craft a short resume with these sections:
+provided to craft a concise resume. Structure the document with <h2> section
+headers and <ul> bullet lists. Include these sections:
 
 1. **Name and Contact Information** - include email and phone.
-2. **Skills** - highlight relevant skills from the student profile.
-3. **Experience Summary / Job History** - summarise the student's background
-   and how it relates to the assigned job.
+2. **Professional Summary** - a short introduction of the candidate.
+3. **Skills** - present as a bullet list.
+4. **Experience** - bullet points for each relevant job or role.
+5. **Education** - mention the education level.
+
+Return only valid HTML using <h2> and <ul> elements. Do not include outer
+<html> or <body> tags.
 
 Student Profile:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
@@ -22,8 +27,6 @@ Assigned Job:
 Title: {job.get('job_title')}
 Description: {job.get('job_description')}
 Desired Skills: {', '.join(job.get('desired_skills', []))}
-
-Return only valid HTML.
 """
 
     resp = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- improve HTML resume prompt to include new sections and bullet lists
- adjust resume generation tests for new sample output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687727da397c833398164ab2d9ebd881