### PR TITLE
Add student notes API and comment UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Job objects created with `/jobs` now include `rejected_students` and
 `assigned` or `rejected` and include the stored note, so notes are visible for
 both assigned and rejected students.
 
+### Student Notes
+
+Use `POST /student-note` with a `job_code`, the `student_email`, and a `note` to
+create or update recruiter comments for a candidate. This endpoint only updates
+the `student_notes[email]` field and does **not** change any assignment status.
+The response includes the email and saved note.
+
+In the job‑matching UI, each row in the match tables now has a **Comment**
+control. Recruiters can open an inline text area to add or edit notes, which are
+displayed for candidates in any status.
+
 ## Driving distance caching
 
 Driving distance lookups use Google's Distance Matrix API. Results are cached in

--- a/app/main.py
+++ b/app/main.py
@@ -1455,6 +1455,28 @@ def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_u
     return {"message": "Student rejected"}
 
 
+@app.post("/student-note")
+def student_note(data: dict, token_data: dict = Depends(get_current_user)):
+    """Create or update a note for a student on a job."""
+    job_code = data.get("job_code")
+    student_email = data.get("student_email")
+    note = data.get("note")
+    if not job_code or not student_email:
+        raise HTTPException(status_code=400, detail="Missing job_code or student_email")
+
+    key = f"job:{job_code}"
+    raw = redis_client.get(key)
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = json.loads(raw)
+    job.setdefault("student_notes", {})
+    job["student_notes"][student_email] = note
+
+    redis_client.set(key, json.dumps(job))
+    return {"email": student_email, "note": note}
+
+
 @app.post("/not-interested")
 def mark_not_interested(data: dict, token_data: dict = Depends(get_current_user)):
     """Record that a student is not interested in a job."""

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -171,6 +171,16 @@
   background-color: #f0f0f0;
 }
 
+.note-editor textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.note-editor button {
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+}
+
 
 .filter-box {
   margin-bottom: 1rem;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -5,6 +5,7 @@ import api from './api';
 import AdminMenu from './AdminMenu';
 import loadGoogleMaps from './utils/loadGoogleMaps';
 import './JobPosting.css';
+import NoteEditor from './NoteEditor';
 
 function JobPosting() {
   const [formData, setFormData] = useState({
@@ -37,6 +38,7 @@ function JobPosting() {
   const [generatedResumes, setGeneratedResumes] = useState({});
   const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
+  const [noteInputs, setNoteInputs] = useState({});
 
   const locationRef = useRef(null);
 
@@ -260,15 +262,12 @@ if (shouldRedirect) {
   };
 
   const handleAssign = async (job, row) => {
-    const note = window.prompt('Add a note for this assignment:');
-    if (note === null) return;
     try {
       await api.post(
         '/assign',
         {
           student_email: row.email,
           job_code: job.job_code,
-          note,
         },
         {
           headers: {
@@ -280,7 +279,7 @@ if (shouldRedirect) {
       setMatches((prev) => ({
         ...prev,
         [job.job_code]: prev[job.job_code].map((m) =>
-          m.email === row.email ? { ...m, status: 'assigned', note } : m
+          m.email === row.email ? { ...m, status: 'assigned' } : m
         ),
       }));
       setJobs((prevJobs) =>
@@ -363,19 +362,31 @@ if (shouldRedirect) {
     }
   };
 
+  const startNote = (jobCode, email, current) => {
+    setNoteInputs((prev) => ({ ...prev, [`${jobCode}:${email}`]: current || '' }));
+  };
+
+  const cancelNote = (jobCode, email) => {
+    setNoteInputs((prev) => {
+      const key = `${jobCode}:${email}`;
+      const copy = { ...prev };
+      delete copy[key];
+      return copy;
+    });
+  };
+
+
   const rejectAssigned = async (jobCode, email) => {
-    const note = window.prompt('Add a note for this rejection:');
-    if (note === null) return;
     try {
       await api.post(
         '/reject-assigned',
-        { job_code: jobCode, student_email: email, note },
+        { job_code: jobCode, student_email: email },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setMatches((prev) => ({
         ...prev,
         [jobCode]: prev[jobCode].map((m) =>
-          m.email === email ? { ...m, status: 'rejected', note } : m
+          m.email === email ? { ...m, status: 'rejected' } : m
         )
       }));
     } catch (err) {
@@ -386,20 +397,19 @@ if (shouldRedirect) {
   const bulkAssign = async (job) => {
     const emails = selectedRows[job.job_code] || [];
     for (const email of emails) {
-      const note = window.prompt(`Add a note for ${email}:`);
-      if (note === null) continue;
       try {
-        await api.post('/assign', {
-          student_email: email,
-          job_code: job.job_code,
-          note,
-        }, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
+        await api.post(
+          '/assign',
+          {
+            student_email: email,
+            job_code: job.job_code,
+          },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
         setMatches((prev) => ({
           ...prev,
           [job.job_code]: prev[job.job_code].map((m) =>
-            m.email === email ? { ...m, status: 'assigned', note } : m
+            m.email === email ? { ...m, status: 'assigned' } : m
           )
         }));
       } catch (err) {
@@ -581,7 +591,30 @@ if (shouldRedirect) {
                         </button>
                       )}
                     </td>
-                    <td>{row.note || ''}</td>
+                    <td>
+                      {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                        <NoteEditor
+                          jobCode={job.job_code}
+                          email={row.email}
+                          initialNote={noteInputs[`${job.job_code}:${row.email}`]}
+                          onSaved={(n) => {
+                            setMatches((prev) => ({
+                              ...prev,
+                              [job.job_code]: (prev[job.job_code] || []).map((m) =>
+                                m.email === row.email ? { ...m, note: n } : m
+                              ),
+                            }));
+                            cancelNote(job.job_code, row.email);
+                          }}
+                          onCancel={() => cancelNote(job.job_code, row.email)}
+                        />
+                      ) : (
+                        <>
+                          {row.note || ''}
+                          <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                        </>
+                      )}
+                    </td>
                     <td>
                       {row.status === 'placed' ? (
                         <span className="badge placed inline">Placed</span>
@@ -648,7 +681,30 @@ if (shouldRedirect) {
                   </button>
                 )}
               </td>
-              <td>{row.note || ''}</td>
+              <td>
+                {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                  <NoteEditor
+                    jobCode={job.job_code}
+                    email={row.email}
+                    initialNote={noteInputs[`${job.job_code}:${row.email}`]}
+                    onSaved={(n) => {
+                      setMatches((prev) => ({
+                        ...prev,
+                        [job.job_code]: (prev[job.job_code] || []).map((m) =>
+                          m.email === row.email ? { ...m, note: n } : m
+                        ),
+                      }));
+                      cancelNote(job.job_code, row.email);
+                    }}
+                    onCancel={() => cancelNote(job.job_code, row.email)}
+                  />
+                ) : (
+                  <>
+                    {row.note || ''}
+                    <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                  </>
+                )}
+              </td>
               <td>
                 <span className="badge assigned inline">Assigned</span>
                 {isRecruiter && (
@@ -678,6 +734,7 @@ if (shouldRedirect) {
             <th>Name</th>
             <th>Email</th>
             <th>Score</th>
+            <th>Note</th>
           </tr>
         </thead>
         <tbody>
@@ -686,6 +743,30 @@ if (shouldRedirect) {
               <td>{row.name}</td>
               <td>{row.email}</td>
               <td>{row.score?.toFixed(2)}</td>
+              <td>
+                {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                  <NoteEditor
+                    jobCode={job.job_code}
+                    email={row.email}
+                    initialNote={noteInputs[`${job.job_code}:${row.email}`]}
+                    onSaved={(n) => {
+                      setMatches((prev) => ({
+                        ...prev,
+                        [job.job_code]: (prev[job.job_code] || []).map((m) =>
+                          m.email === row.email ? { ...m, note: n } : m
+                        ),
+                      }));
+                      cancelNote(job.job_code, row.email);
+                    }}
+                    onCancel={() => cancelNote(job.job_code, row.email)}
+                  />
+                ) : (
+                  <>
+                    {row.note || ''}
+                    <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                  </>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/NoteEditor.js
+++ b/frontend/src/NoteEditor.js
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import api from './api';
+
+export default function NoteEditor({ jobCode, email, initialNote = '', onSaved, onCancel }) {
+  const [note, setNote] = useState(initialNote);
+
+  const save = async () => {
+    await api.post('/student-note', {
+      job_code: jobCode,
+      student_email: email,
+      note,
+    });
+    onSaved && onSaved(note);
+  };
+
+  return (
+    <div className="note-editor">
+      <textarea
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <button onClick={save}>Save</button>
+      {onCancel && <button onClick={onCancel}>Cancel</button>}
+    </div>
+  );
+}

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import NoteEditor from './NoteEditor';
+import api from './api';
+import axios from 'axios';
+
+jest.mock('axios', () => {
+  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  mockAxios.create.mockReturnValue(mockAxios);
+  return mockAxios;
+});
+
+test('saves note via API', async () => {
+  api.post.mockResolvedValue({ data: { email: 's1@example.com', note: 'hi' } });
+  render(<NoteEditor jobCode="J1" email="s1@example.com" onSaved={() => {}} />);
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hi' } });
+  fireEvent.click(screen.getByText('Save'));
+  await waitFor(() => {
+    expect(api.post).toHaveBeenCalledWith('/student-note', {
+      job_code: 'J1',
+      student_email: 's1@example.com',
+      note: 'hi',
+    });
+  });
+});

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -680,7 +680,7 @@ function StudentProfiles() {
                                           )}
                                         </td>
                                         <td>{job.status}</td>
-                                        <td>{['assigned', 'rejected'].includes(job.status) ? job.note || '' : ''}</td>
+                                        <td>{job.note || ''}</td>
                                       </tr>
                                     ))
                                   ) : (

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -797,6 +797,135 @@ def test_assign_note_persists_on_reject(monkeypatch):
     assert entry["status"] == "assigned"
     assert entry["note"] == note
 
+
+def test_student_note_unassigned(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [1.0]})]
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", lambda *a, **k: FakeResp())
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 1.0)
+
+    token = login_admin()
+
+    student = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john@example.com",
+        "phone": "123",
+        "education_level": "College",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 50.0,
+    }
+    client.post("/students", json=student, headers={"Authorization": f"Bearer {token}"})
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    job_code = resp.json()["job_code"]
+
+    note = "standalone note"
+    r = client.post(
+        "/student-note",
+        json={"job_code": job_code, "student_email": student["email"], "note": note},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+    stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
+    assert stored.get("student_notes", {}).get(student["email"]) == note
+    assert student["email"] not in stored.get("assigned_students", [])
+    assert student["email"] not in stored.get("rejected_students", [])
+    assert student["email"] not in stored.get("placed_students", [])
+    assert student["email"] not in stored.get("uninterested_students", [])
+
+
+def test_student_note_assigned(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [1.0]})]
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", lambda *a, **k: FakeResp())
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 1.0)
+
+    token = login_admin()
+
+    student = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john@example.com",
+        "phone": "123",
+        "education_level": "College",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 50.0,
+    }
+    client.post("/students", json=student, headers={"Authorization": f"Bearer {token}"})
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    job_code = resp.json()["job_code"]
+
+    client.post(
+        "/assign",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    note = "new note"
+    r = client.post(
+        "/student-note",
+        json={"job_code": job_code, "student_email": student["email"], "note": note},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+    stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
+    assert student["email"] in stored.get("assigned_students", [])
+    assert stored.get("student_notes", {}).get(student["email"]) == note
+
+    resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()["students"][0]
+    entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
+    assert entry["note"] == note
+    assert entry["status"] == "assigned"
+
     r = client.post(
         "/reject-assigned",
         json={"job_code": job_code, "student_email": student["email"]},


### PR DESCRIPTION
## Summary
- support new `POST /student-note` endpoint to save recruiter comments per job/student
- replace prompts with comment controls in match tables and display notes across statuses
- show notes on student profiles and document workflow

## Testing
- `pytest`
- `cd frontend && CI=true npm test -- --runTestsByPath src/StudentProfiles.test.js src/NoteEditor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688e6e5c7d2c8333a1a0a83980575e83