### PR TITLE
Ensure job match row spans full width

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1279,7 +1279,7 @@ if (shouldRedirect) {
                     </tr>
                   ) : (
                     <tr className="match-table-row">
-                      <td colSpan={!isRecruiter ? 8 : 7}>
+                      <td colSpan={!isRecruiter ? 9 : 8}>
                         {activeSubtab[job.job_code] === 'matches' && renderMatches(job)}
                         {activeSubtab[job.job_code] === 'assigned' && renderAssigned(job)}
                         {activeSubtab[job.job_code] === 'placed' && renderPlaced(job)}


### PR DESCRIPTION
## Summary
- expand match table row to span all columns for recruiter and non-recruiter views

## Testing
- `cd frontend && CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6892f91a78388333890f0b6013b0f595