### PR TITLE
Add job info in candidate job description HTML

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1521,6 +1521,21 @@ Output only valid HTML.
     if raw_content.endswith("```"):
         raw_content = raw_content.rsplit("```", 1)[0].strip()
 
+    details_html = """
+    <h2>Job Details</h2>
+    <ul>
+      <li><strong>Source:</strong> {source}</li>
+      <li><strong>Pay Range:</strong> {pay_min} - {pay_max}</li>
+      <li><strong>Location:</strong> {city}, {state}</li>
+    </ul>
+    """.format(
+        source=job.get("source", ""),
+        pay_min=job.get("min_pay", ""),
+        pay_max=job.get("max_pay", ""),
+        city=job.get("city", ""),
+        state=job.get("state", ""),
+    )
+
     full_html = f"""
 <!DOCTYPE html>
 <html lang=\"en\">
@@ -1544,6 +1559,7 @@ Output only valid HTML.
   </style>
 </head>
 <body>
+{details_html}
 {raw_content}
 </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -618,6 +618,9 @@ def test_generate_job_description(monkeypatch):
             "desired_skills": ["python"],
             "min_pay": 5.0,
             "max_pay": 10.0,
+            "city": "Austin",
+            "state": "TX",
+            "source": "Indeed",
         })
     )
 
@@ -655,6 +658,9 @@ def test_generate_job_description(monkeypatch):
     html_content = get_resp.json()["description"]
     assert html_content.lstrip().startswith("<!DOCTYPE html>")
     assert "done" in html_content
+    assert "Source:" in html_content
+    assert "Pay Range:" in html_content
+    assert "Location:" in html_content
 
 
 def test_job_description_html_route():


### PR DESCRIPTION
## Summary
- include source, pay range, and location when generating job-description HTML for candidates
- extend tests for job description generation to cover new HTML content

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd4ee757c8333a121b797b170a096