### PR TITLE
Add resume preview loading state

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -406,6 +406,20 @@
   cursor: pointer;
   font-size: 1.2rem;
 }
+
+.preview-resume-button {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-right: 0.5rem;
+}
+
+.preview-resume-button:hover {
+  background-color: #0056b3;
+}
 @media (max-width: 768px) {
   .job-matching-layout {
     flex-direction: column;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -35,6 +35,7 @@ function JobPosting() {
   const [editedJobs, setEditedJobs] = useState({});
   const [generatingResumes, setGeneratingResumes] = useState({});
   const [generatedResumes, setGeneratedResumes] = useState({});
+  const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
 
   const locationRef = useRef(null);
@@ -468,6 +469,8 @@ if (shouldRedirect) {
   };
 
   const previewResume = async (email, jobCode) => {
+    const key = `${jobCode}:${email}`;
+    setPreviewingResumes((prev) => ({ ...prev, [key]: true }));
     try {
       const resp = await api.post(
         '/generate-resume',
@@ -481,6 +484,8 @@ if (shouldRedirect) {
       }
     } catch (err) {
       console.error('Preview resume error:', err);
+    } finally {
+      setPreviewingResumes((prev) => ({ ...prev, [key]: false }));
     }
   };
 
@@ -557,6 +562,16 @@ if (shouldRedirect) {
                     </td>
                     <td>{row.score.toFixed(2)}</td>
                     <td>
+                      {previewingResumes[`${job.job_code}:${row.email}`] ? (
+                        <span className="spinner" />
+                      ) : (
+                        <button
+                          className="preview-resume-button"
+                          onClick={() => previewResume(row.email, job.job_code)}
+                        >
+                          Preview Resume
+                        </button>
+                      )}
                       {row.status === 'placed' ? (
                         <span className="badge placed inline">Placed</span>
                       ) : row.status === 'assigned' ? (


### PR DESCRIPTION
## Summary
- track previewing resume state in JobPosting
- show `Preview Resume` button on each unassigned match row
- display spinner while resume preview is loading
- style the preview button like other action buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c51d0a1148333826213641dec8e55