### PR TITLE
Add license-based filtering and admin license management

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ register directly.
 
 Authenticated users can submit student information using `POST /students`.
 Required fields now include location and travel distance:
-`first_name`, `last_name`, `email`, `phone`, `education_level`, `skills`
+`first_name`, `last_name`, `email`, `phone`, `license`, `skills`
 (list of strings), `experience_summary`, `interests`, `city`, `state`, `lat`,
 `lng`, and `max_travel` (in miles). The endpoint combines these details,
 generates an OpenAI embedding and stores the result in Redis keyed by the

--- a/app/main.py
+++ b/app/main.py
@@ -50,6 +50,34 @@ def init_default_school_codes():
             redis_client.set(key, label)
 
 
+DEFAULT_LICENSES: dict[str, str] = {
+    "lvn": "Licensed Vocational Nurse",
+    "ma": "Medical Assistant",
+}
+
+
+def init_default_licenses() -> None:
+    """Seed Redis with default license codes."""
+    for code, label in DEFAULT_LICENSES.items():
+        key = f"license:{code}"
+        existing = redis_client.get(key)
+        if existing != label:
+            redis_client.set(key, label)
+
+
+def all_licenses() -> dict[str, str]:
+    """Return mapping of all configured licenses."""
+    licenses: dict[str, str] = {}
+    for key in redis_client.scan_iter("license:*"):
+        label = redis_client.get(key)
+        if label is not None:
+            code = key.split("license:", 1)[1]
+            licenses[code] = label
+    for c, l in DEFAULT_LICENSES.items():
+        licenses.setdefault(c, l)
+    return licenses
+
+
 def get_school_label(code: str) -> str | None:
     """Return label for a school code from redis or defaults."""
     label = redis_client.get(f"school_code:{code}")
@@ -304,6 +332,7 @@ def init_default_admin():
         )
         print("Default admin user created")
     init_default_school_codes()
+    init_default_licenses()
 
 @app.on_event("startup")
 def on_startup():
@@ -322,6 +351,7 @@ def on_startup():
         print(f"[startup] Using SITE_BASE_URL={SITE_BASE_URL}")
     init_default_admin()
     init_default_school_codes()
+    init_default_licenses()
     init_default_rss_feeds()
     keys = redis_client.keys("match_results:*")
     print(f"🔎 Found {len(keys)} saved match sets at startup.")
@@ -358,7 +388,7 @@ class StudentRequest(BaseModel):
     last_name: str
     email: EmailStr
     phone: str
-    education_level: str
+    license: str = Field(alias="education_level")
     skills: list[str]
     experience_summary: str
     interests: str
@@ -367,6 +397,8 @@ class StudentRequest(BaseModel):
     lat: float
     lng: float
     max_travel: float
+
+    model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("max_travel")
     @classmethod
@@ -381,6 +413,7 @@ class JobRequest(BaseModel):
     desired_skills: list[str]
     job_code: Optional[str] = None
     source: str | None = None
+    required_license: str | None = None
     min_pay: float
     max_pay: float
     city: str
@@ -645,6 +678,54 @@ def delete_school_code(code: str, current_user: dict = Depends(get_current_user)
     return {"message": "School code deleted"}
 
 
+class LicenseRequest(BaseModel):
+    code: str
+    label: str
+
+
+class UpdateLicenseRequest(BaseModel):
+    label: str
+
+
+@app.get("/licenses")
+def list_licenses():
+    licenses = [{"code": c, "label": l} for c, l in all_licenses().items()]
+    return {"licenses": licenses}
+
+
+@app.post("/admin/licenses")
+def add_license(req: LicenseRequest, current_user: dict = Depends(get_current_user)):
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    key = f"license:{req.code}"
+    if redis_client.exists(key):
+        raise HTTPException(status_code=400, detail="License already exists")
+    redis_client.set(key, req.label)
+    return {"message": "License added"}
+
+
+@app.put("/admin/licenses/{code}")
+def update_license(code: str, req: UpdateLicenseRequest, current_user: dict = Depends(get_current_user)):
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    key = f"license:{code}"
+    if not redis_client.exists(key):
+        raise HTTPException(status_code=404, detail="License not found")
+    redis_client.set(key, req.label)
+    return {"message": "License updated"}
+
+
+@app.delete("/admin/licenses/{code}")
+def delete_license(code: str, current_user: dict = Depends(get_current_user)):
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    key = f"license:{code}"
+    if not redis_client.exists(key):
+        raise HTTPException(status_code=404, detail="License not found")
+    redis_client.delete(key)
+    return {"message": "License deleted"}
+
+
 class RSSFeedRequest(BaseModel):
     name: str
     url: str
@@ -706,7 +787,7 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
             last_name=form.get("last_name"),
             email=form.get("email"),
             phone=form.get("phone"),
-            education_level=form.get("education_level"),
+            license=form.get("license") or form.get("education_level"),
             skills=[s.strip() for s in skills_field.split(",") if s.strip()],
             experience_summary=form.get("experience_summary"),
             interests=form.get("interests"),
@@ -754,7 +835,7 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
             instructions = (
                 "Extract a student profile from the following resume text. "
                 "Return JSON with these fields: first_name, last_name, email, phone, "
-                "education_level, skills (as a list), experience_summary, and interests (as a list)."
+                "license, skills (as a list), experience_summary, and interests (as a list)."
             )
             completion = client.chat.completions.create(
                 model="gpt-4o",
@@ -864,7 +945,7 @@ def upload_students(file: UploadFile = File(...), current_user: dict = Depends(g
                 last_name=row["last_name"],
                 email=row["email"],
                 phone=row["phone"],
-                education_level=row["education_level"],
+                license=row.get("license") or row.get("education_level"),
                 skills=skills,
                 experience_summary=row["experience_summary"],
                 interests=row["interests"],
@@ -997,6 +1078,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
     job = json.loads(raw)
     job.setdefault("uninterested_students", [])
 
+    required_license = job.get("required_license")
+
     poster_code = None
     poster_raw = redis_client.get(f"user:{job.get('posted_by')}")
     if poster_raw:
@@ -1040,6 +1123,9 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
             if not emb:
                 continue
             if student.get("email") in job.get("uninterested_students", []):
+                continue
+            student_license = student.get("license") or student.get("education_level")
+            if required_license and student_license != required_license:
                 continue
             student_user_raw = redis_client.get(f"user:{student.get('email')}")
             if student_user_raw and poster_code:
@@ -1100,6 +1186,9 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
             continue
         ucode = udata.get("institutional_code") or udata.get("school_code")
         if ucode != poster_code:
+            continue
+        user_license = udata.get("license") or udata.get("education_level")
+        if required_license and user_license != required_license:
             continue
         email = ukey.split("user:", 1)[1]
         if email in job.get("uninterested_students", []):
@@ -1294,6 +1383,7 @@ def get_metrics(current_user: dict = Depends(get_current_user)):
             or skey.startswith("job:")
             or skey.startswith("metrics:")
             or skey.startswith("school_code:")
+            or skey.startswith("license:")
         ):
             continue
         if redis_client.get(key):
@@ -2253,7 +2343,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
             "last_name": student.get("last_name"),
             "email": email,
             "phone": student.get("phone"),
-            "education_level": student.get("education_level"),
+            "license": student.get("license") or student.get("education_level"),
             "skills": student.get("skills"),
             "experience_summary": student.get("experience_summary"),
             "interests": student.get("interests"),
@@ -2349,7 +2439,7 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
             "last_name": student.get("last_name"),
             "email": email,
             "phone": student.get("phone"),
-            "education_level": student.get("education_level"),
+            "license": student.get("license") or student.get("education_level"),
             "skills": student.get("skills"),
             "experience_summary": student.get("experience_summary"),
             "interests": student.get("interests"),
@@ -2446,17 +2536,15 @@ def student_me(current_user: dict = Depends(get_current_user)):
             })
 
     info = {
-        **{k: student.get(k) for k in [
-            "first_name",
-            "last_name",
-            "email",
-            "phone",
-            "education_level",
-            "skills",
-            "experience_summary",
-            "interests",
-            "institutional_code",
-        ]},
+        "first_name": student.get("first_name"),
+        "last_name": student.get("last_name"),
+        "email": student.get("email"),
+        "phone": student.get("phone"),
+        "license": student.get("license") or student.get("education_level"),
+        "skills": student.get("skills"),
+        "experience_summary": student.get("experience_summary"),
+        "interests": student.get("interests"),
+        "institutional_code": student.get("institutional_code"),
         "assigned_jobs": assigned_jobs,
         "placed_jobs": placed,
         "assigned_job_code": next((j["job_code"] for j in assigned_jobs if j["status"] == "assigned"), None),

--- a/backend/app/services/resume.py
+++ b/backend/app/services/resume.py
@@ -23,14 +23,14 @@ lists. Include these sections:
    strengths and fit for the role.
 3. **Skills** - present as a bullet list.
 4. **Experience** - bullet points for each relevant job or role.
-5. **Education** - mention the education level.
+5. **License** - mention the license type.
 
 Return only valid HTML using <h2> and <ul> elements. Do not include outer
 <html> or <body> tags.
 
 Student Profile:
 Name: {student.get('first_name', '')} {student.get('last_name', '')}
-{contact_lines}Education Level: {student.get('education_level', '')}
+{contact_lines}License: {student.get('license') or student.get('education_level', '')}
 Skills: {', '.join(student.get('skills', []))}
 Experience Summary: {student.get('experience_summary', '')}
 Interests: {student.get('interests', '')}

--- a/frontend/src/AdminUsers.js
+++ b/frontend/src/AdminUsers.js
@@ -9,6 +9,10 @@ function AdminUsers() {
   const [message, setMessage] = useState('');
   const [newCode, setNewCode] = useState('');
   const [newLabel, setNewLabel] = useState('');
+  const [licenses, setLicenses] = useState([]);
+  const [newLicenseCode, setNewLicenseCode] = useState('');
+  const [newLicenseLabel, setNewLicenseLabel] = useState('');
+  const [editLicenseLabels, setEditLicenseLabels] = useState({});
   const [activeTab, setActiveTab] = useState('users');
   const [editLabels, setEditLabels] = useState({});
   const [feeds, setFeeds] = useState([]);
@@ -42,6 +46,15 @@ function AdminUsers() {
     }
   };
 
+  const fetchLicenses = async () => {
+    try {
+      const resp = await api.get('/licenses');
+      setLicenses(resp.data.licenses || []);
+    } catch (err) {
+      console.error('Failed to fetch licenses', err);
+    }
+  };
+
   const fetchFeeds = async () => {
     try {
       const resp = await api.get('/rss-feeds');
@@ -55,6 +68,7 @@ function AdminUsers() {
     if (token) fetchUsers();
     fetchCodes();
     fetchFeeds();
+    fetchLicenses();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleChange = (email, field, value) => {
@@ -173,6 +187,49 @@ function AdminUsers() {
     }
   };
 
+  const handleAddLicense = async () => {
+    try {
+      await api.post(
+        '/admin/licenses',
+        { code: newLicenseCode, label: newLicenseLabel },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setNewLicenseCode('');
+      setNewLicenseLabel('');
+      fetchLicenses();
+      showToast('License added!');
+    } catch (err) {
+      console.error('Failed to add license', err);
+    }
+  };
+
+  const handleUpdateLicense = async (code) => {
+    try {
+      await api.put(
+        `/admin/licenses/${code}`,
+        { label: editLicenseLabels[code] },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      fetchLicenses();
+      showToast('License updated!');
+    } catch (err) {
+      console.error('Failed to update license', err);
+    }
+  };
+
+  const handleDeleteLicense = async (code) => {
+    if (!window.confirm(`Delete license ${code}?`)) return;
+    try {
+      await api.delete(`/admin/licenses/${code}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      fetchLicenses();
+      showToast('License deleted!');
+    } catch (err) {
+      console.error('Failed to delete license', err);
+    }
+  };
+
   const handleRefreshFeeds = async () => {
     try {
       await api.get('/nursing-news?force_refresh=true');
@@ -229,6 +286,12 @@ function AdminUsers() {
           onClick={() => setActiveTab('feeds')}
         >
           RSS Feeds
+        </button>
+        <button
+          className={`tab ${activeTab === 'licenses' ? 'active' : ''}`}
+          onClick={() => setActiveTab('licenses')}
+        >
+          Licenses
         </button>
         <button
           className={`tab ${activeTab === 'tests' ? 'active' : ''}`}
@@ -413,6 +476,60 @@ function AdminUsers() {
                       <button
                         className="delete-button"
                         onClick={() => handleDeleteFeed(f.name)}
+                        style={{ marginLeft: '0.5rem' }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {activeTab === 'licenses' && (
+          <div>
+            <div className="add-code-form">
+              <input
+                type="text"
+                placeholder="Code"
+                value={newLicenseCode}
+                onChange={(e) => setNewLicenseCode(e.target.value)}
+              />
+              <input
+                type="text"
+                placeholder="Label"
+                value={newLicenseLabel}
+                onChange={(e) => setNewLicenseLabel(e.target.value)}
+              />
+              <button onClick={handleAddLicense}>Add License</button>
+            </div>
+            <table className="users-table">
+              <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Label</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {licenses.map((l) => (
+                  <tr key={l.code}>
+                    <td>{l.code}</td>
+                    <td>
+                      <input
+                        type="text"
+                        value={editLicenseLabels[l.code] ?? l.label}
+                        onChange={(e) =>
+                          setEditLicenseLabels((prev) => ({ ...prev, [l.code]: e.target.value }))
+                        }
+                      />
+                    </td>
+                    <td>
+                      <button onClick={() => handleUpdateLicense(l.code)}>Save</button>
+                      <button
+                        className="delete-button"
+                        onClick={() => handleDeleteLicense(l.code)}
                         style={{ marginLeft: '0.5rem' }}
                       >
                         Delete

--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -16,7 +16,7 @@ function ApplicantProfile() {
     last_name: '',
     email: email || '',
     phone: '',
-    education_level: '',
+    license: '',
     skills: '',
     experience_summary: '',
     interests: '',
@@ -26,6 +26,7 @@ function ApplicantProfile() {
     lng: '',
     max_travel: ''
   });
+  const [licenses, setLicenses] = useState([]);
   const [assignedJobs, setAssignedJobs] = useState([]);
   const [isEditing, setIsEditing] = useState(false);
   const [jobDescriptionStatus, setJobDescriptionStatus] = useState({});
@@ -62,6 +63,18 @@ function ApplicantProfile() {
     }
   }, [token]);
 
+  useEffect(() => {
+    const loadLicenses = async () => {
+      try {
+        const resp = await api.get('/licenses');
+        setLicenses(resp.data.licenses || []);
+      } catch (err) {
+        console.error('Failed to fetch licenses', err);
+      }
+    };
+    loadLicenses();
+  }, []);
+
   const fetchProfile = async () => {
     try {
       const resp = await api.get('/students/me', { headers: { Authorization: `Bearer ${token}` } });
@@ -71,7 +84,7 @@ function ApplicantProfile() {
         last_name: data.last_name || '',
         email: data.email || email,
         phone: data.phone || '',
-        education_level: data.education_level || '',
+        license: data.license || data.education_level || '',
         skills: Array.isArray(data.skills) ? data.skills.join(', ') : data.skills || '',
         experience_summary: data.experience_summary || '',
         interests: Array.isArray(data.interests) ? data.interests.join(', ') : data.interests || '',
@@ -208,26 +221,33 @@ function ApplicantProfile() {
           <div className="form-panel">
             <h2>Applicant Profile</h2>
             <form className="profile-form" onSubmit={handleSubmit}>
-              {['first_name','last_name','email','phone','education_level','skills','experience_summary','interests','city','state','max_travel'].map(field => (
-                <React.Fragment key={field}>
-                  <label htmlFor={field}>{field.replace(/_/g, ' ').replace(/\b\w/g,l=>l.toUpperCase())}</label>
-                  {field === 'experience_summary' ? (
-                    <textarea id={field} name={field} value={formData[field]} onChange={handleChange} />
-                  ) : (
-                    <input
-                      id={field}
-                      name={field}
-                      type={field === 'max_travel' ? 'number' : 'text'}
-                      value={formData[field]}
-                      onChange={handleChange}
-                      disabled={field === 'email'}
-                      readOnly={['state'].includes(field)}
-                      ref={field === 'city' ? cityRef : null}
-                      required={['city', 'state', 'max_travel'].includes(field)}
-                    />
-                  )}
-                </React.Fragment>
-              ))}
+              <label htmlFor="first_name">First Name</label>
+              <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
+              <label htmlFor="last_name">Last Name</label>
+              <input id="last_name" name="last_name" type="text" value={formData.last_name} onChange={handleChange} />
+              <label htmlFor="email">Email</label>
+              <input id="email" name="email" type="text" value={formData.email} onChange={handleChange} disabled />
+              <label htmlFor="phone">Phone</label>
+              <input id="phone" name="phone" type="text" value={formData.phone} onChange={handleChange} />
+              <label htmlFor="license">License</label>
+              <select id="license" name="license" value={formData.license} onChange={handleChange}>
+                <option value="">Select...</option>
+                {licenses.map((l) => (
+                  <option key={l.code} value={l.code}>{l.label}</option>
+                ))}
+              </select>
+              <label htmlFor="skills">Skills</label>
+              <input id="skills" name="skills" type="text" value={formData.skills} onChange={handleChange} />
+              <label htmlFor="experience_summary">Experience Summary</label>
+              <textarea id="experience_summary" name="experience_summary" value={formData.experience_summary} onChange={handleChange} />
+              <label htmlFor="interests">Interests</label>
+              <input id="interests" name="interests" type="text" value={formData.interests} onChange={handleChange} />
+              <label htmlFor="city">City</label>
+              <input id="city" name="city" type="text" value={formData.city} onChange={handleChange} ref={cityRef} required />
+              <label htmlFor="state">State</label>
+              <input id="state" name="state" type="text" value={formData.state} onChange={handleChange} readOnly required />
+              <label htmlFor="max_travel">Max Travel</label>
+              <input id="max_travel" name="max_travel" type="number" value={formData.max_travel} onChange={handleChange} required />
               <input type="hidden" id="lat" name="lat" value={formData.lat} readOnly />
               <input type="hidden" id="lng" name="lng" value={formData.lng} readOnly />
               <button type="submit">{isEditing ? 'Update Profile' : 'Save Profile'}</button>

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -12,6 +12,7 @@ function JobPosting() {
     job_title: '',
     job_description: '',
     desired_skills: '',
+    required_license: '',
     source: '',
     min_pay: '',
     max_pay: '',
@@ -38,6 +39,12 @@ function JobPosting() {
   const [generatedResumes, setGeneratedResumes] = useState({});
   const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
+  const [licenses, setLicenses] = useState([]);
+
+  const licenseLabel = (code) => {
+    const l = licenses.find((x) => x.code === code);
+    return l ? l.label : code;
+  };
   const [editingNotes, setEditingNotes] = useState({});
 
   const locationRef = useRef(null);
@@ -60,6 +67,18 @@ function JobPosting() {
   useEffect(() => {
     loadGoogleMaps(initLocationAutocomplete);
   }, [activeTab]);
+
+  useEffect(() => {
+    const loadLicenses = async () => {
+      try {
+        const resp = await api.get('/licenses');
+        setLicenses(resp.data.licenses || []);
+      } catch (err) {
+        console.error('Failed to fetch licenses', err);
+      }
+    };
+    loadLicenses();
+  }, []);
 
   const token = localStorage.getItem('token');
   const decoded = token ? jwtDecode(token) : {};
@@ -152,6 +171,7 @@ if (shouldRedirect) {
         job_title: formData.job_title,
         job_description: formData.job_description,
         desired_skills: formData.desired_skills.split(',').map((s) => s.trim()).filter(Boolean),
+        required_license: formData.required_license,
         min_pay: min,
         max_pay: max,
         city: formData.city,
@@ -167,7 +187,7 @@ if (shouldRedirect) {
       });
       setMessage(`Job posted successfully! Job code: ${resp.data.job_code}`);
       setFormData({
-        job_title: '', job_description: '', desired_skills: '', source: '', min_pay: '', max_pay: '', city: '', state: '', lat: '', lng: ''
+        job_title: '', job_description: '', desired_skills: '', required_license: '', source: '', min_pay: '', max_pay: '', city: '', state: '', lat: '', lng: ''
       });
       fetchJobs();
     } catch (err) {
@@ -891,6 +911,20 @@ if (shouldRedirect) {
                   onChange={handleChange}
                 />
               </div>
+              <div className="form-field">
+                <label htmlFor="required_license">License</label>
+                <select
+                  id="required_license"
+                  name="required_license"
+                  value={formData.required_license}
+                  onChange={handleChange}
+                >
+                  <option value="">Select...</option>
+                  {licenses.map((l) => (
+                    <option key={l.code} value={l.code}>{l.label}</option>
+                  ))}
+                </select>
+              </div>
               {!isRecruiter && (
                 <div className="form-field">
                   <label htmlFor="source">Source</label>
@@ -960,20 +994,22 @@ if (shouldRedirect) {
               <tr>
                 <th></th>
                 <th>Job Code</th>
-              <th>Title</th>
-              <th>Source</th>
-              <th>Pay Range</th>
-              <th>Assigned</th>
-              {!isRecruiter && <th>Placed</th>}
-              <th>Action</th>
-            </tr>
-            <tr className="filter-row">
-              <th></th>
-              <th><input className="column-filter" type="text" value={codeFilter} onChange={(e) => setCodeFilter(e.target.value)} placeholder="Filter" /></th>
-              <th><input className="column-filter" type="text" value={titleFilter} onChange={(e) => setTitleFilter(e.target.value)} placeholder="Filter" /></th>
-              <th><input className="column-filter" type="text" value={sourceFilter} onChange={(e) => setSourceFilter(e.target.value)} placeholder="Filter" /></th>
-              <th colSpan={!isRecruiter ? 4 : 3}></th>
-            </tr>
+                <th>Title</th>
+                <th>License</th>
+                <th>Source</th>
+                <th>Pay Range</th>
+                <th>Assigned</th>
+                {!isRecruiter && <th>Placed</th>}
+                <th>Action</th>
+              </tr>
+              <tr className="filter-row">
+                <th></th>
+                <th><input className="column-filter" type="text" value={codeFilter} onChange={(e) => setCodeFilter(e.target.value)} placeholder="Filter" /></th>
+                <th><input className="column-filter" type="text" value={titleFilter} onChange={(e) => setTitleFilter(e.target.value)} placeholder="Filter" /></th>
+                <th></th>
+                <th><input className="column-filter" type="text" value={sourceFilter} onChange={(e) => setSourceFilter(e.target.value)} placeholder="Filter" /></th>
+                <th colSpan={!isRecruiter ? 4 : 3}></th>
+              </tr>
           </thead>
           <tbody>
             {filteredJobs.map((job) => (
@@ -1012,10 +1048,11 @@ if (shouldRedirect) {
                         e.stopPropagation();
                         setActiveSubtab((prev) => ({ ...prev, [job.job_code]: 'details' }));
                       }}
-                    >
-                      {job.job_title}
-                    </span>
-                  </td>
+                  >
+                    {job.job_title}
+                  </span>
+                </td>
+                  <td>{licenseLabel(job.required_license)}</td>
                   <td>{job.source}</td>
                   <td>
                     {job.min_pay !== undefined && job.max_pay !== undefined
@@ -1098,7 +1135,7 @@ if (shouldRedirect) {
                 {expandedJob === job.job_code && (
                   activeSubtab[job.job_code] === 'details' ? (
                     <tr className="job-details-row">
-                      <td colSpan={!isRecruiter ? 8 : 7}>
+                      <td colSpan={!isRecruiter ? 9 : 8}>
                         <div className="job-description-panel">
                           <h3>{job.job_title}</h3>
                           {editMode[job.job_code] ? (
@@ -1134,6 +1171,26 @@ if (shouldRedirect) {
                                     }))
                                   }
                                 />
+                              </div>
+                              <div className="form-row">
+                                <label>License</label>
+                                <select
+                                  value={editedJobs[job.job_code]?.required_license ?? job.required_license || ''}
+                                  onChange={(e) =>
+                                    setEditedJobs((prev) => ({
+                                      ...prev,
+                                      [job.job_code]: {
+                                        ...prev[job.job_code],
+                                        required_license: e.target.value,
+                                      },
+                                    }))
+                                  }
+                                >
+                                  <option value="">Select...</option>
+                                  {licenses.map((l) => (
+                                    <option key={l.code} value={l.code}>{l.label}</option>
+                                  ))}
+                                </select>
                               </div>
                               <div className="form-row">
                                 <label>Source</label>
@@ -1195,6 +1252,9 @@ if (shouldRedirect) {
                                 <p>
                                   Skills: {Array.isArray(job.desired_skills) ? job.desired_skills.join(', ') : job.desired_skills}
                                 </p>
+                              )}
+                              {job.required_license && (
+                                <p>License: {licenseLabel(job.required_license)}</p>
                               )}
                               <p>Source: {job.source}</p>
                               <p>

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1175,7 +1175,7 @@ if (shouldRedirect) {
                               <div className="form-row">
                                 <label>License</label>
                                 <select
-                                  value={editedJobs[job.job_code]?.required_license ?? job.required_license || ''}
+                                  value={editedJobs[job.job_code]?.required_license ?? (job.required_license || '')}
                                   onChange={(e) =>
                                     setEditedJobs((prev) => ({
                                       ...prev,

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -16,7 +16,7 @@ function StudentProfiles() {
     last_name: '',
     email: '',
     phone: '',
-    education_level: '',
+    license: '',
     skills: '',
     experience_summary: '',
     interests: '',
@@ -26,6 +26,7 @@ function StudentProfiles() {
     lng: '',
     max_travel: ''
   });
+  const [licenses, setLicenses] = useState([]);
   const [formError, setFormError] = useState('');
   const [resumeFile, setResumeFile] = useState(null);
   const [toast, setToast] = useState('');
@@ -157,6 +158,15 @@ function StudentProfiles() {
     }
   };
 
+  const fetchLicenses = async () => {
+    try {
+      const resp = await api.get('/licenses');
+      setLicenses(resp.data.licenses || []);
+    } catch (err) {
+      console.error('Failed to fetch licenses:', err);
+    }
+  };
+
   useEffect(() => {
     if (!token) {
       navigate('/login');
@@ -173,6 +183,7 @@ function StudentProfiles() {
       navigate('/login');
       return;
     }
+    fetchLicenses();
     fetchStudents();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -200,7 +211,7 @@ function StudentProfiles() {
         last_name: student.last_name || '',
         email: student.email || '',
         phone: student.phone || '',
-        education_level: student.education_level || '',
+        license: student.license || student.education_level || '',
         skills: Array.isArray(student.skills)
           ? student.skills.join(', ')
           : student.skills || '',
@@ -316,7 +327,7 @@ function StudentProfiles() {
       last_name: formData.last_name,
       email: formData.email,
       phone: formData.phone,
-      education_level: formData.education_level,
+      license: formData.license,
       skills: formData.skills.split(',').map((s) => s.trim()),
       experience_summary: formData.experience_summary,
       interests: formData.interests.trim(),
@@ -343,7 +354,7 @@ function StudentProfiles() {
         last_name: '',
         email: '',
         phone: '',
-        education_level: '',
+        license: '',
         skills: '',
         experience_summary: '',
         interests: '',
@@ -457,30 +468,33 @@ function StudentProfiles() {
         {activeTab === 'new' && (
           <div className="form-panel">
             <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
-            <form className="profile-form" onSubmit={handleSubmit}>
-            {['first_name', 'last_name', 'email', 'phone', 'education_level', 'skills', 'experience_summary', 'interests', 'city', 'state', 'max_travel'].map((field) => (
-              <React.Fragment key={field}>
-                <label htmlFor={field}>{field.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</label>
-                {field === 'experience_summary' ? (
-                  <textarea
-                    id={field}
-                    name={field}
-                    value={formData[field]}
-                    onChange={handleChange}
-                  />
-                ) : (
-                  <input
-                    id={field}
-                    name={field}
-                    type={field === 'max_travel' ? 'number' : 'text'}
-                    value={formData[field]}
-                    onChange={handleChange}
-                    readOnly={['state'].includes(field)}
-                    ref={field === 'city' ? cityRef : null}
-                  />
-                )}
-              </React.Fragment>
-            ))}
+            <label htmlFor="first_name">First Name</label>
+            <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
+            <label htmlFor="last_name">Last Name</label>
+            <input id="last_name" name="last_name" type="text" value={formData.last_name} onChange={handleChange} />
+            <label htmlFor="email">Email</label>
+            <input id="email" name="email" type="text" value={formData.email} onChange={handleChange} />
+            <label htmlFor="phone">Phone</label>
+            <input id="phone" name="phone" type="text" value={formData.phone} onChange={handleChange} />
+            <label htmlFor="license">License</label>
+            <select id="license" name="license" value={formData.license} onChange={handleChange}>
+              <option value="">Select...</option>
+              {licenses.map((l) => (
+                <option key={l.code} value={l.code}>{l.label}</option>
+              ))}
+            </select>
+            <label htmlFor="skills">Skills</label>
+            <input id="skills" name="skills" type="text" value={formData.skills} onChange={handleChange} />
+            <label htmlFor="experience_summary">Experience Summary</label>
+            <textarea id="experience_summary" name="experience_summary" value={formData.experience_summary} onChange={handleChange} />
+            <label htmlFor="interests">Interests</label>
+            <input id="interests" name="interests" type="text" value={formData.interests} onChange={handleChange} />
+            <label htmlFor="city">City</label>
+            <input id="city" name="city" type="text" value={formData.city} onChange={handleChange} ref={cityRef} />
+            <label htmlFor="state">State</label>
+            <input id="state" name="state" type="text" value={formData.state} onChange={handleChange} readOnly />
+            <label htmlFor="max_travel">Max Travel</label>
+            <input id="max_travel" name="max_travel" type="number" value={formData.max_travel} onChange={handleChange} />
             <input type="hidden" id="lat" name="lat" value={formData.lat} readOnly />
             <input type="hidden" id="lng" name="lng" value={formData.lng} readOnly />
             {/* Uploading documents is temporarily disabled */}

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -467,7 +467,8 @@ function StudentProfiles() {
       <div className="tab-content">
         {activeTab === 'new' && (
           <div className="form-panel">
-            <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
+            <form onSubmit={handleSubmit}>
+              <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
             <label htmlFor="first_name">First Name</label>
             <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
             <label htmlFor="last_name">Last Name</label>
@@ -514,8 +515,8 @@ function StudentProfiles() {
               )}
             </button>
             {formError && <p className="error">{formError}</p>}
-          </form>
-        </div>
+            </form>
+          </div>
         )}
         {activeTab === 'students' && (
         <div

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -467,7 +467,7 @@ function StudentProfiles() {
       <div className="tab-content">
         {activeTab === 'new' && (
           <div className="form-panel">
-            <form onSubmit={handleSubmit}>
+            <form className="profile-form" onSubmit={handleSubmit}>
               <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
             <label htmlFor="first_name">First Name</label>
             <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -12,8 +12,17 @@ jest.mock('axios', () => {
 
 jest.mock('./utils/loadGoogleMaps', () => jest.fn(cb => cb && cb()));
 
+beforeEach(() => {
+  localStorage.setItem('studentTourSeen', 'true');
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    return Promise.resolve({ data: { students: [] } });
+  });
+});
+
 test('renders StudentProfiles without errors', () => {
-  api.get.mockResolvedValueOnce({ data: { students: [] } });
   expect(() => {
     render(
       <BrowserRouter>
@@ -26,26 +35,31 @@ test('renders StudentProfiles without errors', () => {
 test('opens notes history modal when View Notes clicked', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);
-  api.get.mockResolvedValueOnce({
-    data: {
-      students: [
-        {
-          first_name: 'F',
-          last_name: 'L',
-          email: 's@example.com',
-          institutional_code: 'ABC',
-          assigned_jobs: [
-            {
-              job_code: 'J1',
-              job_title: 'Job 1',
-              status: 'open',
-              notes: [{ text: 'Test note' }]
-            }
-          ],
-          placed_jobs: []
-        }
-      ]
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
     }
+    return Promise.resolve({
+      data: {
+        students: [
+          {
+            first_name: 'F',
+            last_name: 'L',
+            email: 's@example.com',
+            institutional_code: 'ABC',
+            assigned_jobs: [
+              {
+                job_code: 'J1',
+                job_title: 'Job 1',
+                status: 'open',
+                notes: [{ text: 'Test note' }]
+              }
+            ],
+            placed_jobs: []
+          }
+        ]
+      }
+    });
   });
   render(
     <BrowserRouter>

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -105,7 +105,7 @@ def test_create_job_and_match(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "summary1",
         "interests": "A",
@@ -120,7 +120,7 @@ def test_create_job_and_match(monkeypatch):
         "last_name": "Roe",
         "email": "jane@example.com",
         "phone": "456",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["java"],
         "experience_summary": "summary2",
         "interests": "B",
@@ -219,6 +219,74 @@ def test_get_match_results_status_placed(monkeypatch):
     assert data["status"] == "placed"
 
 
+def test_match_filters_by_license(monkeypatch):
+    token = login_admin()
+
+    class FakeResp:
+        def __init__(self, emb):
+            self.data = [type("obj", (object,), {"embedding": emb})]
+
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 10.0)
+    monkeypatch.setattr(main_app.client.embeddings, "create", lambda input, model: FakeResp([1.0, 0.0]))
+
+    s1 = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john2@example.com",
+        "phone": "123",
+        "license": "lvn",
+        "skills": ["python"],
+        "experience_summary": "summary1",
+        "interests": "A",
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 100.0,
+    }
+    s2 = {
+        "first_name": "Jane",
+        "last_name": "Roe",
+        "email": "jane2@example.com",
+        "phone": "456",
+        "license": "ma",
+        "skills": ["python"],
+        "experience_summary": "summary2",
+        "interests": "B",
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 100.0,
+    }
+
+    client.post("/students", json=s1, headers={"Authorization": f"Bearer {token}"})
+    client.post("/students", json=s2, headers={"Authorization": f"Bearer {token}"})
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "Need python dev",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "required_license": "lvn",
+    }
+
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    job_code = resp.json()["job_code"]
+
+    match_resp = client.post("/match", json={"job_code": job_code}, headers={"Authorization": f"Bearer {token}"})
+    assert match_resp.status_code == 200
+    data = match_resp.json()["matches"]
+    assert len(data) == 1
+    assert data[0]["email"] == "john2@example.com"
+
+
 def test_match_respects_travel_distance(monkeypatch):
     token = login_admin()
 
@@ -259,7 +327,7 @@ def test_match_respects_travel_distance(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "summary1",
         "interests": "A",
@@ -275,7 +343,7 @@ def test_match_respects_travel_distance(monkeypatch):
         "last_name": "Roe",
         "email": "jane@example.com",
         "phone": "456",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["java"],
         "experience_summary": "summary2",
         "interests": "B",
@@ -377,7 +445,7 @@ def test_match_ignores_label_changes(monkeypatch):
         "last_name": "D",
         "email": applicant["email"],
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "exp",
         "interests": "int",
@@ -506,7 +574,7 @@ def test_rematches_endpoint(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "summary",
         "interests": "i",
@@ -558,7 +626,7 @@ def test_not_interested_filters_out_student(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s1",
         "interests": "i",
@@ -574,7 +642,7 @@ def test_not_interested_filters_out_student(monkeypatch):
         "last_name": "Roe",
         "email": "jane@example.com",
         "phone": "456",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["java"],
         "experience_summary": "s2",
         "interests": "i",
@@ -681,7 +749,7 @@ def test_reject_assigned(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -781,7 +849,7 @@ def test_student_note_school_code_fallback():
         "last_name": "Dent",
         "email": "student@example.com",
         "phone": "123",
-        "education_level": "HS",
+        "license": "ma",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -842,7 +910,7 @@ def test_assign_note_persists_on_reject(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -905,7 +973,7 @@ def test_student_note_unassigned(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -966,7 +1034,7 @@ def test_student_note_assigned(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -1055,7 +1123,7 @@ def test_student_note_multiple_posts_unassigned(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -1128,7 +1196,7 @@ def test_recruiter_can_add_note_for_assigned_student():
         "last_name": "Dent",
         "email": "stu@example.com",
         "phone": "1",
-        "education_level": "HS",
+        "license": "ma",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -1212,7 +1280,7 @@ def test_recruiter_note_forbidden_unassigned_or_unowned():
         "last_name": "One",
         "email": "s1@example.com",
         "phone": "1",
-        "education_level": "HS",
+        "license": "ma",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -1302,7 +1370,7 @@ def test_recruiter_cannot_modify_unowned_job():
         "last_name": "Dent",
         "email": "stu@example.com",
         "phone": "1",
-        "education_level": "HS",
+        "license": "ma",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",
@@ -1368,7 +1436,7 @@ def test_student_note_multiple_posts_assigned(monkeypatch):
         "last_name": "Doe",
         "email": "john@example.com",
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "s",
         "interests": "i",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -358,7 +358,7 @@ def test_upload_students(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "exists", lambda key: False)
 
     csv_data = (
-        "first_name,last_name,email,phone,education_level,skills,experience_summary,interests,city,state,lat,lng,max_travel\n"
+        "first_name,last_name,email,phone,license,skills,experience_summary,interests,city,state,lat,lng,max_travel\n"
         "John,Doe,john@example.com,123,College,python,summary,coding,City,ST,0,0,100\n"
         "Jane,Smith,jane@example.com,456,College,sql,summary2,data,City,ST,0,0,100\n"
     )
@@ -457,8 +457,8 @@ def test_students_all_admin_access():
     init_default_admin()
 
     # Seed some students
-    s1 = {"first_name": "One", "last_name": "A", "email": "one@example.com", "education_level": "College"}
-    s2 = {"first_name": "Two", "last_name": "B", "email": "two@example.com", "education_level": "HS"}
+    s1 = {"first_name": "One", "last_name": "A", "email": "one@example.com", "license": "lvn"}
+    s2 = {"first_name": "Two", "last_name": "B", "email": "two@example.com", "license": "ma"}
     main_app.redis_client.set("student:one@example.com", json.dumps(s1))
     main_app.redis_client.set("student:two@example.com", json.dumps(s2))
 
@@ -508,7 +508,7 @@ def test_update_student(monkeypatch):
         "last_name": "Name",
         "email": "stud@example.com",
         "phone": "000",
-        "education_level": "HS",
+        "license": "ma",
         "skills": ["c"],
         "experience_summary": "old",
         "interests": "old",
@@ -536,7 +536,7 @@ def test_update_student(monkeypatch):
         "last_name": "Name",
         "email": "stud@example.com",
         "phone": "111",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "new summary",
         "interests": "coding",
@@ -557,7 +557,7 @@ def test_update_student(monkeypatch):
 
     saved = json.loads(main_app.redis_client.get("student:stud@example.com"))
     assert saved["first_name"] == "New"
-    assert saved["education_level"] == "College"
+    assert saved["license"] == "lvn"
     assert saved["embedding"] == [1.0, 2.0]
     assert saved["school_code"] == "SC1"
 
@@ -1180,7 +1180,7 @@ def test_students_me_endpoint(monkeypatch):
         "last_name": "User",
         "email": applicant["email"],
         "phone": "123",
-        "education_level": "College",
+        "license": "lvn",
         "skills": ["python"],
         "experience_summary": "summary",
         "interests": "dev",
@@ -1591,7 +1591,7 @@ def test_students_by_school_fallback():
         "last_name": "Dent",
         "email": "student@example.com",
         "phone": "123",
-        "education_level": "HS",
+        "license": "ma",
         "skills": [],
         "experience_summary": "",
         "interests": "",


### PR DESCRIPTION
## Summary
- Introduce license field for students and jobs, including backend schema, API endpoints, and resume output
- Filter job matches by required license and expose Redis-backed license options
- Update web UI to use license dropdowns and add an admin Licenses tab for managing options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892e0bed5bc83338cb538e72c104701