### PR TITLE
Add robust error handling for student notes and storage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1409,11 +1409,19 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
     student_email = data["student_email"]
     note = data.get("note")
     key = f"job:{job_code}"
-    raw = redis_client.get(key)
+    try:
+        raw = redis_client.get(key)
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     if not raw:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    job = json.loads(raw)
+    try:
+        job = json.loads(raw)
+        if not isinstance(job, dict):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid student_notes format")
     job.setdefault("assigned_students", [])
     if student_email not in job["assigned_students"]:
         job["assigned_students"].append(student_email)
@@ -1428,17 +1436,22 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
         if isinstance(raw_notes, str):
             try:
                 notes_map = json.loads(raw_notes)
-            except Exception:
-                notes_map = {}
+                if not isinstance(notes_map, dict):
+                    raise ValueError
+            except (json.JSONDecodeError, ValueError):
+                raise HTTPException(status_code=400, detail="Invalid student_notes format")
         elif isinstance(raw_notes, dict):
             notes_map = raw_notes
         else:
-            notes_map = {}
+            raise HTTPException(status_code=400, detail="Invalid student_notes format")
 
         notes_map.setdefault(student_email, []).append(note_obj)
         job["student_notes"] = notes_map
 
-    redis_client.set(key, json.dumps(job))
+    try:
+        redis_client.set(key, json.dumps(job))
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     resp = {"message": f"Assigned {student_email}"}
     if note is not None:
         resp["notes"] = job["student_notes"][student_email]
@@ -1455,11 +1468,19 @@ def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_u
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
 
     key = f"job:{job_code}"
-    raw = redis_client.get(key)
+    try:
+        raw = redis_client.get(key)
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     if not raw:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    job = json.loads(raw)
+    try:
+        job = json.loads(raw)
+        if not isinstance(job, dict):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid student_notes format")
     job.setdefault("assigned_students", [])
     job.setdefault("rejected_students", [])
 
@@ -1478,17 +1499,22 @@ def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_u
         if isinstance(raw_notes, str):
             try:
                 notes_map = json.loads(raw_notes)
-            except Exception:
-                notes_map = {}
+                if not isinstance(notes_map, dict):
+                    raise ValueError
+            except (json.JSONDecodeError, ValueError):
+                raise HTTPException(status_code=400, detail="Invalid student_notes format")
         elif isinstance(raw_notes, dict):
             notes_map = raw_notes
         else:
-            notes_map = {}
+            raise HTTPException(status_code=400, detail="Invalid student_notes format")
 
         notes_map.setdefault(student_email, []).append(note_obj)
         job["student_notes"] = notes_map
 
-    redis_client.set(key, json.dumps(job))
+    try:
+        redis_client.set(key, json.dumps(job))
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     resp = {"message": "Student rejected"}
     if note is not None:
         resp["notes"] = job["student_notes"][student_email]
@@ -1505,11 +1531,19 @@ def student_note(data: dict, token_data: dict = Depends(get_current_user)):
         raise HTTPException(status_code=400, detail="Missing job_code, student_email, or note")
 
     key = f"job:{job_code}"
-    raw = redis_client.get(key)
+    try:
+        raw = redis_client.get(key)
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     if not raw:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    job = json.loads(raw)
+    try:
+        job = json.loads(raw)
+        if not isinstance(job, dict):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid student_notes format")
 
     # Ensure student_notes is a dict; handle both dict and JSON string forms
     raw_notes = job.get("student_notes", {})
@@ -1517,13 +1551,13 @@ def student_note(data: dict, token_data: dict = Depends(get_current_user)):
         try:
             notes_map = json.loads(raw_notes)
             if not isinstance(notes_map, dict):
-                notes_map = {}
-        except json.JSONDecodeError:
-            notes_map = {}
+                raise ValueError
+        except (json.JSONDecodeError, ValueError):
+            raise HTTPException(status_code=400, detail="Invalid student_notes format")
     elif isinstance(raw_notes, dict):
         notes_map = raw_notes
     else:
-        notes_map = {}
+        raise HTTPException(status_code=400, detail="Invalid student_notes format")
 
     note_obj = {
         "text": note,
@@ -1533,7 +1567,10 @@ def student_note(data: dict, token_data: dict = Depends(get_current_user)):
     notes_map.setdefault(student_email, []).append(note_obj)
     job["student_notes"] = notes_map
 
-    redis_client.set(key, json.dumps(job))
+    try:
+        redis_client.set(key, json.dumps(job))
+    except redis.exceptions.RedisError:
+        raise HTTPException(status_code=503, detail="Storage unavailable")
     return {"email": student_email, "notes": notes_map[student_email]}
 
 


### PR DESCRIPTION
## Summary
- Guard `/assign`, `/reject-assigned`, and `/student-note` routes against Redis failures
- Validate JSON structures for jobs and notes, returning 400 on malformed data
- Ensure responses are consistently JSON for CORS compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f7e91d47483338b4886fb0b6c6778