### PR TITLE
feat: add notes history modal to student profiles

### DIFF
--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+function NotesHistoryModal({ notes = [], onClose }) {
+  return (
+    <div className="notes-modal-overlay">
+      <div className="notes-modal">
+        <button className="close-button" onClick={onClose}>X</button>
+        <h3>Notes History</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {notes.length > 0 ? (
+              notes.map((n, idx) => (
+                <tr key={idx}>
+                  <td>{idx + 1}</td>
+                  <td>{n.text}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan="2">No notes available.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default NotesHistoryModal;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -415,3 +415,70 @@
   color: #333;
 }
 
+.view-notes-btn {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.view-notes-btn:hover {
+  background-color: #005fa3;
+}
+
+.notes-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.notes-modal {
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow-y: auto;
+  min-width: 300px;
+  color: #002244;
+}
+
+.notes-modal table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.notes-modal th,
+.notes-modal td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+
+.notes-modal th {
+  background-color: #003366;
+  color: white;
+}
+
+.notes-modal td {
+  background-color: white;
+  color: black;
+}
+
+.notes-modal .close-button {
+  float: right;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -7,6 +7,7 @@ import AdminMenu from './AdminMenu';
 import jwt_decode from 'jwt-decode';
 import './StudentProfiles.css';
 import './Tour.css';
+import NotesHistoryModal from './NotesHistoryModal';
 
 function StudentProfiles() {
   const [formData, setFormData] = useState({
@@ -91,6 +92,7 @@ function StudentProfiles() {
   const [jobDescriptionStatus, setJobDescriptionStatus] = useState({});
 
   const [expandedRows, setExpandedRows] = useState({});
+  const [modalNotes, setModalNotes] = useState(null);
 
   const handleTourCallback = (data) => {
     const { status, type } = data;
@@ -681,9 +683,14 @@ function StudentProfiles() {
                                         </td>
                                         <td>{job.status}</td>
                                         <td>
-                                          {job.notes && job.notes.length
-                                            ? job.notes[job.notes.length - 1].text
-                                            : job.note || ''}
+                                          <button
+                                            className="view-notes-btn"
+                                            onClick={() => setModalNotes(job.notes || [])}
+                                            type="button"
+                                          >
+                                            View Notes
+                                            {job.notes && ` (${job.notes.length})`}
+                                          </button>
                                         </td>
                                       </tr>
                                     ))
@@ -709,6 +716,12 @@ function StudentProfiles() {
         </div>
         )}
       </div>
+      {modalNotes && (
+        <NotesHistoryModal
+          notes={modalNotes}
+          onClose={() => setModalNotes(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import StudentProfiles from './StudentProfiles';
 import { BrowserRouter } from 'react-router-dom';
 import api from './api';
@@ -21,4 +21,45 @@ test('renders StudentProfiles without errors', () => {
       </BrowserRouter>
     );
   }).not.toThrow();
+});
+
+test('opens notes history modal when View Notes clicked', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  api.get.mockResolvedValueOnce({
+    data: {
+      students: [
+        {
+          first_name: 'F',
+          last_name: 'L',
+          email: 's@example.com',
+          institutional_code: 'ABC',
+          assigned_jobs: [
+            {
+              job_code: 'J1',
+              job_title: 'Job 1',
+              status: 'open',
+              notes: [{ text: 'Test note' }]
+            }
+          ],
+          placed_jobs: []
+        }
+      ]
+    }
+  });
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  const expand = await screen.findByTitle('Expand');
+  fireEvent.click(expand);
+  const viewNotes = await screen.findByText(/View Notes/);
+  fireEvent.click(viewNotes);
+  expect(await screen.findByText('Test note')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('X'));
+  await waitFor(() => {
+    expect(screen.queryByText('Test note')).not.toBeInTheDocument();
+  });
+  localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- replace recruiter note cell with a "View Notes" button
- add `NotesHistoryModal` component to display job notes
- style modal and button for a consistent look

## Testing
- `cd frontend && CI=true npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea3c19488833385cdf1d5c4376557