### PR TITLE
Handle missing institutional code in students_by_school

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2053,6 +2053,8 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=500, detail="Corrupted user data")
 
     institutional_code = user.get("institutional_code") or user.get("school_code")
+    if not institutional_code:
+        raise HTTPException(status_code=400, detail="Institutional code required")
 
     # Gather all job data once
     all_jobs = []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1617,3 +1617,30 @@ def test_students_by_school_fallback():
     data = resp.json()
     assert any(s["email"] == "student@example.com" for s in data["students"])
 
+
+def test_students_by_school_requires_code():
+    main_app.redis_client.flushdb()
+
+    user = {
+        "role": "career",
+        "approved": True,
+    }
+    main_app.redis_client.set("user:counselor@example.com", json.dumps(user))
+
+    token = jwt.encode(
+        {
+            "sub": "counselor@example.com",
+            "role": "career",
+            "exp": datetime.utcnow() + timedelta(hours=1),
+        },
+        JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+
+    resp = client.get(
+        "/students/by-school",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Institutional code required"
+


### PR DESCRIPTION
## Summary
- raise HTTP 400 when counselor has neither institutional_code nor school_code
- add test to ensure students-by-school endpoint requires institutional code

## Testing
- `pytest tests/test_main.py::test_students_by_school_requires_code tests/test_main.py::test_students_by_school_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec91bc78483339895078e8043f510