### PR TITLE
Clear old match results and keep polling for rematch updates

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1078,6 +1078,7 @@ def match_job(req: JobCodeRequest, current_user: dict = Depends(get_current_user
 @app.post("/rematches/{job_code}")
 def rematch_job(job_code: str, current_user: dict = Depends(get_current_user)):
     """Queue a rematch computation without notifying students."""
+    redis_client.delete(f"match_results:{job_code}")
     enq_time = datetime.now().timestamp()
     if hasattr(redis_client, "pipeline"):
         get_queue().enqueue(match_worker, job_code, False, enq_time)

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -198,12 +198,24 @@ if (shouldRedirect) {
   const pollForMatch = (code) => {
     const check = async () => {
       try {
-        const resp = await api.get(`/has-match/${code}`,
-          { headers: { Authorization: `Bearer ${token}` } });
-        if (resp.data.has_match) {
-          await loadMatchResults(code);
-          setLoadingMatches((prev) => ({ ...prev, [code]: false }));
-          return;
+        const has = await api.get(`/has-match/${code}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (has.data.has_match) {
+          const resp = await api.get(`/match/${code}`, {
+            headers: { Authorization: `Bearer ${token}` }
+          });
+          const matchResults = resp.data.matches.map((m) => ({
+            ...m,
+            status: m.status || null
+          }));
+          const prev = matches[code];
+          if (!prev || JSON.stringify(prev) !== JSON.stringify(matchResults)) {
+            setMatches((prevState) => ({ ...prevState, [code]: matchResults }));
+            setMatchLoaded((prevState) => ({ ...prevState, [code]: true }));
+            setLoadingMatches((prevState) => ({ ...prevState, [code]: false }));
+            return;
+          }
         }
       } catch (err) {
         console.error('Error polling match status:', err);
@@ -239,6 +251,13 @@ if (shouldRedirect) {
 
   const handleRematch = async (code) => {
     try {
+      setMatches((prev) => {
+        const copy = { ...prev };
+        delete copy[code];
+        return copy;
+      });
+      setMatchLoaded((prev) => ({ ...prev, [code]: false }));
+      setMatchPresence((prev) => ({ ...prev, [code]: false }));
       setLoadingMatches((prev) => ({ ...prev, [code]: true }));
       const resp = await api.post(
         `/rematches/${code}`,
@@ -249,6 +268,7 @@ if (shouldRedirect) {
         const matchResults = resp.data.matches.map((m) => ({ ...m, status: null }));
         setMatches((prev) => ({ ...prev, [code]: matchResults }));
         setLoadingMatches((prev) => ({ ...prev, [code]: false }));
+        setMatchLoaded((prev) => ({ ...prev, [code]: true }));
       } else {
         pollForMatch(code);
       }


### PR DESCRIPTION
## Summary
- Delete previous `match_results` in `rematch_job` before queuing new match workers
- Recruiter UI polls until fresh match results differ from cached data and clears caches on rematch

## Testing
- `pytest -q`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c15098140833383f8a43a0661785d