### PR TITLE
Add spinner to job match loader

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -288,6 +288,9 @@
   font-size: 0.85rem;
   color: #555;
   margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .matched-button {
@@ -375,9 +378,19 @@
 }
 
 .spinner {
-  font-size: 0.8rem;
-  padding-left: 0.5rem;
-  color: #999;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ccc;
+  border-top: 2px solid #333;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .resume-ready {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -509,7 +509,9 @@ if (shouldRedirect) {
     return (
       <>
         {loadingMatches[job.job_code] && (
-          <div className="loader-bar">Loading matches...</div>
+          <div className="loader-bar">
+            <span className="spinner" /> Loading matches...
+          </div>
         )}
         <button
           disabled={(selectedRows[job.job_code]?.length || 0) === 0}


### PR DESCRIPTION
## Summary
- reuse spinner animation from StudentProfiles
- style loader bar to show spinner and text inline
- show spinner during job matching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3f8282588333ab55f12c3009892a