### PR TITLE
Handle naive datetimes in weekly summary processing

### DIFF
--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -37,9 +37,12 @@ def _parse_ts(ts_str: str | None) -> datetime | None:
         return None
     # Handle ISO with or without 'Z'
     try:
-        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
     except Exception:
         return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -85,3 +85,31 @@ def test_admin_weekly_summary():
     assert (
         captured_stats["stats"]["users"]["career@example.com"]["created_count"] == 1
     )
+
+
+def test_compile_weekly_stats_handles_naive_timestamp():
+    summary.redis_client = DummyRedis()
+    now = datetime.now(timezone.utc)
+    naive = now.replace(tzinfo=None)
+
+    log = {
+        "user": "career@example.com",
+        "method": "POST",
+        "path": "/students",
+        "timestamp": naive.isoformat(),
+        "student_email": "stu@example.com",
+    }
+    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(log))
+
+    job = {
+        "assigned_students": ["stu@example.com"],
+        "placed_students": [],
+        "student_notes": {
+            "stu@example.com": [{"text": "note", "timestamp": naive.isoformat()}]
+        },
+    }
+    summary.redis_client.set("job:1", json.dumps(job))
+
+    stats = summary.compile_weekly_stats("career@example.com", now)
+    assert stats["created_count"] == 1
+    assert stats["students"][0]["latest_note"]["text"] == "note"


### PR DESCRIPTION
## Summary
- ensure parsed timestamps default to UTC
- add regression test for naive log timestamps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68982a5b114c833399dc86c32bf25ee1