### PR TITLE
feat: manage notes in modal

### DIFF
--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -1,29 +1,126 @@
-import React from 'react';
+import React, { useState } from 'react';
+import api from './api';
+import NoteEditor from './NoteEditor';
 
-function NotesHistoryModal({ notes = [], onClose }) {
+function NotesHistoryModal({ notes = [], onClose, isAdmin = false, jobCode, studentEmail }) {
+  const [localNotes, setLocalNotes] = useState(notes);
+  const [adding, setAdding] = useState(false);
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editText, setEditText] = useState('');
+  const token = localStorage.getItem('token');
+
+  const handleAddSaved = (newNote) => {
+    setLocalNotes(prev => [...prev, newNote]);
+    setAdding(false);
+  };
+
+  const startEdit = (idx) => {
+    setEditingIndex(idx);
+    setEditText(localNotes[idx].text);
+  };
+
+  const cancelEdit = () => {
+    setEditingIndex(null);
+    setEditText('');
+  };
+
+  const saveEdit = async () => {
+    try {
+      const resp = await api.put(
+        '/student-note',
+        {
+          job_code: jobCode,
+          student_email: studentEmail,
+          index: editingIndex,
+          note: editText,
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      const updated = resp.data?.notes;
+      if (Array.isArray(updated)) {
+        setLocalNotes(updated);
+      } else {
+        setLocalNotes(prev =>
+          prev.map((n, i) => (i === editingIndex ? { ...n, text: editText } : n))
+        );
+      }
+      cancelEdit();
+    } catch (err) {
+      console.error('Failed to edit note', err);
+    }
+  };
+
+  const deleteNote = async (idx) => {
+    try {
+      await api.delete('/student-note', {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { job_code: jobCode, student_email: studentEmail, index: idx },
+      });
+      setLocalNotes(prev => prev.filter((_, i) => i !== idx));
+    } catch (err) {
+      console.error('Failed to delete note', err);
+    }
+  };
+
   return (
     <div className="notes-modal-overlay">
       <div className="notes-modal">
         <button className="close-button" onClick={onClose}>X</button>
         <h3>Notes History</h3>
+        {isAdmin && !adding && (
+          <button onClick={() => setAdding(true)}>Add Note</button>
+        )}
+        {isAdmin && adding && (
+          <NoteEditor
+            jobCode={jobCode}
+            email={studentEmail}
+            onSaved={handleAddSaved}
+            onCancel={() => setAdding(false)}
+          />
+        )}
         <table>
           <thead>
             <tr>
               <th>#</th>
               <th>Note</th>
+              {isAdmin && <th>Actions</th>}
             </tr>
           </thead>
           <tbody>
-            {notes.length > 0 ? (
-              notes.map((n, idx) => (
+            {localNotes.length > 0 ? (
+              localNotes.map((n, idx) => (
                 <tr key={idx}>
                   <td>{idx + 1}</td>
-                  <td>{n.text}</td>
+                  <td>
+                    {editingIndex === idx ? (
+                      <textarea
+                        value={editText}
+                        onChange={(e) => setEditText(e.target.value)}
+                      />
+                    ) : (
+                      n.text
+                    )}
+                  </td>
+                  {isAdmin && (
+                    <td>
+                      {editingIndex === idx ? (
+                        <>
+                          <button onClick={saveEdit}>Save</button>
+                          <button onClick={cancelEdit}>Cancel</button>
+                        </>
+                      ) : (
+                        <>
+                          <button onClick={() => startEdit(idx)}>Edit</button>
+                          <button onClick={() => deleteNote(idx)}>Delete</button>
+                        </>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))
             ) : (
               <tr>
-                <td colSpan="2">No notes available.</td>
+                <td colSpan={isAdmin ? 3 : 2}>No notes available.</td>
               </tr>
             )}
           </tbody>

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -133,6 +133,7 @@ function StudentProfiles() {
     decoded = {};
   }
   const userRole = decoded?.role;
+  const isAdmin = userRole === 'admin';
 
   const fetchStudents = async () => {
     setIsLoading(true);
@@ -714,7 +715,13 @@ function StudentProfiles() {
                                         <td>
                                           <button
                                             className="view-notes-btn"
-                                            onClick={() => setModalNotes(job.notes || [])}
+                                            onClick={() =>
+                                              setModalNotes({
+                                                notes: job.notes || [],
+                                                jobCode: job.job_code,
+                                                studentEmail: s.email,
+                                              })
+                                              }
                                             type="button"
                                           >
                                             View Notes
@@ -747,7 +754,10 @@ function StudentProfiles() {
       </div>
       {modalNotes && (
         <NotesHistoryModal
-          notes={modalNotes}
+          notes={modalNotes.notes}
+          jobCode={modalNotes.jobCode}
+          studentEmail={modalNotes.studentEmail}
+          isAdmin={isAdmin}
           onClose={() => setModalNotes(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- pass isAdmin flag and note context to NotesHistoryModal
- add administrative note controls for add/edit/delete

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f94090c348333bad824db4503a921