### PR TITLE
fix: sync assigned count after rejection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1317,6 +1317,19 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         placed = set(job.get("placed_students", []))
         rejected = set(job.get("rejected_students", []))
 
+        existing = {m["email"] for m in matches}
+        for email in assigned:
+            if email not in existing:
+                udata = redis_client.hgetall(f"user:{email}") or {}
+                first = udata.get(b"first_name", b"").decode()
+                last = udata.get(b"last_name", b"").decode()
+                name = f"{first} {last}".strip()
+                matches.append({
+                    "name": name,
+                    "email": email,
+                    "score": None,
+                })
+
         for m in matches:
             if m["email"] in placed:
                 m["status"] = "placed"

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -415,6 +415,18 @@ if (shouldRedirect) {
           m.email === email ? { ...m, status: 'rejected' } : m
         )
       }));
+      setJobs((prevJobs) =>
+        prevJobs.map((j) =>
+          j.job_code === jobCode
+            ? {
+                ...j,
+                assigned_students: (j.assigned_students || []).filter(
+                  (em) => em !== email
+                ),
+              }
+            : j
+        )
+      );
     } catch (err) {
       console.error('Reject failed', err);
     }

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -219,6 +219,45 @@ def test_get_match_results_status_placed(monkeypatch):
     assert data["status"] == "placed"
 
 
+def test_get_match_results_includes_missing_assigned(monkeypatch):
+    token = login_admin()
+
+    store = {}
+
+    def fake_get(key):
+        return store.get(key)
+
+    def fake_set(key, value):
+        store[key] = value
+
+    monkeypatch.setattr(main_app.redis_client, "get", fake_get)
+    monkeypatch.setattr(main_app.redis_client, "set", fake_set)
+
+    job_code = "XYZ3"
+    store[f"match_results:{job_code}"] = json.dumps([])
+    store[f"job:{job_code}"] = json.dumps({
+        "job_code": job_code,
+        "assigned_students": ["a@example.com", "b@example.com"],
+        "placed_students": []
+    })
+
+    def fake_hgetall(key):
+        data = {
+            "user:a@example.com": {b"first_name": b"A", b"last_name": b"One"},
+            "user:b@example.com": {b"first_name": b"B", b"last_name": b"Two"},
+        }
+        return data.get(key, {})
+
+    monkeypatch.setattr(main_app.redis_client, "hgetall", fake_hgetall, raising=False)
+
+    resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()["matches"]
+    emails = {m["email"] for m in data}
+    assert emails == {"a@example.com", "b@example.com"}
+    assert all(m["status"] == "assigned" for m in data)
+
+
 def test_match_filters_by_license(monkeypatch):
     token = login_admin()
 


### PR DESCRIPTION
## Summary
- remove rejected candidates from job's assigned list so badge matches subtable

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cabb8b2f083339500b361e08ca781