### PR TITLE
Handle legacy string notes in student endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1962,6 +1962,16 @@ def delete_student(email: str, current_user: dict = Depends(get_current_user)):
 
     return {"message": f"Student {email} and related data deleted successfully"}
 
+
+def _normalize_notes(value):
+    """Return a list of note objects and the latest note text."""
+    if isinstance(value, str):
+        return [{"text": value}], value
+    if isinstance(value, list):
+        latest = value[-1].get("text") if value else None
+        return value, latest
+    return [], None
+
 @app.get("/students/all")
 def get_all_students(current_user: dict = Depends(get_current_user)):
     if current_user.get("role") != "admin":
@@ -2010,8 +2020,8 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
         jobs_list = []
         for job in all_jobs:
             status = None
-            notes = job.get("student_notes", {}).get(email, [])
-            latest_note = notes[-1]["text"] if notes else None
+            notes_raw = job.get("student_notes", {}).get(email, [])
+            notes, latest_note = _normalize_notes(notes_raw)
             if email in job.get("placed_students", []):
                 status = "placed"
             elif email in job.get("assigned_students", []):
@@ -2102,8 +2112,8 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
         jobs_list = []
         for job in all_jobs:
             status = None
-            notes = job.get("student_notes", {}).get(email, [])
-            latest_note = notes[-1]["text"] if notes else None
+            notes_raw = job.get("student_notes", {}).get(email, [])
+            notes, latest_note = _normalize_notes(notes_raw)
             if email in job.get("placed_students", []):
                 status = "placed"
             elif email in job.get("assigned_students", []):
@@ -2160,8 +2170,8 @@ def student_me(current_user: dict = Depends(get_current_user)):
         except Exception:
             continue
         status = None
-        notes = job.get("student_notes", {}).get(email, [])
-        latest_note = notes[-1]["text"] if notes else None
+        notes_raw = job.get("student_notes", {}).get(email, [])
+        notes, latest_note = _normalize_notes(notes_raw)
         if email in job.get("placed_students", []):
             placed += 1
             status = "placed"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1644,3 +1644,70 @@ def test_students_by_school_requires_code():
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Institutional code required"
 
+
+def test_student_endpoints_handle_string_notes():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "student@example.com",
+        "institutional_code": "001",
+    }
+    main_app.redis_client.set("student:student@example.com", json.dumps(student))
+
+    job = {
+        "job_code": "J1",
+        "job_title": "Test",
+        "student_notes": {"student@example.com": "legacy"},
+        "assigned_students": ["student@example.com"],
+    }
+    main_app.redis_client.set("job:J1", json.dumps(job))
+
+    login_resp = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    )
+    token_admin = login_resp.json()["token"]
+    resp_all = client.get(
+        "/students/all", headers={"Authorization": f"Bearer {token_admin}"}
+    )
+    entry = resp_all.json()["students"][0]["assigned_jobs"][0]
+    assert entry["notes"] == [{"text": "legacy"}]
+    assert entry["note"] == "legacy"
+
+    counselor = {"role": "career", "approved": True, "institutional_code": "001"}
+    main_app.redis_client.set("user:counselor@example.com", json.dumps(counselor))
+    token_counselor = jwt.encode(
+        {
+            "sub": "counselor@example.com",
+            "role": "career",
+            "exp": datetime.utcnow() + timedelta(hours=1),
+        },
+        JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+    resp_school = client.get(
+        "/students/by-school",
+        headers={"Authorization": f"Bearer {token_counselor}"},
+    )
+    entry = resp_school.json()["students"][0]["assigned_jobs"][0]
+    assert entry["notes"] == [{"text": "legacy"}]
+    assert entry["note"] == "legacy"
+
+    token_student = jwt.encode(
+        {
+            "sub": "student@example.com",
+            "role": "applicant",
+            "exp": datetime.utcnow() + timedelta(hours=1),
+        },
+        JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+    resp_me = client.get(
+        "/students/me", headers={"Authorization": f"Bearer {token_student}"}
+    )
+    entry = resp_me.json()["assigned_jobs"][0]
+    assert entry["notes"] == [{"text": "legacy"}]
+    assert entry["note"] == "legacy"
+


### PR DESCRIPTION
## Summary
- Normalize job `student_notes` to support both legacy string notes and new list format
- Update `/students/all`, `/students/by-school`, and `/students/me` to use normalized notes
- Add regression test ensuring endpoints handle legacy string notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eecb707908333a1934a11d09c51c1