### PR TITLE
Add custom user-agent for RSS fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,6 @@ remove a user from the system.
 ## Nursing News
 
 The `/nursing-news` endpoint retrieves articles from several nursing-focused RSS
-feeds. Results are cached for one hour to improve performance.
+feeds. Results are cached for one hour to improve performance. RSS requests use
+a browser-like `User-Agent` header to avoid being blocked by some feed
+providers.

--- a/app/main.py
+++ b/app/main.py
@@ -1780,6 +1780,8 @@ def all_rss_feeds() -> dict[str, str]:
 
 NURSING_NEWS_CACHE_KEY = "cache:nursing_news"
 NURSING_NEWS_TTL = 3600  # seconds
+# Use a browser-like User-Agent when fetching RSS feeds to avoid blocking
+RSS_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
 
 @app.get("/nursing-news")
@@ -1796,7 +1798,7 @@ async def nursing_news(force_refresh: bool = False):
 
     feeds = all_rss_feeds()
 
-    async with httpx.AsyncClient(timeout=10) as client:
+    async with httpx.AsyncClient(timeout=10, headers=RSS_HEADERS) as client:
         tasks = [client.get(url) for url in feeds.values()]
         responses = await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1172,7 +1172,11 @@ def test_nursing_news_cache(monkeypatch):
             calls.append(url)
             return DummyResp()
 
-    monkeypatch.setattr(main_app.httpx, "AsyncClient", lambda timeout=10: DummyClient())
+    monkeypatch.setattr(
+        main_app.httpx,
+        "AsyncClient",
+        lambda timeout=10, headers=None: DummyClient(),
+    )
 
     resp1 = client.get("/nursing-news")
     assert resp1.status_code == 200


### PR DESCRIPTION
## Summary
- send `User-Agent: Mozilla/5.0` when fetching nursing RSS feeds
- update README to mention custom header
- adjust tests for new httpx call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687874ce375c8333b4f978b71f1583e1