### PR TITLE
Add resume preview button

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -406,6 +406,21 @@
   cursor: pointer;
   font-size: 1.2rem;
 }
+
+.preview-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.preview-button:disabled {
+  background-color: #d3d3d3;
+  color: #666;
+  cursor: not-allowed;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -35,6 +35,7 @@ function JobPosting() {
   const [editedJobs, setEditedJobs] = useState({});
   const [generatingResumes, setGeneratingResumes] = useState({});
   const [generatedResumes, setGeneratedResumes] = useState({});
+  const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
 
   const locationRef = useRef(null);
@@ -468,6 +469,8 @@ if (shouldRedirect) {
   };
 
   const previewResume = async (email, jobCode) => {
+    const key = `${jobCode}:${email}`;
+    setPreviewingResumes((prev) => ({ ...prev, [key]: true }));
     try {
       const resp = await api.post(
         '/generate-resume',
@@ -481,6 +484,8 @@ if (shouldRedirect) {
       }
     } catch (err) {
       console.error('Preview resume error:', err);
+    } finally {
+      setPreviewingResumes((prev) => ({ ...prev, [key]: false }));
     }
   };
 
@@ -525,6 +530,7 @@ if (shouldRedirect) {
               <th></th>
               <th>Name</th>
               <th>Score</th>
+              <th>Preview</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -556,6 +562,18 @@ if (shouldRedirect) {
                       {row.last_name || row.name?.split(' ')[1]}
                     </td>
                     <td>{row.score.toFixed(2)}</td>
+                    <td>
+                      {previewingResumes[`${job.job_code}:${row.email}`] ? (
+                        <span className="spinner" />
+                      ) : (
+                        <button
+                          className="preview-button"
+                          onClick={() => previewResume(row.email, job.job_code)}
+                        >
+                          Preview Resume
+                        </button>
+                      )}
+                    </td>
                     <td>
                       {row.status === 'placed' ? (
                         <span className="badge placed inline">Placed</span>


### PR DESCRIPTION
## Summary
- track preview state in JobPosting
- enable resume preview on match rows
- add styles for preview button

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688c4d8bacdc8333b04396d86deb6b20