### PR TITLE
Add Redis backfill script for institutional codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,20 @@ Match jobs record queue and processing time in Redis. The `/metrics` endpoint ex
 The `/generate-resume` endpoint accepts an optional `preview` flag. When `true`,
 the generated resume includes placeholder contact information and does not
 require the student to be listed in `assigned_students` for the job.
+
+## Backfilling Institutional Codes
+
+Some legacy records may still use the `school_code` field instead of the
+preferred `institutional_code`. A one-time script is provided to copy any
+missing `institutional_code` values from `school_code` for both user and student
+records stored in Redis.
+
+Run the script with:
+
+```bash
+export REDIS_URL=redis://localhost:6379/0  # or your instance
+python scripts/backfill_codes.py
+```
+
+The script scans all `user:*` and `student:*` keys and updates records where
+`institutional_code` is absent but `school_code` exists.

--- a/scripts/backfill_codes.py
+++ b/scripts/backfill_codes.py
@@ -1,0 +1,34 @@
+import os
+import json
+import redis
+
+
+def backfill_institutional_codes():
+    """Copy school_code to institutional_code for user and student records."""
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        raise RuntimeError("Missing REDIS_URL")
+
+    client = redis.Redis.from_url(redis_url, decode_responses=True)
+    total_updated = 0
+
+    for pattern in ("user:*", "student:*"):
+        for key in client.scan_iter(pattern):
+            raw = client.get(key)
+            if not raw:
+                continue
+            try:
+                data = json.loads(raw)
+            except Exception:
+                continue
+            inst = data.get("institutional_code")
+            school = data.get("school_code")
+            if (not inst) and school:
+                data["institutional_code"] = school
+                client.set(key, json.dumps(data))
+                total_updated += 1
+    print(f"Backfill complete. Updated {total_updated} records.")
+
+
+if __name__ == "__main__":
+    backfill_institutional_codes()


### PR DESCRIPTION
## Summary
- add one-time script to copy `school_code` into `institutional_code` for Redis user and student records
- document running the backfill script in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eca0b0b9c8333aee3d5df59a9f6f6