### PR TITLE
Change label to 'Notify Candidate'

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -572,7 +572,7 @@ if (shouldRedirect) {
               <td>
                 <span className="badge assigned inline">Assigned</span>
                 {isRecruiter && (
-                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Interested</button>
+                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
                 )}
                 {!isRecruiter && (
                   <button onClick={() => handlePlace(job, row)}>Place</button>


### PR DESCRIPTION
## Summary
- clarify recruiter email action label in job posting page

## Testing
- `pytest -q`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ab1511b408333b76624e36007521b