### PR TITLE
Load env for worker and surface OpenAI summary errors

### DIFF
--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
@@ -15,6 +16,7 @@ send_email = None
 
 # Reuse a single OpenAI client; reads OPENAI_API_KEY from env
 openai_client = OpenAI()
+logger = logging.getLogger(__name__)
 
 
 def _ensure_dependencies() -> None:
@@ -162,14 +164,21 @@ def build_summary_narrative(stats: Dict[str, Any], user_name: str) -> str:
         f"Include key numbers, short insights, and 3 bullet action items if applicable.\n"
         f"Stats JSON:\n{json.dumps(stats)}"
     )
+    model = os.getenv("SUMMARY_MODEL", "gpt-4o")
     try:
         resp = openai_client.chat.completions.create(
-            model="gpt-5-mini",
+            model=model,
             messages=[{"role": "user", "content": prompt}],
             temperature=0.4,
         )
         return (resp.choices[0].message.content or "").strip()
-    except Exception:
+    except Exception as exc:
+        api_key_present = bool(os.getenv("OPENAI_API_KEY"))
+        logger.exception(
+            "OpenAI summary generation failed (model=%s, api_key=%s)",
+            model,
+            "present" if api_key_present else "missing",
+        )
         # Safe fallback
         return "Here is your activity summary:\n" + json.dumps(stats, indent=2)
 

--- a/worker.py
+++ b/worker.py
@@ -1,9 +1,30 @@
 import os
 import json
+import logging
+
 import redis
+from dotenv import load_dotenv
 from rq import Worker, Queue
 
 from backend.app.services.summary import send_weekly_summary
+
+load_dotenv()
+
+missing_vars = [
+    var
+    for var in [
+        "OPENAI_API_KEY",
+        "SUMMARY_MODEL",
+        "SMTP_HOST",
+        "SMTP_PORT",
+        "SMTP_USER",
+        "SMTP_PASSWORD",
+        "EMAIL_SENDER",
+    ]
+    if not os.getenv(var)
+]
+if missing_vars:
+    logging.warning("Missing environment variables: %s", ", ".join(missing_vars))
 
 redis_url = os.getenv("REDIS_URL")
 if not redis_url:


### PR DESCRIPTION
## Summary
- load `.env` and warn on missing SMTP/OpenAI variables in `worker.py`
- make summary model configurable via `SUMMARY_MODEL` and log OpenAI failures for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d3b072e4833387d8f59de1219b27