### PR TITLE
Add new landing page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import LandingPage from './LandingPage';
 import './App.css';
 import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
@@ -24,7 +25,7 @@ function App() {
     <Router>
       <div className="App">
         <Routes>
-          <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route path="/" element={<LandingPage />} />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/register" element={<RegisterForm />} />
           <Route path="/request-code" element={<RequestInstitutionCode />} />

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -19,9 +19,9 @@ beforeAll(() => {
   };
 });
 
-test('renders login form', () => {
+test('renders landing page', () => {
   render(<App />);
-  const heading = screen.getByRole('heading', { name: /login/i });
+  const heading = screen.getByRole('heading', { name: /who are you/i });
   expect(heading).toBeInTheDocument();
 });
 

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -1,0 +1,44 @@
+.landing-container {
+  background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
+  min-height: 100vh;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  position: relative;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.landing-logo {
+  width: 150px;
+  height: 150px;
+  margin-bottom: 1rem;
+}
+
+.landing-title {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+.landing-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.landing-btn {
+  background-color: #0074d9;
+  color: white;
+  padding: 0.8rem 1.5rem;
+  border-radius: 5px;
+  text-decoration: none;
+  font-weight: 600;
+  width: 220px;
+}
+
+.landing-btn:hover {
+  background-color: #005fa3;
+}

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import TopMenu from './TopMenu';
+import logo from './logo.svg';
+import './LandingPage.css';
+
+function LandingPage() {
+  return (
+    <div className="landing-container">
+      <TopMenu />
+      <img src={logo} className="landing-logo" alt="TalentMatch AI logo" />
+      <h1 className="landing-title">Who Are You?</h1>
+      <div className="landing-buttons">
+        <Link to="/login" className="landing-btn">Career Services Login</Link>
+        <Link to="/login" className="landing-btn">Recruiter</Link>
+        <Link to="/login" className="landing-btn">Job Seekers</Link>
+      </div>
+    </div>
+  );
+}
+
+export default LandingPage;


### PR DESCRIPTION
## Summary
- show a landing page with role buttons instead of redirecting to login
- route `/` to `LandingPage`
- update tests for new heading

## Testing
- `CI=true npm test --silent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6885bb6c020c8333a8452b25ae515de9