### PR TITLE
Handle non-string values in backfill script

### DIFF
--- a/scripts/backfill_codes.py
+++ b/scripts/backfill_codes.py
@@ -14,7 +14,12 @@ def backfill_institutional_codes():
 
     for pattern in ("user:*", "student:*"):
         for key in client.scan_iter(pattern):
-            raw = client.get(key)
+            if client.type(key) != "string":
+                continue
+            try:
+                raw = client.get(key)
+            except redis.exceptions.ResponseError:
+                continue
             if not raw:
                 continue
             try:
@@ -25,7 +30,10 @@ def backfill_institutional_codes():
             school = data.get("school_code")
             if (not inst) and school:
                 data["institutional_code"] = school
-                client.set(key, json.dumps(data))
+                try:
+                    client.set(key, json.dumps(data))
+                except redis.exceptions.ResponseError:
+                    continue
                 total_updated += 1
     print(f"Backfill complete. Updated {total_updated} records.")
 


### PR DESCRIPTION
## Summary
- guard Redis key access by skipping non-string keys
- parse JSON values and safely write back with `client.set`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed88d96f483338e5bb52d49f2c44e