### PR TITLE
Improve recruiter interest notification email

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1311,9 +1311,9 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
 
     body = (
         f"Hello {first_name},\n\n"
-        "Your resume has been matched with a job and the recruiter has reviewed. "
-        "You are receiving this email because the Recruiter would like to notify you "
-        "that you are a match and will be contacting you to discuss your resume. "
+        "Your resume has been matched with a job and the recruiter has reviewed your resume.\n\n"
+        "You are receiving this email because the Recruiter would like to notify you that you are a match "
+        "and will be contacting you to discuss your resume.\n\n"
         "Please see the attached document outlining the job description as it pertains to your resume.\n\n"
         "Good Luck!\n\n"
         "Support Team @ TalentMatch-AI"


### PR DESCRIPTION
## Summary
- tweak the email text used by `/notify-interest` so candidates receive a consistent message

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687adc1f4cd08333800e9e0aed228342