### PR TITLE
Schedule weekly summary at 08:30

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,6 @@ export REDIS_URL=redis://localhost:6379/0  # adjust as needed
 python scripts/schedule_weekly_summary.py
 ```
 
-This configures the `weekly_summary_worker` to run every Monday at 08:00 server time. The script may be invoked at deploy time or via cron.
+This configures the `weekly_summary_worker` to run every Monday at 08:30 server time. The script may be invoked at deploy time or via cron.
 
 Career staff receive individual activity summaries, while any admin users are emailed a site-wide summary covering all career staff activity.

--- a/scripts/schedule_weekly_summary.py
+++ b/scripts/schedule_weekly_summary.py
@@ -6,14 +6,14 @@ from worker import weekly_summary_worker
 
 
 def schedule_weekly_summary() -> None:
-    """Enqueue weekly summaries every Monday at 08:00 server time."""
+    """Enqueue weekly summaries every Monday at 08:30 server time."""
     redis_url = os.getenv("REDIS_URL")
     if not redis_url:
         raise RuntimeError("Missing REDIS_URL")
     connection = redis.Redis.from_url(redis_url)
     scheduler = Scheduler(queue_name="weekly", connection=connection)
-    scheduler.cron("0 8 * * MON", func=weekly_summary_worker, queue_name="weekly")
-    print("Scheduled weekly summary at 08:00 every Monday")
+    scheduler.cron("30 8 * * MON", func=weekly_summary_worker, queue_name="weekly")
+    print("Scheduled weekly summary at 08:30 every Monday")
 
 
 if __name__ == "__main__":

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -35,7 +35,7 @@ class DummyRedis:
 
 def test_admin_weekly_summary():
     summary.redis_client = DummyRedis()
-    now = datetime.now(timezone.utc)
+    now = datetime(2025, 8, 8, tzinfo=timezone.utc)
 
     # Users
     summary.redis_client.set("user:career@example.com", json.dumps({"role": "career"}))
@@ -78,7 +78,15 @@ def test_admin_weekly_summary():
 
     summary.build_summary_narrative = fake_build
 
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    original_dt = summary.datetime
+    summary.datetime = FixedDateTime
     summary.send_weekly_summary("admin@example.com")
+    summary.datetime = original_dt
 
     assert sent["to"] == "admin@example.com"
     assert "Weekly Activity Summary" in sent["subject"]
@@ -89,7 +97,7 @@ def test_admin_weekly_summary():
 
 def test_compile_weekly_stats_handles_naive_timestamp():
     summary.redis_client = DummyRedis()
-    now = datetime.now(timezone.utc)
+    now = datetime(2025, 8, 8, tzinfo=timezone.utc)
     naive = now.replace(tzinfo=None)
 
     log = {


### PR DESCRIPTION
## Summary
- Send weekly summary emails at 08:30 every Monday
- Update documentation to reflect new dispatch time
- Stabilize summary tests with fixed dates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a044dfbec833394acd6e7763b8e1b