### PR TITLE
Fix RQ worker redis decoding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -86,12 +86,15 @@ SITE_BASE_URL = os.getenv("SITE_BASE_URL", "").rstrip("/")
 if not redis_url:
     raise RuntimeError("Missing REDIS_URL in .env")
 
-# Redis connection
+# Redis connection for general app data (strings/JSON)
 redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
+# Separate connection for RQ that returns bytes
+rq_redis_client = redis.Redis.from_url(redis_url)
 
 # Background task queue helper
 def get_queue() -> Queue:
-    return Queue(connection=redis_client)
+    """Return an RQ queue using a raw-redis connection."""
+    return Queue(connection=rq_redis_client)
 
 # In-memory vector search index for student embeddings
 EMBEDDING_DIM: int | None = None

--- a/worker.py
+++ b/worker.py
@@ -8,6 +8,7 @@ if not redis_url:
     raise RuntimeError("Missing REDIS_URL")
 
 # Connect to Redis
-redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
+# RQ expects raw bytes, so disable automatic response decoding
+redis_client = redis.Redis.from_url(redis_url)
 queue = Queue(connection=redis_client)
 Worker([queue], connection=redis_client).work()


### PR DESCRIPTION
## Summary
- avoid decode_responses when using RQ workers
- use a separate redis connection for RQ queue

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b9ae58b388333af8ae7bc8f0757bc