### PR TITLE
Fix frontend form and operator precedence

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1175,7 +1175,7 @@ if (shouldRedirect) {
                               <div className="form-row">
                                 <label>License</label>
                                 <select
-                                  value={editedJobs[job.job_code]?.required_license ?? job.required_license || ''}
+                                  value={editedJobs[job.job_code]?.required_license ?? (job.required_license || '')}
                                   onChange={(e) =>
                                     setEditedJobs((prev) => ({
                                       ...prev,

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -467,7 +467,8 @@ function StudentProfiles() {
       <div className="tab-content">
         {activeTab === 'new' && (
           <div className="form-panel">
-            <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
+            <form onSubmit={handleSubmit}>
+              <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
             <label htmlFor="first_name">First Name</label>
             <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
             <label htmlFor="last_name">Last Name</label>
@@ -514,8 +515,8 @@ function StudentProfiles() {
               )}
             </button>
             {formError && <p className="error">{formError}</p>}
-          </form>
-        </div>
+            </form>
+          </div>
         )}
         {activeTab === 'students' && (
         <div


### PR DESCRIPTION
## Summary
- wrap `required_license` value expression in `JobPosting` with parentheses to avoid nullish coalescing precedence errors
- add missing `<form onSubmit={handleSubmit}>` wrapper for new student profile fields

## Testing
- `CI=true npm test 2>&1 | tail -n 20` *(1 failing test, existing)

------
https://chatgpt.com/codex/tasks/task_e_6892e8c61b288333981e657cb7468f35