### PR TITLE
Include institutional code in login tokens

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -516,6 +516,9 @@ def login(req: LoginRequest):
         "role": user["role"],
         "exp": datetime.utcnow() + timedelta(hours=1),
     }
+    inst_code = user.get("institutional_code") or user.get("school_code")
+    if inst_code:
+        payload["institutional_code"] = inst_code
     token = jwt.encode(payload, JWT_SECRET, algorithm=ALGORITHM)
     print(f"Login successful for {req.email}")
     try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -486,6 +486,31 @@ def test_metrics_filtered_by_school():
     assert data["placement_rate"] == 1
 
 
+def test_metrics_career_login_token():
+    main_app.redis_client.flushdb()
+    import bcrypt
+    hashed = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+    user = {
+        "role": "career",
+        "approved": True,
+        "institutional_code": "001",
+        "password": hashed,
+    }
+    main_app.redis_client.set("user:c@example.com", json.dumps(user))
+
+    resp = client.post("/login", json={"email": "c@example.com", "password": "pw"})
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    payload = jwt.decode(token, main_app.JWT_SECRET, algorithms=[main_app.ALGORITHM])
+    assert payload.get("institutional_code") == "001"
+
+    resp2 = client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+    assert resp2.status_code == 200
+    data = resp2.json()
+    assert data["total_users"] == 1
+    assert data["total_student_profiles"] == 0
+
+
 def test_admin_reset_jobs():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- attach institutional_code to JWTs on login so career users can fetch metrics
- add regression test verifying metrics access via login-generated token

## Testing
- `pytest tests/test_main.py::test_metrics_endpoint tests/test_main.py::test_metrics_filtered_by_school tests/test_main.py::test_metrics_career_login_token -q`

------
https://chatgpt.com/codex/tasks/task_e_6896d3843eb88333a50574a210f3dd1f