### PR TITLE
style: apply profile form styling

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -467,7 +467,7 @@ function StudentProfiles() {
       <div className="tab-content">
         {activeTab === 'new' && (
           <div className="form-panel">
-            <form onSubmit={handleSubmit}>
+            <form className="profile-form" onSubmit={handleSubmit}>
               <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
             <label htmlFor="first_name">First Name</label>
             <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -12,8 +12,17 @@ jest.mock('axios', () => {
 
 jest.mock('./utils/loadGoogleMaps', () => jest.fn(cb => cb && cb()));
 
+beforeEach(() => {
+  localStorage.setItem('studentTourSeen', 'true');
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    return Promise.resolve({ data: { students: [] } });
+  });
+});
+
 test('renders StudentProfiles without errors', () => {
-  api.get.mockResolvedValueOnce({ data: { students: [] } });
   expect(() => {
     render(
       <BrowserRouter>
@@ -26,26 +35,31 @@ test('renders StudentProfiles without errors', () => {
 test('opens notes history modal when View Notes clicked', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);
-  api.get.mockResolvedValueOnce({
-    data: {
-      students: [
-        {
-          first_name: 'F',
-          last_name: 'L',
-          email: 's@example.com',
-          institutional_code: 'ABC',
-          assigned_jobs: [
-            {
-              job_code: 'J1',
-              job_title: 'Job 1',
-              status: 'open',
-              notes: [{ text: 'Test note' }]
-            }
-          ],
-          placed_jobs: []
-        }
-      ]
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
     }
+    return Promise.resolve({
+      data: {
+        students: [
+          {
+            first_name: 'F',
+            last_name: 'L',
+            email: 's@example.com',
+            institutional_code: 'ABC',
+            assigned_jobs: [
+              {
+                job_code: 'J1',
+                job_title: 'Job 1',
+                status: 'open',
+                notes: [{ text: 'Test note' }]
+              }
+            ],
+            placed_jobs: []
+          }
+        ]
+      }
+    });
   });
   render(
     <BrowserRouter>


### PR DESCRIPTION
## Summary
- add `profile-form` class to new profile form for consistent styling
- ensure StudentProfiles tests disable tour and mock API calls

## Testing
- `pytest`
- `npm test -- --watchAll=false`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6892ec693ae4833383aa330074720aac