### PR TITLE
Schedule weekly summaries and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ python worker.py
 
 `/match` and `/rematches/{job_code}` enqueue work for these workers.
 
+### Weekly summary emails
+
+Weekly activity summaries are enqueued every Monday at **08:30** server time using
+[`rq-scheduler`](https://github.com/rq/rq-scheduler). The worker registers this
+cron job on startup, but a scheduler process must be running to move the job to
+the `weekly` queue when the time arrives.
+
+Ensure the following environment variables are set: `REDIS_URL`,
+`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, and `EMAIL_SENDER`.
+
+Example deployment commands:
+
+```bash
+# Start the worker (also schedules the cron job)
+python worker.py
+
+# In a separate process, run the scheduler to enqueue weekly jobs
+rqscheduler --queue weekly
+```
+
+The cron expression runs in the server's local time zone; adjust the host time
+zone if a different send time is required.
+
 ## Frontend
 
 The frontend was bootstrapped with Create React App and lives in the `frontend` folder. Install dependencies and start the development server with:

--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -311,21 +311,24 @@ Stats JSON:
         return "Here is your activity summary:\n" + json.dumps(stats, indent=2)
 
 
-def send_weekly_summary(user_email: str) -> None:
-    """Compile stats and email a weekly summary to the given user (career or admin)."""
+def send_weekly_summary(user_email: str) -> bool:
+    """Compile stats and email a weekly summary to the given user (career or admin).
+
+    Returns True if an email was sent, otherwise False.
+    """
     _ensure_dependencies()
     raw = _decode(redis_client.get(f"user:{user_email}"))
     if not raw:
-        return
+        return False
 
     try:
         user = json.loads(raw)
     except Exception:
-        return
+        return False
 
     role = user.get("role")
     if role not in {"career", "admin"}:
-        return
+        return False
 
     display_name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip() or user_email
     now = datetime.now(timezone.utc)
@@ -338,3 +341,4 @@ def send_weekly_summary(user_email: str) -> None:
 
     body = build_summary_narrative(stats, display_name)
     send_email(user_email, "Your Weekly Activity Summary", body)
+    return True

--- a/scripts/schedule_weekly_summary.py
+++ b/scripts/schedule_weekly_summary.py
@@ -2,8 +2,6 @@ import os
 import redis
 from rq_scheduler import Scheduler
 
-from worker import weekly_summary_worker
-
 
 def schedule_weekly_summary() -> None:
     """Enqueue weekly summaries every Monday at 08:30 server time."""
@@ -12,6 +10,10 @@ def schedule_weekly_summary() -> None:
         raise RuntimeError("Missing REDIS_URL")
     connection = redis.Redis.from_url(redis_url)
     scheduler = Scheduler(queue_name="weekly", connection=connection)
+
+    # Import here to avoid circular dependency when worker imports this module
+    from worker import weekly_summary_worker
+
     scheduler.cron("30 8 * * MON", func=weekly_summary_worker, queue_name="weekly")
     print("Scheduled weekly summary at 08:30 every Monday")
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,57 @@
+import json
+import logging
+import os
+
+os.environ.setdefault("REDIS_URL", "redis://localhost/0")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import worker
+
+
+class DummyRedis:
+    def __init__(self, data):
+        self.data = data
+
+    def scan_iter(self, pattern="*"):
+        for key in self.data:
+            yield key
+
+    def get(self, key):
+        return self.data.get(key)
+
+
+def test_weekly_summary_logs_success(monkeypatch, caplog):
+    user_data = {"user:career@example.com": json.dumps({"role": "career"})}
+    dummy = DummyRedis(user_data)
+    monkeypatch.setattr(worker, "redis_client", dummy)
+
+    sent = {}
+
+    def fake_send(email):
+        sent["email"] = email
+        return True
+
+    monkeypatch.setattr(worker, "send_weekly_summary", fake_send)
+
+    caplog.set_level(logging.INFO)
+    worker.weekly_summary_worker()
+
+    assert "Sending weekly summary to career@example.com" in caplog.text
+    assert "Successfully sent weekly summary to career@example.com" in caplog.text
+    assert sent["email"] == "career@example.com"
+
+
+def test_weekly_summary_logs_error(monkeypatch, caplog):
+    user_data = {"user:career@example.com": json.dumps({"role": "career"})}
+    dummy = DummyRedis(user_data)
+    monkeypatch.setattr(worker, "redis_client", dummy)
+
+    def fake_send(email):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(worker, "send_weekly_summary", fake_send)
+
+    caplog.set_level(logging.INFO)
+    worker.weekly_summary_worker()
+
+    assert "Failed to send weekly summary to career@example.com" in caplog.text

--- a/worker.py
+++ b/worker.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from rq import Worker, Queue
 
 from backend.app.services.summary import send_weekly_summary
+from scripts.schedule_weekly_summary import schedule_weekly_summary
 
 load_dotenv()
 
@@ -33,6 +34,8 @@ if not redis_url:
 redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
 rq_client = redis.Redis.from_url(redis_url)
 
+logger = logging.getLogger(__name__)
+
 def weekly_summary_worker() -> None:
     """Send summaries to career staff and admins."""
     for key in redis_client.scan_iter("user:*"):
@@ -46,10 +49,18 @@ def weekly_summary_worker() -> None:
         role = user.get("role")
         if role in {"career", "admin"}:
             email = key.split("user:", 1)[1]
-            send_weekly_summary(email)
+            logger.info("Sending weekly summary to %s", email)
+            try:
+                if send_weekly_summary(email):
+                    logger.info("Successfully sent weekly summary to %s", email)
+                else:
+                    logger.warning("No weekly summary sent to %s", email)
+            except Exception:
+                logger.exception("Failed to send weekly summary to %s", email)
 
 
 if __name__ == "__main__":
+    schedule_weekly_summary()
     default_queue = Queue(connection=rq_client)
     weekly_queue = Queue("weekly", connection=rq_client)
     Worker([default_queue, weekly_queue], connection=rq_client).work()


### PR DESCRIPTION
## Summary
- schedule weekly summary job at worker startup
- log success and failures when sending weekly summaries
- document how to run weekly summary scheduler

## Testing
- `pytest`
- `pytest tests/test_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_689a0d172aa483338fd696e8c6675cf7