### PR TITLE
Allow resume preview without assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,9 @@ providers.
 ## Metrics
 
 Match jobs record queue and processing time in Redis. The `/metrics` endpoint exposes `total_match_queue_time` and `total_match_process_time` along with existing counters.
+
+## Resume Previews
+
+The `/generate-resume` endpoint accepts an optional `preview` flag. When `true`,
+the generated resume includes placeholder contact information and does not
+require the student to be listed in `assigned_students` for the job.

--- a/app/main.py
+++ b/app/main.py
@@ -1547,7 +1547,8 @@ def generate_resume(req: ResumeRequest, current_user: dict = Depends(get_current
     job = json.loads(job_raw)
     student = json.loads(student_raw)
 
-    if req.student_email not in job.get("assigned_students", []) and req.student_email not in job.get("placed_students", []):
+    if not preview and req.student_email not in job.get("assigned_students", []) \
+        and req.student_email not in job.get("placed_students", []):
         raise HTTPException(status_code=403, detail="Student not assigned to job")
 
     raw_html = generate_resume_text(client, student, job, include_contact=not preview).strip()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -965,7 +965,8 @@ def test_generate_resume_preview(monkeypatch):
             "job_title": "Dev",
             "job_description": "desc",
             "desired_skills": ["python"],
-            "assigned_students": ["stud@example.com"],
+            "assigned_students": [],
+            "placed_students": [],
         })
     )
 


### PR DESCRIPTION
## Summary
- let resume previews bypass assignment check
- update tests for new preview behaviour
- document preview flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c4a0568508333bad3468dda17d63a