### PR TITLE
Rename interest action to Notify Candidate

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -558,7 +558,7 @@ if (shouldRedirect) {
               <td>
                 <span className="badge assigned inline">Assigned</span>
                 {isRecruiter && (
-                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Interested</button>
+                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
                 )}
                 {!isRecruiter && (
                   <button onClick={() => handlePlace(job, row)}>Place</button>


### PR DESCRIPTION
## Summary
- update JobPosting button text to say Notify Candidate when emailing a student

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaf5697c0833399cfa302f951fbaa