### PR TITLE
Use localhost for API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pytest
 Create a `.env` file with these example values:
 
 ```
-REACT_APP_API_URL=http://127.0.0.1:8000
+REACT_APP_API_URL=http://localhost:8000
 REACT_APP_GOOGLE_KEY=frontend_key
 GOOGLE_KEY=backend_key
 SMTP_HOST=smtp.example.com

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-REACT_APP_API_URL=http://127.0.0.1:8000
+REACT_APP_API_URL=http://localhost:8000
 


### PR DESCRIPTION
## Summary
- use `localhost` instead of `127.0.0.1` for the frontend API base URL
- update README to reflect `localhost` configuration

## Testing
- `pytest`
- `CI=true npm --prefix frontend test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898340133948333a0d547deca87b9d4