### PR TITLE
Include JWT token in NoteEditor requests

### DIFF
--- a/frontend/src/NoteEditor.js
+++ b/frontend/src/NoteEditor.js
@@ -3,13 +3,18 @@ import api from './api';
 
 export default function NoteEditor({ jobCode, email, initialNote = '', onSaved, onCancel }) {
   const [note, setNote] = useState(initialNote);
+  const token = localStorage.getItem('token');
 
   const save = async () => {
-    await api.post('/student-note', {
-      job_code: jobCode,
-      student_email: email,
-      note,
-    });
+    await api.post(
+      '/student-note',
+      {
+        job_code: jobCode,
+        student_email: email,
+        note,
+      },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
     onSaved && onSaved(note);
   };
 

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -10,15 +10,22 @@ jest.mock('axios', () => {
 });
 
 test('saves note via API', async () => {
+  const token = 'test-token';
+  localStorage.setItem('token', token);
   api.post.mockResolvedValue({ data: { email: 's1@example.com', note: 'hi' } });
   render(<NoteEditor jobCode="J1" email="s1@example.com" onSaved={() => {}} />);
   fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hi' } });
   fireEvent.click(screen.getByText('Save'));
   await waitFor(() => {
-    expect(api.post).toHaveBeenCalledWith('/student-note', {
-      job_code: 'J1',
-      student_email: 's1@example.com',
-      note: 'hi',
-    });
+    expect(api.post).toHaveBeenCalledWith(
+      '/student-note',
+      {
+        job_code: 'J1',
+        student_email: 's1@example.com',
+        note: 'hi',
+      },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
   });
+  localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- Retrieve JWT token from localStorage and attach it as a Bearer token in NoteEditor save requests
- Update NoteEditor tests to expect Authorization header with Bearer token

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688e8d5150a08333b8e642b9b372141e