### PR TITLE
Add weekly summary email service and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,16 @@ python scripts/backfill_codes.py
 
 The script scans all `user:*` and `student:*` keys and updates records where
 `institutional_code` is absent but `school_code` exists.
+
+## Scheduling Weekly Summaries
+
+Run the scheduler script to enqueue weekly summary jobs:
+
+```bash
+export REDIS_URL=redis://localhost:6379/0  # adjust as needed
+python scripts/schedule_weekly_summary.py
+```
+
+This configures the `weekly_summary_worker` to run every Monday at 08:00 server time. The script may be invoked at deploy time or via cron.
+
+Career staff receive individual activity summaries, while any admin users are emailed a site-wide summary covering all career staff activity.

--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -1,0 +1,146 @@
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import httpx
+from openai import OpenAI
+
+from app.main import ACTIVITY_LOG_KEY, redis_client, send_email
+
+# Reuse a single OpenAI client for efficiency
+openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=httpx.Client())
+
+
+def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
+    """Aggregate creation and job placement stats for a career user."""
+    week_ago = now - timedelta(days=7)
+    student_emails: set[str] = set()
+
+    logs = redis_client.lrange(ACTIVITY_LOG_KEY, 0, -1)
+    for raw in logs:
+        try:
+            entry = json.loads(raw)
+        except Exception:
+            continue
+        if entry.get("user") != user_email:
+            continue
+        if entry.get("method") != "POST" or not entry.get("path", "").startswith("/students"):
+            continue
+        ts_str = entry.get("timestamp")
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except Exception:
+            continue
+        if ts < week_ago or ts > now:
+            continue
+
+        email = entry.get("student_email")
+        if not email:
+            path = entry.get("path", "")
+            if path.startswith("/students/"):
+                email = path.split("/students/", 1)[1]
+            elif "?email=" in path:
+                email = path.split("?email=", 1)[1]
+        if email:
+            student_emails.add(email)
+
+    stats_students: List[Dict[str, Any]] = []
+    for email in student_emails:
+        assigned = placed = 0
+        latest_note: Dict[str, Any] | None = None
+        for key in redis_client.scan_iter("job:*"):
+            job_raw = redis_client.get(key)
+            if not job_raw:
+                continue
+            try:
+                job = json.loads(job_raw)
+            except Exception:
+                continue
+            if email in job.get("assigned_students", []):
+                assigned += 1
+            if email in job.get("placed_students", []):
+                placed += 1
+            notes_map = job.get("student_notes", {})
+            if isinstance(notes_map, str):
+                try:
+                    notes_map = json.loads(notes_map)
+                except Exception:
+                    notes_map = {}
+            notes = notes_map.get(email) or []
+            if notes:
+                latest = notes[-1]
+                ts = latest.get("timestamp")
+                if not latest_note or (ts and ts > latest_note.get("timestamp")):
+                    latest_note = {"text": latest.get("text", ""), "timestamp": ts}
+        stats_students.append(
+            {
+                "email": email,
+                "assigned_jobs": assigned,
+                "placed_jobs": placed,
+                "latest_note": latest_note,
+            }
+        )
+
+    return {"created_count": len(student_emails), "students": stats_students}
+
+
+def build_summary_narrative(stats: Dict[str, Any], user_name: str) -> str:
+    """Generate a narrative summary of the week's activity."""
+    prompt = (
+        f"Provide a brief weekly activity summary for {user_name}.\n"
+        f"Stats: {json.dumps(stats)}"
+    )
+    try:
+        resp = openai_client.chat.completions.create(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content
+    except Exception:
+        return "Here is your activity summary: " + json.dumps(stats)
+
+
+def send_weekly_summary(user_email: str) -> None:
+    """Compile stats and email a weekly summary to the given user."""
+    user_key = f"user:{user_email}"
+    raw = redis_client.get(user_key)
+    if not raw:
+        return
+    try:
+        user = json.loads(raw)
+    except Exception:
+        return
+
+    role = user.get("role")
+    if role not in {"career", "admin"}:
+        return
+
+    name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip() or user_email
+    now = datetime.now(timezone.utc)
+    if role == "career":
+        stats = compile_weekly_stats(user_email, now)
+    else:
+        stats = compile_all_weekly_stats(now)
+    body = build_summary_narrative(stats, name)
+    send_email(user_email, "Your Weekly Activity Summary", body)
+
+
+def compile_all_weekly_stats(now: datetime) -> Dict[str, Any]:
+    """Aggregate weekly stats for all career staff."""
+    users: Dict[str, Any] = {}
+    for key in redis_client.scan_iter("user:*"):
+        raw = redis_client.get(key)
+        if not raw:
+            continue
+        try:
+            user = json.loads(raw)
+        except Exception:
+            continue
+        if user.get("role") != "career":
+            continue
+        email = key.split("user:", 1)[1]
+        users[email] = compile_weekly_stats(email, now)
+    return {"users": users}

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ uvicorn==0.34.3
 yarl==1.20.1
 rq>=1.15
 faiss-cpu>=1.11.0
+rq-scheduler>=0.13

--- a/scripts/schedule_weekly_summary.py
+++ b/scripts/schedule_weekly_summary.py
@@ -1,0 +1,20 @@
+import os
+import redis
+from rq_scheduler import Scheduler
+
+from worker import weekly_summary_worker
+
+
+def schedule_weekly_summary() -> None:
+    """Enqueue weekly summaries every Monday at 08:00 server time."""
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        raise RuntimeError("Missing REDIS_URL")
+    connection = redis.Redis.from_url(redis_url)
+    scheduler = Scheduler(queue_name="weekly", connection=connection)
+    scheduler.cron("0 8 * * MON", func=weekly_summary_worker, queue_name="weekly")
+    print("Scheduled weekly summary at 08:00 every Monday")
+
+
+if __name__ == "__main__":
+    schedule_weekly_summary()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,87 @@
+import json
+from datetime import datetime, timezone
+
+from backend.app.services import summary
+
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+        self.lists = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def lpush(self, key, value):
+        self.lists.setdefault(key, []).insert(0, value)
+
+    def lrange(self, key, start, end):
+        lst = self.lists.get(key, [])
+        if end == -1:
+            end = len(lst) - 1
+        return lst[start : end + 1]
+
+    def scan_iter(self, pattern="*"):
+        from fnmatch import fnmatch
+
+        for k in list(self.store.keys()) + list(self.lists.keys()):
+            if fnmatch(k, pattern):
+                yield k
+
+
+
+def test_admin_weekly_summary():
+    summary.redis_client = DummyRedis()
+    now = datetime.now(timezone.utc)
+
+    # Users
+    summary.redis_client.set("user:career@example.com", json.dumps({"role": "career"}))
+    summary.redis_client.set("user:admin@example.com", json.dumps({"role": "admin"}))
+
+    # Activity log for career user
+    log = {
+        "user": "career@example.com",
+        "method": "POST",
+        "path": "/students",
+        "timestamp": now.isoformat(),
+        "student_email": "stu@example.com",
+    }
+    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(log))
+
+    # Job record
+    job = {
+        "assigned_students": ["stu@example.com"],
+        "placed_students": [],
+        "student_notes": {
+            "stu@example.com": [{"text": "note", "timestamp": now.isoformat()}]
+        },
+    }
+    summary.redis_client.set("job:1", json.dumps(job))
+
+    sent = {}
+
+    def fake_send_email(to, subject, body):
+        sent["to"] = to
+        sent["subject"] = subject
+        sent["body"] = body
+
+    summary.send_email = fake_send_email
+
+    captured_stats = {}
+
+    def fake_build(stats, user_name):
+        captured_stats["stats"] = stats
+        return "body"
+
+    summary.build_summary_narrative = fake_build
+
+    summary.send_weekly_summary("admin@example.com")
+
+    assert sent["to"] == "admin@example.com"
+    assert "Weekly Activity Summary" in sent["subject"]
+    assert (
+        captured_stats["stats"]["users"]["career@example.com"]["created_count"] == 1
+    )

--- a/worker.py
+++ b/worker.py
@@ -1,14 +1,34 @@
 import os
+import json
 import redis
 from rq import Worker, Queue
 
-# Grab your Redis URL from the environment
+from backend.app.services.summary import send_weekly_summary
+
 redis_url = os.getenv("REDIS_URL")
 if not redis_url:
     raise RuntimeError("Missing REDIS_URL")
 
-# Connect to Redis
-# RQ expects raw bytes, so disable automatic response decoding
-redis_client = redis.Redis.from_url(redis_url)
-queue = Queue(connection=redis_client)
-Worker([queue], connection=redis_client).work()
+redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
+rq_client = redis.Redis.from_url(redis_url)
+
+def weekly_summary_worker() -> None:
+    """Send summaries to career staff and admins."""
+    for key in redis_client.scan_iter("user:*"):
+        raw = redis_client.get(key)
+        if not raw:
+            continue
+        try:
+            user = json.loads(raw)
+        except Exception:
+            continue
+        role = user.get("role")
+        if role in {"career", "admin"}:
+            email = key.split("user:", 1)[1]
+            send_weekly_summary(email)
+
+
+if __name__ == "__main__":
+    default_queue = Queue(connection=rq_client)
+    weekly_queue = Queue("weekly", connection=rq_client)
+    Worker([default_queue, weekly_queue], connection=rq_client).work()


### PR DESCRIPTION
## Summary
- allow admins to receive a site-wide weekly activity summary via email
- send summaries to admins in the weekly worker and document behavior
- add test covering admin summary generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689787bfd1a08333802e3ae3345a111f