### PR TITLE
Add rematch workflow and preview resume support

### DIFF
--- a/backend/app/schemas/resume.py
+++ b/backend/app/schemas/resume.py
@@ -3,3 +3,4 @@ from pydantic import BaseModel
 class ResumeRequest(BaseModel):
     student_email: str
     job_code: str
+    preview: bool | None = False

--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -1,11 +1,23 @@
-def generate_resume_text(client, student: dict, job: dict) -> str:
+def generate_resume_text(client, student: dict, job: dict, include_contact: bool = True) -> str:
     """Create an HTML resume tailored to the student and job."""
+
+    contact_note = (
+        "- include email and phone." if include_contact else "- omit contact details."
+    )
+
+    contact_lines = ""
+    if include_contact:
+        contact_lines = (
+            f"Email: {student.get('email', '')}\n"
+            f"Phone: {student.get('phone', '')}\n"
+        )
+
     instructions = f"""
 You are generating a professional resume in HTML format. Use the information
 provided to craft a concise resume. Structure the document with <h2> section
 headers and <ul> bullet lists. Include these sections:
 
-1. **Name and Contact Information** - include email and phone.
+1. **Name and Contact Information** {contact_note}
 2. **Professional Summary** - a short introduction of the candidate.
 3. **Skills** - present as a bullet list.
 4. **Experience** - bullet points for each relevant job or role.
@@ -16,9 +28,7 @@ Return only valid HTML using <h2> and <ul> elements. Do not include outer
 
 Student Profile:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
-Email: {student.get('email', '')}
-Phone: {student.get('phone', '')}
-Education Level: {student.get('education_level', '')}
+{contact_lines}Education Level: {student.get('education_level', '')}
 Skills: {', '.join(student.get('skills', []))}
 Experience Summary: {student.get('experience_summary', '')}
 Interests: {student.get('interests', '')}


### PR DESCRIPTION
## Summary
- let resume generation omit contact info when previewing
- remove automatic emails from `/match`
- add `/rematches/{job_code}` endpoint and interest notification endpoint
- allow recruiters to preview resumes, rematch jobs, and mark candidates as interested in the UI
- track rematch metric
- add tests for new preview and rematch behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687870ecb7748333b783c0b7ef870d2e