### PR TITLE
Add role specific login pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LandingPage from './LandingPage';
 import './App.css';
 import LoginForm from './LoginForm';
+import RoleLogin from './RoleLogin';
 import RegisterForm from './RegisterForm';
 import Dashboard from './Dashboard';
 import ProtectedRoute from './ProtectedRoute';
@@ -27,6 +28,7 @@ function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/login" element={<LoginForm />} />
+          <Route path="/login/:role" element={<RoleLogin />} />
           <Route path="/register" element={<RegisterForm />} />
           <Route path="/request-code" element={<RequestInstitutionCode />} />
           <Route path="/about" element={<AboutPanel />} />

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -11,9 +11,9 @@ function LandingPage() {
       <img src={logo} className="landing-logo" alt="TalentMatch AI logo" />
       <h1 className="landing-title">Who Are You?</h1>
       <div className="landing-buttons">
-        <Link to="/login" className="landing-btn">Career Services Login</Link>
-        <Link to="/login" className="landing-btn">Recruiter</Link>
-        <Link to="/login" className="landing-btn">Job Seekers</Link>
+        <Link to="/login/career" className="landing-btn">Career Services Login</Link>
+        <Link to="/login/recruiter" className="landing-btn">Recruiter</Link>
+        <Link to="/login/applicant" className="landing-btn">Job Seekers</Link>
       </div>
     </div>
   );

--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -2,8 +2,29 @@
   background-color: #001f3f;
   height: 100vh;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.login-content {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.login-container.with-info .login-content {
+  flex-direction: row;
+  gap: 2rem;
+}
+
+.info-panel {
+  background-color: #003366;
+  padding: 2rem;
+  border-radius: 10px;
+  color: white;
+  max-width: 400px;
+  border-left: 2px solid white;
 }
 
 .login-form {

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -4,7 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 import TopMenu from './TopMenu';
 
-function LoginForm() {
+function LoginForm({ infoContent }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -56,8 +56,9 @@ function LoginForm() {
   };
 
   return (
-    <div className="login-container">
+    <div className={`login-container${infoContent ? ' with-info' : ''}`}> 
       <TopMenu />
+      <div className="login-content">
       <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
 
@@ -83,6 +84,8 @@ function LoginForm() {
 
         {error && <p className="error">{error}</p>}
       </form>
+      {infoContent && <div className="info-panel">{infoContent}</div>}
+      </div>
     </div>
   );
 }

--- a/frontend/src/RoleLogin.js
+++ b/frontend/src/RoleLogin.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import LoginForm from './LoginForm';
+
+const roleInfo = {
+  career: (
+    <>
+      <h2>Career Services</h2>
+      <p>TalentMatch AI empowers your department with holistic student profiles, AI-driven matching and instant reporting.</p>
+    </>
+  ),
+  recruiter: (
+    <>
+      <h2>Recruiters</h2>
+      <p>Find candidates who are more than just resumes using our AI-powered matching and custom insights.</p>
+    </>
+  ),
+  applicant: (
+    <>
+      <h2>Job Seekers</h2>
+      <p>Build a biography that tells your story and get matched to roles where you can thrive.</p>
+    </>
+  ),
+};
+
+function RoleLogin() {
+  const { role } = useParams();
+  return <LoginForm infoContent={roleInfo[role]} />;
+}
+
+export default RoleLogin;


### PR DESCRIPTION
## Summary
- create new `RoleLogin` component to display login with info panel
- adjust `LoginForm` to optionally show role-specific info
- update styles to support side-by-side layout
- add `/login/:role` route and update landing page buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886fa7cd6b883339568a6df86acf1cb