### PR TITLE
Start note editor blank and refresh note histories

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -38,7 +38,7 @@ function JobPosting() {
   const [generatedResumes, setGeneratedResumes] = useState({});
   const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
-  const [noteInputs, setNoteInputs] = useState({});
+  const [editingNotes, setEditingNotes] = useState({});
 
   const locationRef = useRef(null);
 
@@ -362,12 +362,12 @@ if (shouldRedirect) {
     }
   };
 
-  const startNote = (jobCode, email, current) => {
-    setNoteInputs((prev) => ({ ...prev, [`${jobCode}:${email}`]: current || '' }));
+  const startNote = (jobCode, email) => {
+    setEditingNotes((prev) => ({ ...prev, [`${jobCode}:${email}`]: true }));
   };
 
   const cancelNote = (jobCode, email) => {
-    setNoteInputs((prev) => {
+    setEditingNotes((prev) => {
       const key = `${jobCode}:${email}`;
       const copy = { ...prev };
       delete copy[key];
@@ -593,25 +593,24 @@ if (shouldRedirect) {
                       )}
                     </td>
                     <td>
-                      {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                      {editingNotes[`${job.job_code}:${row.email}`] ? (
                         <NoteEditor
                           jobCode={job.job_code}
                           email={row.email}
-                          initialNote={noteInputs[`${job.job_code}:${row.email}`]}
-                          onSaved={(n) => {
+                          notes={row.notes || []}
+                          onSaved={(newNote) => {
                             setMatches((prev) => ({
                               ...prev,
                               [job.job_code]: (prev[job.job_code] || []).map((m) =>
                                 m.email === row.email
                                   ? {
                                       ...m,
-                                      note: n,
-                                      notes: [...(m.notes || []), { text: n }],
+                                      note: newNote.text,
+                                      notes: [...(m.notes || []), newNote],
                                     }
                                   : m
                               ),
                             }));
-                            cancelNote(job.job_code, row.email);
                           }}
                           onCancel={() => cancelNote(job.job_code, row.email)}
                         />
@@ -620,17 +619,7 @@ if (shouldRedirect) {
                           {row.notes && row.notes.length
                             ? row.notes[row.notes.length - 1].text
                             : row.note || ''}
-                          <button
-                            onClick={() =>
-                              startNote(
-                                job.job_code,
-                                row.email,
-                                row.notes && row.notes.length
-                                  ? row.notes[row.notes.length - 1].text
-                                  : row.note
-                              )
-                            }
-                          >
+                          <button onClick={() => startNote(job.job_code, row.email)}>
                             Comment
                           </button>
                         </>
@@ -705,25 +694,24 @@ if (shouldRedirect) {
                 )}
               </td>
               <td>
-                {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                {editingNotes[`${job.job_code}:${row.email}`] ? (
                   <NoteEditor
                     jobCode={job.job_code}
                     email={row.email}
-                    initialNote={noteInputs[`${job.job_code}:${row.email}`]}
-                    onSaved={(n) => {
+                    notes={row.notes || []}
+                    onSaved={(newNote) => {
                       setMatches((prev) => ({
                         ...prev,
                         [job.job_code]: (prev[job.job_code] || []).map((m) =>
                           m.email === row.email
                             ? {
                                 ...m,
-                                note: n,
-                                notes: [...(m.notes || []), { text: n }],
+                                note: newNote.text,
+                                notes: [...(m.notes || []), newNote],
                               }
                             : m
                         ),
                       }));
-                      cancelNote(job.job_code, row.email);
                     }}
                     onCancel={() => cancelNote(job.job_code, row.email)}
                   />
@@ -732,17 +720,7 @@ if (shouldRedirect) {
                     {row.notes && row.notes.length
                       ? row.notes[row.notes.length - 1].text
                       : row.note || ''}
-                    <button
-                      onClick={() =>
-                        startNote(
-                          job.job_code,
-                          row.email,
-                          row.notes && row.notes.length
-                            ? row.notes[row.notes.length - 1].text
-                            : row.note
-                        )
-                      }
-                    >
+                    <button onClick={() => startNote(job.job_code, row.email)}>
                       Comment
                     </button>
                   </>
@@ -789,25 +767,24 @@ if (shouldRedirect) {
               <td>{row.email}</td>
               <td>{row.score?.toFixed(2)}</td>
               <td>
-                {noteInputs[`${job.job_code}:${row.email}`] !== undefined ? (
+                {editingNotes[`${job.job_code}:${row.email}`] ? (
                   <NoteEditor
                     jobCode={job.job_code}
                     email={row.email}
-                    initialNote={noteInputs[`${job.job_code}:${row.email}`]}
-                    onSaved={(n) => {
+                    notes={row.notes || []}
+                    onSaved={(newNote) => {
                       setMatches((prev) => ({
                         ...prev,
                         [job.job_code]: (prev[job.job_code] || []).map((m) =>
                           m.email === row.email
                             ? {
                                 ...m,
-                                note: n,
-                                notes: [...(m.notes || []), { text: n }],
+                                note: newNote.text,
+                                notes: [...(m.notes || []), newNote],
                               }
                             : m
                         ),
                       }));
-                      cancelNote(job.job_code, row.email);
                     }}
                     onCancel={() => cancelNote(job.job_code, row.email)}
                   />
@@ -816,17 +793,7 @@ if (shouldRedirect) {
                     {row.notes && row.notes.length
                       ? row.notes[row.notes.length - 1].text
                       : row.note || ''}
-                    <button
-                      onClick={() =>
-                        startNote(
-                          job.job_code,
-                          row.email,
-                          row.notes && row.notes.length
-                            ? row.notes[row.notes.length - 1].text
-                            : row.note
-                        )
-                      }
-                    >
+                    <button onClick={() => startNote(job.job_code, row.email)}>
                       Comment
                     </button>
                   </>

--- a/frontend/src/NoteEditor.js
+++ b/frontend/src/NoteEditor.js
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import api from './api';
 
-export default function NoteEditor({ jobCode, email, initialNote = '', onSaved, onCancel }) {
-  const [note, setNote] = useState(initialNote);
+export default function NoteEditor({ jobCode, email, notes = [], onSaved, onCancel }) {
+  const [note, setNote] = useState('');
   const token = localStorage.getItem('token');
 
   const save = async () => {
-    await api.post(
+    const resp = await api.post(
       '/student-note',
       {
         job_code: jobCode,
@@ -15,7 +15,9 @@ export default function NoteEditor({ jobCode, email, initialNote = '', onSaved, 
       },
       { headers: { Authorization: `Bearer ${token}` } }
     );
-    onSaved && onSaved(note);
+    const newNote = resp.data.notes[resp.data.notes.length - 1];
+    setNote('');
+    onSaved && onSaved(newNote);
   };
 
   return (
@@ -26,6 +28,15 @@ export default function NoteEditor({ jobCode, email, initialNote = '', onSaved, 
       />
       <button onClick={save}>Save</button>
       {onCancel && <button onClick={onCancel}>Cancel</button>}
+      {notes.length > 0 && (
+        <div className="note-history">
+          {notes.map((n, i) => (
+            <div key={i} className="note-history-item">
+              {n.text}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -13,7 +13,10 @@ test('saves note via API', async () => {
   const token = 'test-token';
   localStorage.setItem('token', token);
   api.post.mockResolvedValue({ data: { email: 's1@example.com', notes: [{ text: 'hi' }] } });
-  render(<NoteEditor jobCode="J1" email="s1@example.com" onSaved={() => {}} />);
+  const onSaved = jest.fn();
+  render(
+    <NoteEditor jobCode="J1" email="s1@example.com" onSaved={onSaved} notes={[]} />
+  );
   fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hi' } });
   fireEvent.click(screen.getByText('Save'));
   await waitFor(() => {
@@ -26,6 +29,8 @@ test('saves note via API', async () => {
       },
       { headers: { Authorization: `Bearer ${token}` } }
     );
+    expect(onSaved).toHaveBeenCalledWith({ text: 'hi' });
+    expect(screen.getByRole('textbox').value).toBe('');
   });
   localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- Start `NoteEditor` with an empty textarea and show read-only note history
- Clear the input and return the new note object after saving
- Update recruiter views to keep the editor open and append saved notes to history

## Testing
- `CI=true npm test -- src/NoteEditor.test.js --runInBand`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebc50b8608333b6b81f6f25bc081c