### PR TITLE
Implement rejection workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ email address.
 Administrators can manage user accounts. Use `DELETE /admin/users/{email}` to
 remove a user from the system.
 
+## Rejection Workflow
+
+Recruiters can mark an assigned candidate as no longer interested via
+`POST /reject-assigned`. Provide the `job_code`, the candidate's email, and a
+note explaining the reason. The student will be removed from the job's
+`assigned_students` list and recorded in `rejected_students` with the note stored
+under `rejection_notes[email]`.
+
+Job objects created with `/jobs` now include `rejected_students` and
+`rejection_notes` fields by default. Student listing endpoints
+(`/students/all`, `/students/by-school`, and `/students/me`) return these jobs
+with a `status` of `rejected` and the stored note.
+
 ## Nursing News
 
 The `/nursing-news` endpoint retrieves articles from several nursing-focused RSS

--- a/app/main.py
+++ b/app/main.py
@@ -857,6 +857,8 @@ def create_job(job: JobRequest, current_user: dict = Depends(get_current_user)):
     data.setdefault("assigned_students", [])
     data.setdefault("placed_students", [])
     data.setdefault("uninterested_students", [])
+    data.setdefault("rejected_students", [])
+    data.setdefault("rejection_notes", {})
 
     redis_client.set(key, json.dumps(data))
     print(f"Stored job at {key}: {data}")
@@ -1013,11 +1015,14 @@ def _perform_match(job_code: str, send_emails: bool = True):
 
     assigned = set(job.get("assigned_students", []))
     placed = set(job.get("placed_students", []))
+    rejected = set(job.get("rejected_students", []))
     for m in top_matches:
         if m["email"] in placed:
             m["status"] = "placed"
         elif m["email"] in assigned:
             m["status"] = "assigned"
+        elif m["email"] in rejected:
+            m["status"] = "rejected"
         else:
             m["status"] = None
 
@@ -1083,12 +1088,15 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         job = json.loads(job_raw)
         assigned = set(job.get("assigned_students", []))
         placed = set(job.get("placed_students", []))
+        rejected = set(job.get("rejected_students", []))
 
         for m in matches:
             if m["email"] in placed:
                 m["status"] = "placed"
             elif m["email"] in assigned:
                 m["status"] = "assigned"
+            elif m["email"] in rejected:
+                m["status"] = "rejected"
             else:
                 m["status"] = None
 
@@ -1113,6 +1121,8 @@ def list_jobs(current_user: dict = Depends(get_current_user)):
             job.setdefault("assigned_students", [])
             job.setdefault("placed_students", [])
             job.setdefault("uninterested_students", [])
+            job.setdefault("rejected_students", [])
+            job.setdefault("rejection_notes", {})
             jobs.append(job)
     print(f"Returning {len(jobs)} jobs from Redis")
     return {"jobs": jobs}
@@ -1280,6 +1290,38 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
 
     redis_client.set(key, json.dumps(job))
     return {"message": f"Assigned {student_email}"}
+
+
+@app.post("/reject-assigned")
+def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_user)):
+    """Remove an assigned student from a job and record a rejection note."""
+    job_code = data.get("job_code")
+    student_email = data.get("student_email")
+    note = data.get("note", "")
+    if not job_code or not student_email:
+        raise HTTPException(status_code=400, detail="Missing job_code or student_email")
+
+    key = f"job:{job_code}"
+    raw = redis_client.get(key)
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = json.loads(raw)
+    job.setdefault("assigned_students", [])
+    job.setdefault("rejected_students", [])
+    job.setdefault("rejection_notes", {})
+
+    if student_email in job["assigned_students"]:
+        job["assigned_students"].remove(student_email)
+    if student_email not in job["rejected_students"]:
+        job["rejected_students"].append(student_email)
+
+    notes = job.get("rejection_notes", {})
+    notes[student_email] = note
+    job["rejection_notes"] = notes
+
+    redis_client.set(key, json.dumps(job))
+    return {"message": "Student rejected"}
 
 
 @app.post("/not-interested")
@@ -1787,23 +1829,32 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
         }
 
         # Add optional match data
-        info["assigned_jobs"] = [
-            {
-                "job_code": job.get("job_code"),
-                "job_title": job.get("job_title"),
-                "source": job.get("source"),
-                "min_pay": job.get("min_pay"),
-                "max_pay": job.get("max_pay"),
-                "job_description": job.get("job_description"),
-            }
-            for job in all_jobs
-            if email in job.get("assigned_students", [])
-        ]
-        info["placed_jobs"] = sum(
-            1 for job in all_jobs if email in job.get("placed_students", [])
-        )
-        if info["assigned_jobs"]:
-            info["assigned_job_code"] = info["assigned_jobs"][0]["job_code"]
+        jobs_list = []
+        for job in all_jobs:
+            status = None
+            note = None
+            if email in job.get("placed_students", []):
+                status = "placed"
+            elif email in job.get("assigned_students", []):
+                status = "assigned"
+            elif email in job.get("rejected_students", []):
+                status = "rejected"
+                note = job.get("rejection_notes", {}).get(email)
+            if status:
+                jobs_list.append({
+                    "job_code": job.get("job_code"),
+                    "job_title": job.get("job_title"),
+                    "source": job.get("source"),
+                    "min_pay": job.get("min_pay"),
+                    "max_pay": job.get("max_pay"),
+                    "job_description": job.get("job_description"),
+                    "status": status,
+                    "note": note,
+                })
+
+        info["assigned_jobs"] = jobs_list
+        info["placed_jobs"] = sum(1 for j in jobs_list if j["status"] == "placed")
+        info["assigned_job_code"] = next((j["job_code"] for j in jobs_list if j["status"] == "assigned"), None)
 
         students.append(info)
 
@@ -1865,24 +1916,32 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
             "assigned_job_code": None,
         }
 
-        # Add assigned/placed jobs info
-        info["assigned_jobs"] = [
-            {
-                "job_code": job.get("job_code"),
-                "job_title": job.get("job_title"),
-                "source": job.get("source"),
-                "min_pay": job.get("min_pay"),
-                "max_pay": job.get("max_pay"),
-                "job_description": job.get("job_description"),
-            }
-            for job in all_jobs
-            if email in job.get("assigned_students", [])
-        ]
-        info["placed_jobs"] = sum(
-            1 for job in all_jobs if email in job.get("placed_students", [])
-        )
-        if info["assigned_jobs"]:
-            info["assigned_job_code"] = info["assigned_jobs"][0]["job_code"]
+        jobs_list = []
+        for job in all_jobs:
+            status = None
+            note = None
+            if email in job.get("placed_students", []):
+                status = "placed"
+            elif email in job.get("assigned_students", []):
+                status = "assigned"
+            elif email in job.get("rejected_students", []):
+                status = "rejected"
+                note = job.get("rejection_notes", {}).get(email)
+            if status:
+                jobs_list.append({
+                    "job_code": job.get("job_code"),
+                    "job_title": job.get("job_title"),
+                    "source": job.get("source"),
+                    "min_pay": job.get("min_pay"),
+                    "max_pay": job.get("max_pay"),
+                    "job_description": job.get("job_description"),
+                    "status": status,
+                    "note": note,
+                })
+
+        info["assigned_jobs"] = jobs_list
+        info["placed_jobs"] = sum(1 for j in jobs_list if j["status"] == "placed")
+        info["assigned_job_code"] = next((j["job_code"] for j in jobs_list if j["status"] == "assigned"), None)
 
         students.append(info)
 
@@ -1914,7 +1973,17 @@ def student_me(current_user: dict = Depends(get_current_user)):
             job = json.loads(job_raw)
         except Exception:
             continue
-        if email in job.get("assigned_students", []):
+        status = None
+        note = None
+        if email in job.get("placed_students", []):
+            placed += 1
+            status = "placed"
+        elif email in job.get("assigned_students", []):
+            status = "assigned"
+        elif email in job.get("rejected_students", []):
+            status = "rejected"
+            note = job.get("rejection_notes", {}).get(email)
+        if status:
             assigned_jobs.append({
                 "job_code": job.get("job_code"),
                 "job_title": job.get("job_title"),
@@ -1922,9 +1991,9 @@ def student_me(current_user: dict = Depends(get_current_user)):
                 "min_pay": job.get("min_pay"),
                 "max_pay": job.get("max_pay"),
                 "job_description": job.get("job_description"),
+                "status": status,
+                "note": note,
             })
-        if email in job.get("placed_students", []):
-            placed += 1
 
     info = {
         **{k: student.get(k) for k in [
@@ -1940,7 +2009,7 @@ def student_me(current_user: dict = Depends(get_current_user)):
         ]},
         "assigned_jobs": assigned_jobs,
         "placed_jobs": placed,
-        "assigned_job_code": assigned_jobs[0]["job_code"] if assigned_jobs else None,
+        "assigned_job_code": next((j["job_code"] for j in assigned_jobs if j["status"] == "assigned"), None),
     }
     return info
 

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -265,6 +265,11 @@
   color: white;
 }
 
+.badge.rejected {
+  background-color: #d9534f;
+  color: white;
+}
+
 .job-description-panel {
   text-align: left;
   padding: 1rem 2rem;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -334,6 +334,26 @@ if (shouldRedirect) {
     }
   };
 
+  const rejectAssigned = async (jobCode, email) => {
+    const note = window.prompt('Add a note for this rejection:');
+    if (note === null) return;
+    try {
+      await api.post(
+        '/reject-assigned',
+        { job_code: jobCode, student_email: email, note },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setMatches((prev) => ({
+        ...prev,
+        [jobCode]: prev[jobCode].map((m) =>
+          m.email === email ? { ...m, status: 'rejected', note } : m
+        )
+      }));
+    } catch (err) {
+      console.error('Reject failed', err);
+    }
+  };
+
   const bulkAssign = async (job) => {
     const emails = selectedRows[job.job_code] || [];
     for (const email of emails) {
@@ -519,6 +539,8 @@ if (shouldRedirect) {
                             <button onClick={() => handlePlace(job, row)}>Place</button>
                           )}
                         </>
+                      ) : row.status === 'rejected' ? (
+                        <span className="badge rejected inline">Rejected</span>
                       ) : (
                         <>
                           <button onClick={() => handleAssign(job, row)}>Interested</button>
@@ -580,6 +602,9 @@ if (shouldRedirect) {
                 {!isRecruiter && (
                   <button onClick={() => handlePlace(job, row)}>Place</button>
                 )}
+                <button onClick={() => rejectAssigned(job.job_code, row.email)}>
+                  Not Interested
+                </button>
               </td>
             </tr>
           ))}

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -630,6 +630,8 @@ function StudentProfiles() {
                                     <th>Rate</th>
                                     <th>Source</th>
                                     <th>Job Description</th>
+                                    <th>Status</th>
+                                    <th>Recruiter Note</th>
                                   </tr>
                                 </thead>
                                 <tbody>
@@ -677,11 +679,13 @@ function StudentProfiles() {
                                             </button>
                                           )}
                                         </td>
+                                        <td>{job.status}</td>
+                                        <td>{job.note || ''}</td>
                                       </tr>
                                     ))
                                   ) : (
                                     <tr className="no-jobs-row">
-                                      <td colSpan="4">No jobs assigned by recruiters.</td>
+                                      <td colSpan="6">No jobs assigned by recruiters.</td>
                                     </tr>
                                   )}
                                 </tbody>

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -661,3 +661,73 @@ def test_recruiter_job_source_autopopulated(monkeypatch):
     job_code = resp.json()["job_code"]
     stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
     assert stored["source"] == "Unitek-Sacramento"
+
+
+def test_reject_assigned(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [1.0]})]
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", lambda *a, **k: FakeResp())
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 1.0)
+
+    token = login_admin()
+
+    student = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john@example.com",
+        "phone": "123",
+        "education_level": "College",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 50.0,
+    }
+    client.post("/students", json=student, headers={"Authorization": f"Bearer {token}"})
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    job_code = resp.json()["job_code"]
+
+    client.post(
+        "/assign",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    note = "not a fit"
+    r = client.post(
+        "/reject-assigned",
+        json={"job_code": job_code, "student_email": student["email"], "note": note},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+    stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
+    assert student["email"] not in stored.get("assigned_students", [])
+    assert student["email"] in stored.get("rejected_students", [])
+    assert stored.get("rejection_notes", {}).get(student["email"]) == note
+
+    resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()["students"][0]
+    entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
+    assert entry["status"] == "rejected"
+    assert entry["note"] == note


### PR DESCRIPTION
## Summary
- add `rejected_students` and `rejection_notes` when creating a job
- implement `/reject-assigned` endpoint to remove an assigned candidate with a note
- mark rejected students in match results
- surface rejected status and note in student listing endpoints
- add ability to reject assigned candidates from the UI and show recruiter notes
- document new workflow
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888591e6c048333b88d77e55528b0ab