### PR TITLE
Serve job descriptions via public link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ SMTP_PASSWORD=secret
 EMAIL_SENDER=noreply@example.com
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
+SITE_BASE_URL=https://yourdomain.com
 ```
 
 ## Registration Codes

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -671,6 +671,22 @@ def test_job_description_html_route():
     assert "html" in resp.text.lower()
 
 
+def test_public_job_description_html_route():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    main_app.redis_client.set(
+        "jobdesc:codep:stud@example.com",
+        "public desc",
+    )
+
+    resp = client.get(
+        "/public/job-description-html/codep/stud@example.com",
+    )
+    assert resp.status_code == 200
+    assert "public" in resp.text.lower()
+
+
 def test_notify_interest_generates_description(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()
@@ -718,9 +734,8 @@ def test_notify_interest_generates_description(monkeypatch):
     assert stored is not None and "done" in stored
     assert main_app.redis_client.get("jobdesc:codei:stud@example.com") == stored
     assert "Good Luck" in sent.get("body")
-    attachments = sent.get("attachments")
-    assert attachments and attachments[0][0] == "job_description.html"
-    assert attachments[0][1] == stored
+    assert "/public/job-description-html/codei/stud@example.com" in sent.get("body")
+    assert sent.get("attachments") is None
 
 
 def test_generate_resume_html(monkeypatch):


### PR DESCRIPTION
## Summary
- add `SITE_BASE_URL` config for generating email links
- expose `/public/job-description-html` to view HTML without auth
- update notify interest emails to point to the new public link
- document new env var in README
- adjust tests for email body link and new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b29d85a90833393afec3dc3f3cbc0