### PR TITLE
Allow recruiters to note and secure assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,20 +108,31 @@ both assigned and rejected students.
 ### Student Notes
 
 Use `POST /student-note` with a `job_code`, the `student_email`, and a `note` to
-create or update recruiter comments for a candidate. Each note is stored as an
-object containing the note text, the authenticated user's email, and an ISO
-timestamp. Notes are accumulated in `student_notes[email]`, which is now a list
-of these objects. This endpoint only updates the `student_notes[email]` field
-and does **not** change any assignment status. The response includes the email
-and the updated list of notes.
+record comments for a candidate. Recruiters may add notes only for jobs they
+created **and** students they have assigned to those jobs. Administrators may
+add notes for any job and are the only role permitted to edit or delete
+existing notes. Each note is stored as an object containing the text, the
+author's email, and an ISO timestamp. The endpoint does not change assignment
+status and returns the updated list of notes.
 
-Example request:
+Example recruiter request:
 
 ```json
 {
   "job_code": "job123",
   "student_email": "alice@example.com",
   "note": "Left a voicemail"
+}
+```
+
+Example admin edit request (`PUT /student-note`):
+
+```json
+{
+  "job_code": "job123",
+  "student_email": "alice@example.com",
+  "index": 0,
+  "note": "Spoke with candidate"
 }
 ```
 

--- a/app/main.py
+++ b/app/main.py
@@ -1422,6 +1422,11 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
             raise ValueError
     except (json.JSONDecodeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid student_notes format")
+    role = token_data.get("role")
+    if role == "recruiter" and job.get("posted_by") != token_data.get("sub"):
+        raise HTTPException(status_code=403, detail="Not authorized to modify this job")
+    if role not in ("admin", "recruiter"):
+        raise HTTPException(status_code=403, detail="Admin privileges required")
     job.setdefault("assigned_students", [])
     if student_email not in job["assigned_students"]:
         job["assigned_students"].append(student_email)
@@ -1487,6 +1492,11 @@ def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_u
             raise ValueError
     except (json.JSONDecodeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid student_notes format")
+    role = token_data.get("role")
+    if role == "recruiter" and job.get("posted_by") != token_data.get("sub"):
+        raise HTTPException(status_code=403, detail="Not authorized to modify this job")
+    if role not in ("admin", "recruiter"):
+        raise HTTPException(status_code=403, detail="Admin privileges required")
     job.setdefault("assigned_students", [])
     job.setdefault("rejected_students", [])
 
@@ -1536,8 +1546,6 @@ def reject_assigned_student(data: dict, token_data: dict = Depends(get_current_u
 @app.post("/student-note")
 def student_note(data: dict, token_data: dict = Depends(get_current_user)):
     """Create or update a note for a student on a job."""
-    if token_data.get("role") != "admin":
-        raise HTTPException(status_code=403, detail="Admin privileges required")
     job_code = data.get("job_code")
     student_email = data.get("student_email")
     note = data.get("note")
@@ -1558,6 +1566,17 @@ def student_note(data: dict, token_data: dict = Depends(get_current_user)):
             raise ValueError
     except (json.JSONDecodeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid student_notes format")
+
+    role = token_data.get("role")
+    if role == "admin":
+        pass
+    elif role == "recruiter" and (
+        job.get("posted_by") == token_data.get("sub")
+        and student_email in job.get("assigned_students", [])
+    ):
+        pass
+    else:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
 
     # Ensure student_notes is a dict; handle both dict and JSON string forms
     raw_notes = job.get("student_notes", {})
@@ -2268,6 +2287,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
                     "max_pay": job.get("max_pay"),
                     "job_description": job.get("job_description"),
                     "status": status,
+                    "posted_by": job.get("posted_by"),
                     "notes": notes,
                     **({"note": latest_note} if latest_note is not None else {}),
                 })
@@ -2360,6 +2380,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
                     "max_pay": job.get("max_pay"),
                     "job_description": job.get("job_description"),
                     "status": status,
+                    "posted_by": job.get("posted_by"),
                     "notes": notes,
                     **({"note": latest_note} if latest_note is not None else {}),
                 })
@@ -2419,6 +2440,7 @@ def student_me(current_user: dict = Depends(get_current_user)):
                 "max_pay": job.get("max_pay"),
                 "job_description": job.get("job_description"),
                 "status": status,
+                "posted_by": job.get("posted_by"),
                 "notes": notes,
                 **({"note": latest_note} if latest_note is not None else {}),
             })

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import api from './api';
 import NoteEditor from './NoteEditor';
 
-function NotesHistoryModal({ notes = [], onClose, isAdmin = false, jobCode, studentEmail }) {
+function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = false, jobCode, studentEmail }) {
   const [localNotes, setLocalNotes] = useState(notes);
   const [adding, setAdding] = useState(false);
   const [editingIndex, setEditingIndex] = useState(null);
@@ -67,10 +67,10 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, jobCode, stud
       <div className="notes-modal">
         <button className="close-button" onClick={onClose}>X</button>
         <h3>Notes History</h3>
-        {isAdmin && !adding && (
+        {canAdd && !adding && (
           <button onClick={() => setAdding(true)}>Add Note</button>
         )}
-        {isAdmin && adding && (
+        {canAdd && adding && (
           <NoteEditor
             jobCode={jobCode}
             email={studentEmail}

--- a/frontend/src/NotesHistoryModal.test.js
+++ b/frontend/src/NotesHistoryModal.test.js
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import NotesHistoryModal from './NotesHistoryModal';
+import axios from 'axios';
+
+jest.mock('axios', () => {
+  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  mockAxios.create.mockReturnValue(mockAxios);
+  return mockAxios;
+});
+
+test('recruiter can add note but not edit', () => {
+  render(
+    <NotesHistoryModal
+      notes={[]}
+      onClose={() => {}}
+      jobCode="J1"
+      studentEmail="s@example.com"
+      canAdd={true}
+      isAdmin={false}
+    />
+  );
+  expect(screen.getByText('Add Note')).toBeInTheDocument();
+  expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+});
+
+test('no add button when not allowed', () => {
+  render(
+    <NotesHistoryModal
+      notes={[]}
+      onClose={() => {}}
+      jobCode="J1"
+      studentEmail="s@example.com"
+      canAdd={false}
+      isAdmin={false}
+    />
+  );
+  expect(screen.queryByText('Add Note')).not.toBeInTheDocument();
+});

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -720,8 +720,13 @@ function StudentProfiles() {
                                                 notes: job.notes || [],
                                                 jobCode: job.job_code,
                                                 studentEmail: s.email,
+                                                canAdd:
+                                                  isAdmin ||
+                                                  (userRole === 'recruiter' &&
+                                                    job.posted_by === decoded.sub &&
+                                                    job.status === 'assigned'),
                                               })
-                                              }
+                                            }
                                             type="button"
                                           >
                                             View Notes
@@ -757,6 +762,7 @@ function StudentProfiles() {
           notes={modalNotes.notes}
           jobCode={modalNotes.jobCode}
           studentEmail={modalNotes.studentEmail}
+          canAdd={modalNotes.canAdd}
           isAdmin={isAdmin}
           onClose={() => setModalNotes(null)}
         />

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -737,28 +737,29 @@ def test_reject_assigned(monkeypatch):
     entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
     assert entry["status"] == "rejected"
     assert entry["notes"][-1]["text"] == note
+    assert "posted_by" in entry
 
 
 def test_student_note_school_code_fallback():
     main_app.redis_client.flushdb()
     init_default_admin()
 
-    counselor = {
-        "email": "counselor@example.com",
-        "first_name": "Coun",
-        "last_name": "Selor",
+    recruiter = {
+        "email": "recruiter@example.com",
+        "first_name": "Rec",
+        "last_name": "R",
         "school_code": "1001",
         "password": "pw",
-        "role": "career",
+        "role": "recruiter",
     }
-    client.post("/register", json=counselor)
-    ck = f"user:{counselor['email']}"
+    client.post("/register", json=recruiter)
+    ck = f"user:{recruiter['email']}"
     cdata = json.loads(main_app.redis_client.get(ck))
     cdata["approved"] = True
-    cdata["role"] = "career"
+    cdata["role"] = "recruiter"
     main_app.redis_client.set(ck, json.dumps(cdata))
     token = client.post(
-        "/login", json={"email": counselor["email"], "password": counselor["password"]}
+        "/login", json={"email": recruiter["email"], "password": recruiter["password"]}
     ).json()["token"]
 
     job = {
@@ -820,6 +821,7 @@ def test_student_note_school_code_fallback():
     stu = next(s for s in data if s["email"] == student["email"])
     entry = next(j for j in stu["assigned_jobs"] if j["job_code"] == job_code)
     assert entry["notes"][-1]["text"] == note
+    assert "posted_by" in entry
 
 
 def test_assign_note_persists_on_reject(monkeypatch):
@@ -882,6 +884,7 @@ def test_assign_note_persists_on_reject(monkeypatch):
     entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
     assert entry["status"] == "assigned"
     assert entry["notes"][-1]["text"] == note
+    assert "posted_by" in entry
 
 
 def test_student_note_unassigned(monkeypatch):
@@ -1013,6 +1016,7 @@ def test_student_note_assigned(monkeypatch):
     entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
     assert entry["notes"][-1]["text"] == note
     assert entry["status"] == "assigned"
+    assert "posted_by" in entry
 
     r = client.post(
         "/reject-assigned",
@@ -1030,6 +1034,7 @@ def test_student_note_assigned(monkeypatch):
     entry = next(j for j in data["assigned_jobs"] if j["job_code"] == job_code)
     assert entry["status"] == "rejected"
     assert entry["notes"][-1]["text"] == note
+    assert "posted_by" in entry
 
 
 def test_student_note_multiple_posts_unassigned(monkeypatch):
@@ -1094,6 +1099,255 @@ def test_student_note_multiple_posts_unassigned(monkeypatch):
     assert len(notes) == 2
     assert notes[0]["text"] == note1
     assert notes[-1]["text"] == note2
+
+
+def test_recruiter_can_add_note_for_assigned_student():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    recruiter = {
+        "email": "rec@example.com",
+        "first_name": "Rec",
+        "last_name": "R",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "recruiter",
+    }
+    client.post("/register", json=recruiter)
+    rk = f"user:{recruiter['email']}"
+    rdata = json.loads(main_app.redis_client.get(rk))
+    rdata["approved"] = True
+    rdata["role"] = "recruiter"
+    main_app.redis_client.set(rk, json.dumps(rdata))
+    token = client.post(
+        "/login", json={"email": recruiter["email"], "password": recruiter["password"]}
+    ).json()["token"]
+
+    student = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "stu@example.com",
+        "phone": "1",
+        "education_level": "HS",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10.0,
+        "school_code": "1001",
+    }
+    main_app.redis_client.set(f"student:{student['email']}", json.dumps(student))
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    job_code = resp.json()["job_code"]
+
+    client.post(
+        "/assign",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    note = "follow up"
+    r = client.post(
+        "/student-note",
+        json={"job_code": job_code, "student_email": student["email"], "note": note},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
+    notes = stored.get("student_notes", {}).get(student["email"])
+    assert notes[-1]["text"] == note
+
+
+def test_recruiter_note_forbidden_unassigned_or_unowned():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    rec1 = {
+        "email": "rec1@example.com",
+        "first_name": "R1",
+        "last_name": "One",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "recruiter",
+    }
+    rec2 = {
+        "email": "rec2@example.com",
+        "first_name": "R2",
+        "last_name": "Two",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "recruiter",
+    }
+    for rec in (rec1, rec2):
+        client.post("/register", json=rec)
+        rk = f"user:{rec['email']}"
+        rdata = json.loads(main_app.redis_client.get(rk))
+        rdata["approved"] = True
+        rdata["role"] = "recruiter"
+        main_app.redis_client.set(rk, json.dumps(rdata))
+    token1 = client.post(
+        "/login", json={"email": rec1["email"], "password": rec1["password"]}
+    ).json()["token"]
+    token2 = client.post(
+        "/login", json={"email": rec2["email"], "password": rec2["password"]}
+    ).json()["token"]
+
+    student1 = {
+        "first_name": "Stu",
+        "last_name": "One",
+        "email": "s1@example.com",
+        "phone": "1",
+        "education_level": "HS",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10.0,
+        "school_code": "1001",
+    }
+    student2 = {**student1, "email": "s2@example.com"}
+    main_app.redis_client.set(f"student:{student1['email']}", json.dumps(student1))
+    main_app.redis_client.set(f"student:{student2['email']}", json.dumps(student2))
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token1}"})
+    job_code = resp.json()["job_code"]
+
+    client.post(
+        "/assign",
+        json={"student_email": student1["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token1}"},
+    )
+
+    note = "check"
+    r_unassigned = client.post(
+        "/student-note",
+        json={"job_code": job_code, "student_email": student2["email"], "note": note},
+        headers={"Authorization": f"Bearer {token1}"},
+    )
+    assert r_unassigned.status_code == 403
+
+    r_unowned = client.post(
+        "/student-note",
+        json={"job_code": job_code, "student_email": student1["email"], "note": note},
+        headers={"Authorization": f"Bearer {token2}"},
+    )
+    assert r_unowned.status_code == 403
+
+
+def test_recruiter_cannot_modify_unowned_job():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    rec1 = {
+        "email": "rec1@example.com",
+        "first_name": "R1",
+        "last_name": "One",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "recruiter",
+    }
+    rec2 = {
+        "email": "rec2@example.com",
+        "first_name": "R2",
+        "last_name": "Two",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "recruiter",
+    }
+    for rec in (rec1, rec2):
+        client.post("/register", json=rec)
+        rk = f"user:{rec['email']}"
+        rdata = json.loads(main_app.redis_client.get(rk))
+        rdata["approved"] = True
+        rdata["role"] = "recruiter"
+        main_app.redis_client.set(rk, json.dumps(rdata))
+    token1 = client.post(
+        "/login", json={"email": rec1["email"], "password": rec1["password"]}
+    ).json()["token"]
+    token2 = client.post(
+        "/login", json={"email": rec2["email"], "password": rec2["password"]}
+    ).json()["token"]
+
+    student = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "stu@example.com",
+        "phone": "1",
+        "education_level": "HS",
+        "skills": ["python"],
+        "experience_summary": "s",
+        "interests": "i",
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10.0,
+        "school_code": "1001",
+    }
+    main_app.redis_client.set(f"student:{student['email']}", json.dumps(student))
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token1}"})
+    job_code = resp.json()["job_code"]
+
+    r_assign = client.post(
+        "/assign",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token2}"},
+    )
+    assert r_assign.status_code == 403
+
+    client.post(
+        "/assign",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token1}"},
+    )
+
+    r_reject = client.post(
+        "/reject-assigned",
+        json={"student_email": student["email"], "job_code": job_code},
+        headers={"Authorization": f"Bearer {token2}"},
+    )
+    assert r_reject.status_code == 403
 
 
 def test_student_note_multiple_posts_assigned(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1675,6 +1675,7 @@ def test_student_endpoints_handle_string_notes():
     entry = resp_all.json()["students"][0]["assigned_jobs"][0]
     assert entry["notes"] == [{"text": "legacy"}]
     assert entry["note"] == "legacy"
+    assert "posted_by" in entry
 
     counselor = {"role": "career", "approved": True, "institutional_code": "001"}
     main_app.redis_client.set("user:counselor@example.com", json.dumps(counselor))
@@ -1694,6 +1695,7 @@ def test_student_endpoints_handle_string_notes():
     entry = resp_school.json()["students"][0]["assigned_jobs"][0]
     assert entry["notes"] == [{"text": "legacy"}]
     assert entry["note"] == "legacy"
+    assert "posted_by" in entry
 
     token_student = jwt.encode(
         {
@@ -1710,4 +1712,5 @@ def test_student_endpoints_handle_string_notes():
     entry = resp_me.json()["assigned_jobs"][0]
     assert entry["notes"] == [{"text": "legacy"}]
     assert entry["note"] == "legacy"
+    assert "posted_by" in entry
 


### PR DESCRIPTION
## Summary
- Allow recruiters to post notes on students they have assigned to their own jobs while keeping edit/delete admin-only
- Include job poster in student listing endpoints to enable ownership checks
- Gate frontend note controls on recruiter ownership and add tests for note permissions
- Restrict student assignment/rejection to job owners and document recruiter note capabilities

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68902de182408333887829fdbe1d4cfe