### PR TITLE
Align match action controls with initial buttons

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -284,6 +284,13 @@
   color: white;
 }
 
+.action-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .job-description-panel {
   text-align: left;
   padding: 1rem 2rem;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -617,24 +617,28 @@ if (shouldRedirect) {
                     </td>
                     <td>
                       {row.status === 'placed' ? (
-                        <span className="badge placed inline">Placed</span>
+                        <div className="action-controls">
+                          <span className="badge placed inline">Placed</span>
+                        </div>
                       ) : row.status === 'assigned' ? (
-                        <>
+                        <div className="action-controls">
                           <span className="badge assigned inline">Assigned</span>
                           {!isRecruiter && (
                             <button onClick={() => handlePlace(job, row)}>Place</button>
                           )}
-                        </>
+                        </div>
                       ) : row.status === 'rejected' ? (
-                        <span className="badge rejected inline">Rejected</span>
+                        <div className="action-controls">
+                          <span className="badge rejected inline">Rejected</span>
+                        </div>
                       ) : (
-                        <>
+                        <div className="action-controls">
                           <button onClick={() => handleAssign(job, row)}>Interested</button>
                           <button onClick={() => markNotInterested(job.job_code, row.email)}>Not Interested</button>
                           {!isRecruiter && (
                             <button onClick={() => handlePlace(job, row)}>Place</button>
                           )}
-                        </>
+                        </div>
                       )}
                     </td>
                   </tr>
@@ -706,16 +710,18 @@ if (shouldRedirect) {
                 )}
               </td>
               <td>
-                <span className="badge assigned inline">Assigned</span>
-                {isRecruiter && (
-                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
-                )}
-                {!isRecruiter && (
-                  <button onClick={() => handlePlace(job, row)}>Place</button>
-                )}
-                <button onClick={() => rejectAssigned(job.job_code, row.email)}>
-                  Not Interested
-                </button>
+                <div className="action-controls">
+                  <span className="badge assigned inline">Assigned</span>
+                  {isRecruiter && (
+                    <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
+                  )}
+                  {!isRecruiter && (
+                    <button onClick={() => handlePlace(job, row)}>Place</button>
+                  )}
+                  <button onClick={() => rejectAssigned(job.job_code, row.email)}>
+                    Not Interested
+                  </button>
+                </div>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- group match action buttons with a shared `action-controls` wrapper
- style wrapper to align assigned controls with initial match buttons

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9b2ee0d483338ab0e343157f6ce4