### PR TITLE
Load environment variables before service imports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,7 @@
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from datetime import datetime, timedelta, timezone
 import json
 import csv
@@ -19,7 +23,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator
 from jose import jwt, JWTError
-from dotenv import load_dotenv
 import bcrypt
 for _p in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
     os.environ.pop(_p, None)
@@ -100,7 +103,7 @@ def all_school_codes() -> dict[str, str]:
     return codes
 
 # Load environment variables
-load_dotenv()
+# (Handled at top of file)
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=httpx.Client())
 redis_url = os.getenv("REDIS_URL")
 


### PR DESCRIPTION
## Summary
- Invoke `load_dotenv` at the very top of `app/main.py` so environment variables are available before other imports.
- Remove duplicate `load_dotenv` call in favor of the early invocation.

## Testing
- `pytest tests/test_main.py::test_read_root -q`
- `python - <<'PY'
import app.main as m
print(m.client.api_key)
PY`
- `OPENAI_BASE_URL=http://127.0.0.1 uvicorn app.main:app --reload` *(fails: Error 111 connecting to localhost:6379. Connection refused.)*

------
https://chatgpt.com/codex/tasks/task_e_6897d4efb6d483339890a291fc8c987b