### PR TITLE
Add description email on interest

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -671,6 +671,54 @@ def test_job_description_html_route():
     assert "html" in resp.text.lower()
 
 
+def test_notify_interest_generates_description(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    main_app.redis_client.set(
+        "student:stud@example.com",
+        json.dumps({"first_name": "Stud", "last_name": "S", "skills": ["python"]})
+    )
+    main_app.redis_client.set(
+        "job:codei",
+        json.dumps({
+            "job_code": "codei",
+            "job_title": "Dev",
+            "job_description": "desc",
+            "desired_skills": ["python"],
+            "assigned_students": ["stud@example.com"],
+        })
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "done"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    sent = {}
+
+    def fake_send(recipient, subject, body):
+        sent['body'] = body
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(main_app, "send_email", fake_send)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/notify-interest",
+        json={"student_email": "stud@example.com", "job_code": "codei"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    stored = main_app.redis_client.get("job_description:codei:stud@example.com")
+    assert stored is not None and "done" in stored
+    assert main_app.redis_client.get("jobdesc:codei:stud@example.com") == stored
+    assert sent.get("body") == stored
+
+
 def test_generate_resume_html(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- generate job description HTML in a helper function
- send generated description via `/notify-interest` and store it
- test notification generates and persists description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa4a43cb48333b17c8bee96585936