### PR TITLE
Align job posting action buttons

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -255,6 +255,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 .badge {

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -249,6 +249,14 @@
   min-width: 120px;
 }
 
+.job-table .action-cell,
+.matches-table .action-cell {
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .badge {
   display: inline-block;
   min-width: 100px;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -615,7 +615,7 @@ if (shouldRedirect) {
                         </>
                       )}
                     </td>
-                    <td>
+                    <td className="action-cell">
                       {row.status === 'placed' ? (
                         <span className="badge placed inline">Placed</span>
                       ) : row.status === 'assigned' ? (
@@ -705,7 +705,7 @@ if (shouldRedirect) {
                   </>
                 )}
               </td>
-              <td>
+              <td className="action-cell">
                 <span className="badge assigned inline">Assigned</span>
                 {isRecruiter && (
                   <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
@@ -1023,12 +1023,12 @@ if (shouldRedirect) {
                       )}
                     </td>
                   )}
-                  <td>
-                    {(() => {
-                      const hasMatchInRedis = matchPresence[job.job_code] === true;
+                <td className="action-cell">
+                  {(() => {
+                    const hasMatchInRedis = matchPresence[job.job_code] === true;
 
-                      return hasMatchInRedis ? (
-                        <>
+                    return hasMatchInRedis ? (
+                      <>
                           <button
                             onClick={(e) => {
                               e.stopPropagation();


### PR DESCRIPTION
## Summary
- Align action buttons in job table and match subtables using shared styling

## Testing
- `python -m pytest -q`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e9e16d834833397a9dfbcb57196d3