### PR TITLE
Handle student job notes as lists

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2008,6 +2008,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
         for job in all_jobs:
             status = None
             notes = job.get("student_notes", {}).get(email, [])
+            latest_note = notes[-1]["text"] if notes else None
             if email in job.get("placed_students", []):
                 status = "placed"
             elif email in job.get("assigned_students", []):
@@ -2026,6 +2027,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
                     "job_description": job.get("job_description"),
                     "status": status,
                     "notes": notes,
+                    **({"note": latest_note} if latest_note is not None else {}),
                 })
 
         info["assigned_jobs"] = jobs_list
@@ -2096,6 +2098,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
         for job in all_jobs:
             status = None
             notes = job.get("student_notes", {}).get(email, [])
+            latest_note = notes[-1]["text"] if notes else None
             if email in job.get("placed_students", []):
                 status = "placed"
             elif email in job.get("assigned_students", []):
@@ -2114,6 +2117,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
                     "job_description": job.get("job_description"),
                     "status": status,
                     "notes": notes,
+                    **({"note": latest_note} if latest_note is not None else {}),
                 })
 
         info["assigned_jobs"] = jobs_list
@@ -2152,6 +2156,7 @@ def student_me(current_user: dict = Depends(get_current_user)):
             continue
         status = None
         notes = job.get("student_notes", {}).get(email, [])
+        latest_note = notes[-1]["text"] if notes else None
         if email in job.get("placed_students", []):
             placed += 1
             status = "placed"
@@ -2171,6 +2176,7 @@ def student_me(current_user: dict = Depends(get_current_user)):
                 "job_description": job.get("job_description"),
                 "status": status,
                 "notes": notes,
+                **({"note": latest_note} if latest_note is not None else {}),
             })
 
     info = {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -601,7 +601,13 @@ if (shouldRedirect) {
                             setMatches((prev) => ({
                               ...prev,
                               [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                                m.email === row.email ? { ...m, note: n } : m
+                                m.email === row.email
+                                  ? {
+                                      ...m,
+                                      note: n,
+                                      notes: [...(m.notes || []), { text: n }],
+                                    }
+                                  : m
                               ),
                             }));
                             cancelNote(job.job_code, row.email);
@@ -610,8 +616,22 @@ if (shouldRedirect) {
                         />
                       ) : (
                         <>
-                          {row.note || ''}
-                          <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                          {row.notes && row.notes.length
+                            ? row.notes[row.notes.length - 1].text
+                            : row.note || ''}
+                          <button
+                            onClick={() =>
+                              startNote(
+                                job.job_code,
+                                row.email,
+                                row.notes && row.notes.length
+                                  ? row.notes[row.notes.length - 1].text
+                                  : row.note
+                              )
+                            }
+                          >
+                            Comment
+                          </button>
                         </>
                       )}
                     </td>
@@ -691,7 +711,13 @@ if (shouldRedirect) {
                       setMatches((prev) => ({
                         ...prev,
                         [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                          m.email === row.email ? { ...m, note: n } : m
+                          m.email === row.email
+                            ? {
+                                ...m,
+                                note: n,
+                                notes: [...(m.notes || []), { text: n }],
+                              }
+                            : m
                         ),
                       }));
                       cancelNote(job.job_code, row.email);
@@ -700,8 +726,22 @@ if (shouldRedirect) {
                   />
                 ) : (
                   <>
-                    {row.note || ''}
-                    <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                    {row.notes && row.notes.length
+                      ? row.notes[row.notes.length - 1].text
+                      : row.note || ''}
+                    <button
+                      onClick={() =>
+                        startNote(
+                          job.job_code,
+                          row.email,
+                          row.notes && row.notes.length
+                            ? row.notes[row.notes.length - 1].text
+                            : row.note
+                        )
+                      }
+                    >
+                      Comment
+                    </button>
                   </>
                 )}
               </td>
@@ -753,7 +793,13 @@ if (shouldRedirect) {
                       setMatches((prev) => ({
                         ...prev,
                         [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                          m.email === row.email ? { ...m, note: n } : m
+                          m.email === row.email
+                            ? {
+                                ...m,
+                                note: n,
+                                notes: [...(m.notes || []), { text: n }],
+                              }
+                            : m
                         ),
                       }));
                       cancelNote(job.job_code, row.email);
@@ -762,8 +808,22 @@ if (shouldRedirect) {
                   />
                 ) : (
                   <>
-                    {row.note || ''}
-                    <button onClick={() => startNote(job.job_code, row.email, row.note)}>Comment</button>
+                    {row.notes && row.notes.length
+                      ? row.notes[row.notes.length - 1].text
+                      : row.note || ''}
+                    <button
+                      onClick={() =>
+                        startNote(
+                          job.job_code,
+                          row.email,
+                          row.notes && row.notes.length
+                            ? row.notes[row.notes.length - 1].text
+                            : row.note
+                        )
+                      }
+                    >
+                      Comment
+                    </button>
                   </>
                 )}
               </td>

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -12,7 +12,7 @@ jest.mock('axios', () => {
 test('saves note via API', async () => {
   const token = 'test-token';
   localStorage.setItem('token', token);
-  api.post.mockResolvedValue({ data: { email: 's1@example.com', note: 'hi' } });
+  api.post.mockResolvedValue({ data: { email: 's1@example.com', notes: [{ text: 'hi' }] } });
   render(<NoteEditor jobCode="J1" email="s1@example.com" onSaved={() => {}} />);
   fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hi' } });
   fireEvent.click(screen.getByText('Save'));

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -680,7 +680,11 @@ function StudentProfiles() {
                                           )}
                                         </td>
                                         <td>{job.status}</td>
-                                        <td>{job.note || ''}</td>
+                                        <td>
+                                          {job.notes && job.notes.length
+                                            ? job.notes[job.notes.length - 1].text
+                                            : job.note || ''}
+                                        </td>
                                       </tr>
                                     ))
                                   ) : (


### PR DESCRIPTION
## Summary
- Return each job's list of student notes and legacy last note for student listing routes
- Update student profile and job posting pages to read note lists with backward compatibility
- Adjust NoteEditor test to reflect new notes payload

## Testing
- `pytest`
- `npm test --prefix frontend --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ea1413a2c83339ba2035e5293da00