### PR TITLE
feat: handle legacy school codes in student lookups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1997,7 +1997,8 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
             "skills": student.get("skills"),
             "experience_summary": student.get("experience_summary"),
             "interests": student.get("interests"),
-            "institutional_code": student.get("institutional_code"),  # ✅ Added
+            "institutional_code": student.get("institutional_code")
+            or student.get("school_code"),
             "assigned_jobs": [],
             "placed_jobs": 0,
             "assigned_job_code": None,
@@ -2051,7 +2052,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
     except Exception:
         raise HTTPException(status_code=500, detail="Corrupted user data")
 
-    institutional_code = user.get("institutional_code")
+    institutional_code = user.get("institutional_code") or user.get("school_code")
 
     # Gather all job data once
     all_jobs = []
@@ -2076,7 +2077,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
         except Exception:
             continue
 
-        if student.get("institutional_code") != institutional_code:
+        if (student.get("institutional_code") or student.get("school_code")) != institutional_code:
             continue
 
         email = student.get("email")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from jose import jwt
 import json
 import app.main as main_app
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 class DummyRedis:
@@ -1574,4 +1574,46 @@ def test_match_metrics_increment(monkeypatch):
     queue = float(main_app.redis_client.get("metrics:match_queue_time") or 0)
     assert process > 0
     assert queue >= 0
+
+
+def test_students_by_school_fallback():
+    main_app.redis_client.flushdb()
+
+    user = {
+        "role": "career",
+        "approved": True,
+        "school_code": "1001",
+    }
+    main_app.redis_client.set("user:counselor@example.com", json.dumps(user))
+
+    student = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "student@example.com",
+        "phone": "123",
+        "education_level": "HS",
+        "skills": [],
+        "experience_summary": "",
+        "interests": "",
+        "school_code": "1001",
+    }
+    main_app.redis_client.set("student:student@example.com", json.dumps(student))
+
+    token = jwt.encode(
+        {
+            "sub": "counselor@example.com",
+            "role": "career",
+            "exp": datetime.utcnow() + timedelta(hours=1),
+        },
+        JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+
+    resp = client.get(
+        "/students/by-school",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(s["email"] == "student@example.com" for s in data["students"])
 


### PR DESCRIPTION
## Summary
- support `school_code` fallback in `/students/by-school`
- include legacy code in `/students/all` responses
- add regression test for users with only `school_code`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec71ef20483338d618d6cd6da8fa4