### PR TITLE
Clarify SITE_BASE_URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ ADMIN_PASSWORD=admin123
 SITE_BASE_URL=https://yourdomain.com
 ```
 
+`SITE_BASE_URL` must point to the base URL of the FastAPI backend (e.g.,
+`https://your-api.com`). Using the React frontend URL here will cause links in
+emails to break.
+
 ## Registration Codes
 
 Career services staff and recruiters must supply an institutional code when registering.

--- a/app/main.py
+++ b/app/main.py
@@ -246,6 +246,10 @@ def on_startup():
     except Exception as e:
         print(f"Redis connection failed: {e}")
         raise
+    if not SITE_BASE_URL:
+        print(
+            "[startup] Warning: SITE_BASE_URL is empty; links in notification emails may be incorrect"
+        )
     init_default_admin()
     init_default_school_codes()
     init_default_rss_feeds()


### PR DESCRIPTION
## Summary
- clarify that SITE_BASE_URL should be the FastAPI backend URL
- warn on startup if SITE_BASE_URL is unset

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bae6452b883338bb77d79742287e2