### PR TITLE
Track student profile creator and creation time

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -883,6 +883,8 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
         data["institutional_code"] = institutional_code
     if school_label is not None:
         data["school_label"] = school_label
+    data["created_by"] = current_user.get("sub")
+    data["created_at"] = datetime.now(timezone.utc).isoformat()
     redis_client.set(f"student:{student_data.email}", json.dumps(data))
     ensure_index(len(embedding))
     if vector_index is not None:
@@ -934,6 +936,12 @@ def update_student(
         data["school_label"] = school_label
     if "school_code" in existing:
         data["school_code"] = existing.get("school_code")
+    created_by = existing.get("created_by")
+    created_at = existing.get("created_at")
+    if created_by is not None:
+        data["created_by"] = created_by
+    if created_at is not None:
+        data["created_at"] = created_at
 
     redis_client.set(key, json.dumps(data))
     rebuild_vector_index()
@@ -981,6 +989,8 @@ def upload_students(file: UploadFile = File(...), current_user: dict = Depends(g
 
         data = student.model_dump()
         data["embedding"] = embedding
+        data["created_by"] = current_user.get("sub")
+        data["created_at"] = datetime.now(timezone.utc).isoformat()
         redis_client.set(f"student:{student.email}", json.dumps(data))
         ensure_index(len(embedding))
         if vector_index is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -369,6 +369,65 @@ def test_upload_students(monkeypatch):
     assert len(stored) == 2
 
 
+def test_student_creation_records_metadata(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
+    token = login_resp.json()["token"]
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.0, 0.1]})]
+
+    def fake_create(input, model):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+    monkeypatch.setattr(main_app, "ensure_index", lambda dim: None)
+    monkeypatch.setattr(main_app, "rebuild_vector_index", lambda: None)
+    main_app.vector_index = None
+
+    profile = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "stud@example.com",
+        "phone": "123",
+        "license": "lvn",
+        "skills": ["python"],
+        "experience_summary": "summary",
+        "interests": "coding",
+        "city": "Town",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10,
+    }
+
+    resp = client.post("/students", json=profile, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+    raw = main_app.redis_client.get(f"student:{profile['email']}")
+    stored = json.loads(raw)
+    assert stored["created_by"] == "admin@example.com"
+    assert "created_at" in stored
+    datetime.fromisoformat(stored["created_at"])
+
+    updated = profile.copy()
+    updated["city"] = "NewCity"
+    resp2 = client.put(
+        f"/students/{profile['email']}",
+        json=updated,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp2.status_code == 200
+    raw2 = main_app.redis_client.get(f"student:{profile['email']}")
+    stored2 = json.loads(raw2)
+    assert stored2["city"] == "NewCity"
+    assert stored2["created_by"] == "admin@example.com"
+    assert stored2["created_at"] == stored["created_at"]
+
+
 def test_metrics_endpoint():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- Record who created a student profile and when it's created
- Preserve creation metadata on updates and bulk uploads
- Add regression test verifying student metadata stored and retained

## Testing
- `pytest tests/test_main.py::test_student_creation_records_metadata -q`
- `pytest tests/test_main.py::test_upload_students -q`


------
https://chatgpt.com/codex/tasks/task_e_6899749902988333a304871a135d41e7