### PR TITLE
Fix logo overflow

### DIFF
--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -12,8 +12,9 @@
 }
 
 .landing-logo {
-  /* Maintain aspect ratio while enlarging the logo */
-  width: 300px;
+  /* Scale logo but keep it within the viewport */
+  width: 90vw;
+  max-width: 450px;
   height: auto;
   margin-bottom: 1rem;
   animation: glow 3s ease-in-out infinite, flash 1.5s linear infinite;


### PR DESCRIPTION
## Summary
- tweak landing page logo sizing so it's not cut off

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886482bf1c883339b48b4746d85d39e