### PR TITLE
Add admin email test feature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ import redis
 import asyncio
 import re
 from html import unescape
+import random
 from backend.app.schemas.resume import ResumeRequest
 from backend.app.schemas.description import DescriptionRequest
 from backend.app.services.resume import generate_resume_text
@@ -1907,6 +1908,33 @@ def check_admin():
     if not raw:
         return {"exists": False}
     return json.loads(raw)
+
+
+@app.post("/admin/test-notification")
+def admin_test_notification(current_user: dict = Depends(get_current_user)):
+    """Send a sample candidate notification to the admin's email."""
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    admin_email = current_user.get("sub")
+    job_title = random.choice(
+        [
+            "Registered Nurse",
+            "Clinical Manager",
+            "Nursing Assistant",
+            "Care Coordinator",
+            "Health Specialist",
+        ]
+    )
+    send_email(
+        admin_email,
+        f"Recruiter Interest: {job_title}",
+        (
+            f"Hello,\n\nA recruiter has expressed interest in you for the job '{job_title}'. "
+            "They may contact you soon."
+        ),
+    )
+    return {"message": "Test email sent"}
 
 
 @app.get("/activity-log")

--- a/frontend/src/AdminUsers.js
+++ b/frontend/src/AdminUsers.js
@@ -182,6 +182,19 @@ function AdminUsers() {
     }
   };
 
+  const handleSendTest = async () => {
+    try {
+      await api.post(
+        '/admin/test-notification',
+        {},
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      showToast('Test email sent!');
+    } catch (err) {
+      console.error('Failed to send test email', err);
+    }
+  };
+
   const handleDelete = async (email) => {
     if (!window.confirm(`Delete user ${email}?`)) return;
     try {
@@ -216,6 +229,12 @@ function AdminUsers() {
           onClick={() => setActiveTab('feeds')}
         >
           RSS Feeds
+        </button>
+        <button
+          className={`tab ${activeTab === 'tests' ? 'active' : ''}`}
+          onClick={() => setActiveTab('tests')}
+        >
+          Tests
         </button>
       </div>
       <div className="tab-content">
@@ -403,6 +422,15 @@ function AdminUsers() {
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+        {activeTab === 'tests' && (
+          <div style={{ marginTop: '1rem' }}>
+            <p>
+              Click the button below to send yourself a sample notification email
+              so you can see what candidates receive.
+            </p>
+            <button onClick={handleSendTest}>Send Test Email</button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- allow admins to send themselves a sample notification email
- expose `/admin/test-notification` endpoint
- show a new **Tests** tab in Manage Users with button to trigger test
- test admin test email behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abb9a0e5c83338be8a2549a86271c