### PR TITLE
Fix admin metrics request handling

### DIFF
--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -35,10 +35,14 @@ function Metrics() {
       return;
     }
     let schoolCode;
+    let userRole = '';
     try {
       const dec = jwtDecode(token);
-      setRole(dec.role);
-      schoolCode = dec.institutional_code || dec.school_code;
+      userRole = dec.role;
+      setRole(userRole);
+      if (userRole === 'career') {
+        schoolCode = dec.institutional_code || dec.school_code;
+      }
     } catch {
       setLoading(false);
       setError('Invalid token');
@@ -47,7 +51,7 @@ function Metrics() {
     const fetchMetrics = async () => {
       try {
         let url = '/metrics';
-        if (schoolCode) {
+        if (userRole === 'career' && schoolCode) {
           url += `?school_code=${schoolCode}`;
         }
         const resp = await api.get(url, {


### PR DESCRIPTION
## Summary
- Only include `school_code` query parameter when the user is a career role
- Prevents admin tokens with institutional codes from being treated as filtered metrics requests

## Testing
- `pytest -q`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e0e785848333bde85e94eb37f9e2