### PR TITLE
fix: add explicit extensions for note modules

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -5,7 +5,7 @@ import api from './api';
 import AdminMenu from './AdminMenu';
 import loadGoogleMaps from './utils/loadGoogleMaps';
 import './JobPosting.css';
-import NoteEditor from './NoteEditor';
+import NoteEditor from './NoteEditor.js';
 
 function JobPosting() {
   const [formData, setFormData] = useState({

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import NoteEditor from './NoteEditor';
+import NoteEditor from './NoteEditor.js';
 import api from './api';
 import axios from 'axios';
 

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import api from './api';
-import NoteEditor from './NoteEditor';
+import NoteEditor from './NoteEditor.js';
 
 function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = false, jobCode, studentEmail }) {
   const [localNotes, setLocalNotes] = useState(notes);

--- a/frontend/src/NotesHistoryModal.test.js
+++ b/frontend/src/NotesHistoryModal.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import NotesHistoryModal from './NotesHistoryModal';
+import NotesHistoryModal from './NotesHistoryModal.js';
 import axios from 'axios';
 
 jest.mock('axios', () => {

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -8,7 +8,7 @@ import AdminMenu from './AdminMenu';
 import jwt_decode from 'jwt-decode';
 import './StudentProfiles.css';
 import './Tour.css';
-import NotesHistoryModal from './NotesHistoryModal';
+import NotesHistoryModal from './NotesHistoryModal.js';
 
 function StudentProfiles() {
   const [formData, setFormData] = useState({


### PR DESCRIPTION
## Summary
- fix NoteEditor and NotesHistoryModal imports by adding `.js` extensions
- update associated tests to use explicit `.js` paths

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6896d90c64308333ba4edc5c5b5b5f31