### PR TITLE
Exclude assigned matches from limit and add recruiter note history

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1203,6 +1203,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{student.get('first_name', '')} {student.get('last_name', '')}",
+                "first_name": student.get("first_name", ""),
+                "last_name": student.get("last_name", ""),
                 "email": student.get("email"),
                 "score": score,
                 "distance_miles": round(dist, 1),
@@ -1241,6 +1243,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{udata.get('first_name', '')} {udata.get('last_name', '')}",
+                "first_name": udata.get("first_name", ""),
+                "last_name": udata.get("last_name", ""),
                 "email": email,
                 "score": 0.0,
                 "distance_miles": None,
@@ -1337,6 +1341,13 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         matches = json.loads(results_json)
         print(f"📦 Returning {len(matches)} stored matches for job {job_code}")
 
+        # Ensure each match has first and last name fields
+        for m in matches:
+            if "first_name" not in m or "last_name" not in m:
+                parts = m.get("name", "").split(" ", 1)
+                m.setdefault("first_name", parts[0] if parts else "")
+                m.setdefault("last_name", parts[1] if len(parts) > 1 else "")
+
         job_raw = redis_client.get(f"job:{job_code}")
         if not job_raw:
             raise HTTPException(status_code=404, detail="Job not found")
@@ -1355,6 +1366,8 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
                 name = f"{first} {last}".strip()
                 matches.append({
                     "name": name,
+                    "first_name": first,
+                    "last_name": last,
                     "email": email,
                     "score": None,
                 })

--- a/app/main.py
+++ b/app/main.py
@@ -1248,16 +1248,19 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         )
 
     matches.sort(key=lambda x: x["score"], reverse=True)
-    top_matches = matches[:10]
 
     assigned = set(job.get("assigned_students", []))
+    # Exclude already assigned students from the match limit so recruiters
+    # can always receive up to 10 new candidates regardless of how many
+    # students have been assigned.
+    filtered_matches = [m for m in matches if m["email"] not in assigned]
+    top_matches = filtered_matches[:10]
+
     placed = set(job.get("placed_students", []))
     rejected = set(job.get("rejected_students", []))
     for m in top_matches:
         if m["email"] in placed:
             m["status"] = "placed"
-        elif m["email"] in assigned:
-            m["status"] = "assigned"
         elif m["email"] in rejected:
             m["status"] = "rejected"
         else:

--- a/app/main.py
+++ b/app/main.py
@@ -1369,6 +1369,12 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
             else:
                 m["status"] = None
 
+            notes_raw = job.get("student_notes", {}).get(m["email"], [])
+            notes, latest_note = _normalize_notes(notes_raw)
+            m["notes"] = notes
+            if latest_note is not None:
+                m["note"] = latest_note
+
         return {"matches": matches}
     except Exception as e:
         print(f"❌ Failed to load match results for {job_code}: {e}")

--- a/app/main.py
+++ b/app/main.py
@@ -2472,7 +2472,10 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
 
 @app.get("/students/by-school")
 def students_by_school(current_user: dict = Depends(get_current_user)):
-    """Return all student profiles belonging to the current user's school."""
+    """Return student profiles for the current user's school.
+
+    Career service users only see profiles they created themselves.
+    """
     user_key = f"user:{current_user.get('sub')}"
     raw_user = redis_client.get(user_key)
     if not raw_user:
@@ -2511,6 +2514,9 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
             continue
 
         if (student.get("institutional_code") or student.get("school_code")) != institutional_code:
+            continue
+
+        if current_user.get("role") == "career" and student.get("created_by") != current_user.get("sub"):
             continue
 
         email = student.get("email")

--- a/app/main.py
+++ b/app/main.py
@@ -1203,6 +1203,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{student.get('first_name', '')} {student.get('last_name', '')}",
+                "first_name": student.get("first_name", ""),
+                "last_name": student.get("last_name", ""),
                 "email": student.get("email"),
                 "score": score,
                 "distance_miles": round(dist, 1),
@@ -1241,6 +1243,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{udata.get('first_name', '')} {udata.get('last_name', '')}",
+                "first_name": udata.get("first_name", ""),
+                "last_name": udata.get("last_name", ""),
                 "email": email,
                 "score": 0.0,
                 "distance_miles": None,
@@ -1337,6 +1341,13 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         matches = json.loads(results_json)
         print(f"📦 Returning {len(matches)} stored matches for job {job_code}")
 
+        # Ensure each match has first and last name fields
+        for m in matches:
+            if "first_name" not in m or "last_name" not in m:
+                parts = m.get("name", "").split(" ", 1)
+                m.setdefault("first_name", parts[0] if parts else "")
+                m.setdefault("last_name", parts[1] if len(parts) > 1 else "")
+
         job_raw = redis_client.get(f"job:{job_code}")
         if not job_raw:
             raise HTTPException(status_code=404, detail="Job not found")
@@ -1350,11 +1361,13 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         for email in assigned:
             if email not in existing:
                 udata = redis_client.hgetall(f"user:{email}") or {}
-                first = udata.get(b"first_name", b"").decode()
-                last = udata.get(b"last_name", b"").decode()
+                first = udata.get("first_name", "")
+                last = udata.get("last_name", "")
                 name = f"{first} {last}".strip()
                 matches.append({
                     "name": name,
+                    "first_name": first,
+                    "last_name": last,
                     "email": email,
                     "score": None,
                 })

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -645,7 +645,7 @@ if (shouldRedirect) {
                           ? row.notes[row.notes.length - 1].text
                           : row.note || ''}
                         <button onClick={() => openNotes(job, row)}>
-                          Comment
+                          View Notes{row.notes && ` (${row.notes.length})`}
                         </button>
                       </>
                     </td>
@@ -723,7 +723,7 @@ if (shouldRedirect) {
                     ? row.notes[row.notes.length - 1].text
                     : row.note || ''}
                   <button onClick={() => openNotes(job, row)}>
-                    Comment
+                    View Notes{row.notes && ` (${row.notes.length})`}
                   </button>
                 </>
               </td>
@@ -773,7 +773,7 @@ if (shouldRedirect) {
                     ? row.notes[row.notes.length - 1].text
                     : row.note || ''}
                   <button onClick={() => openNotes(job, row)}>
-                    Comment
+                    View Notes{row.notes && ` (${row.notes.length})`}
                   </button>
                 </>
               </td>

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -5,7 +5,7 @@ import api from './api';
 import AdminMenu from './AdminMenu';
 import loadGoogleMaps from './utils/loadGoogleMaps';
 import './JobPosting.css';
-import NoteEditor from './NoteEditor';
+import NotesHistoryModal from './NotesHistoryModal';
 
 function JobPosting() {
   const [formData, setFormData] = useState({
@@ -45,7 +45,7 @@ function JobPosting() {
     const l = licenses.find((x) => x.code === code);
     return l ? l.label : code;
   };
-  const [editingNotes, setEditingNotes] = useState({});
+  const [modalNotes, setModalNotes] = useState(null);
 
   const locationRef = useRef(null);
 
@@ -388,16 +388,25 @@ if (shouldRedirect) {
     }
   };
 
-  const startNote = (jobCode, email) => {
-    setEditingNotes((prev) => ({ ...prev, [`${jobCode}:${email}`]: true }));
-  };
-
-  const cancelNote = (jobCode, email) => {
-    setEditingNotes((prev) => {
-      const key = `${jobCode}:${email}`;
-      const copy = { ...prev };
-      delete copy[key];
-      return copy;
+  const openNotes = (job, row) => {
+    setModalNotes({
+      notes: row.notes || [],
+      jobCode: job.job_code,
+      studentEmail: row.email,
+      canAdd:
+        isRecruiter &&
+        job.posted_by === email &&
+        row.status === 'assigned',
+      onSaved: (newNote) => {
+        setMatches((prev) => ({
+          ...prev,
+          [job.job_code]: (prev[job.job_code] || []).map((m) =>
+            m.email === row.email
+              ? { ...m, note: newNote.text, notes: [...(m.notes || []), newNote] }
+              : m
+          ),
+        }));
+      },
     });
   };
 
@@ -631,37 +640,14 @@ if (shouldRedirect) {
                       )}
                     </td>
                     <td>
-                      {editingNotes[`${job.job_code}:${row.email}`] ? (
-                        <NoteEditor
-                          jobCode={job.job_code}
-                          email={row.email}
-                          notes={row.notes || []}
-                          onSaved={(newNote) => {
-                            setMatches((prev) => ({
-                              ...prev,
-                              [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                                m.email === row.email
-                                  ? {
-                                      ...m,
-                                      note: newNote.text,
-                                      notes: [...(m.notes || []), newNote],
-                                    }
-                                  : m
-                              ),
-                            }));
-                          }}
-                          onCancel={() => cancelNote(job.job_code, row.email)}
-                        />
-                      ) : (
-                        <>
-                          {row.notes && row.notes.length
-                            ? row.notes[row.notes.length - 1].text
-                            : row.note || ''}
-                          <button onClick={() => startNote(job.job_code, row.email)}>
-                            Comment
-                          </button>
-                        </>
-                      )}
+                      <>
+                        {row.notes && row.notes.length
+                          ? row.notes[row.notes.length - 1].text
+                          : row.note || ''}
+                        <button onClick={() => openNotes(job, row)}>
+                          Comment
+                        </button>
+                      </>
                     </td>
                     <td className="status-cell">
                       {row.status === 'placed' ? (
@@ -732,37 +718,14 @@ if (shouldRedirect) {
                 )}
               </td>
               <td>
-                {editingNotes[`${job.job_code}:${row.email}`] ? (
-                  <NoteEditor
-                    jobCode={job.job_code}
-                    email={row.email}
-                    notes={row.notes || []}
-                    onSaved={(newNote) => {
-                      setMatches((prev) => ({
-                        ...prev,
-                        [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                          m.email === row.email
-                            ? {
-                                ...m,
-                                note: newNote.text,
-                                notes: [...(m.notes || []), newNote],
-                              }
-                            : m
-                        ),
-                      }));
-                    }}
-                    onCancel={() => cancelNote(job.job_code, row.email)}
-                  />
-                ) : (
-                  <>
-                    {row.notes && row.notes.length
-                      ? row.notes[row.notes.length - 1].text
-                      : row.note || ''}
-                    <button onClick={() => startNote(job.job_code, row.email)}>
-                      Comment
-                    </button>
-                  </>
-                )}
+                <>
+                  {row.notes && row.notes.length
+                    ? row.notes[row.notes.length - 1].text
+                    : row.note || ''}
+                  <button onClick={() => openNotes(job, row)}>
+                    Comment
+                  </button>
+                </>
               </td>
               <td className="status-cell">
                 <span className="badge assigned inline">Assigned</span>
@@ -805,37 +768,14 @@ if (shouldRedirect) {
               <td>{row.email}</td>
               <td>{row.score?.toFixed(2)}</td>
               <td>
-                {editingNotes[`${job.job_code}:${row.email}`] ? (
-                  <NoteEditor
-                    jobCode={job.job_code}
-                    email={row.email}
-                    notes={row.notes || []}
-                    onSaved={(newNote) => {
-                      setMatches((prev) => ({
-                        ...prev,
-                        [job.job_code]: (prev[job.job_code] || []).map((m) =>
-                          m.email === row.email
-                            ? {
-                                ...m,
-                                note: newNote.text,
-                                notes: [...(m.notes || []), newNote],
-                              }
-                            : m
-                        ),
-                      }));
-                    }}
-                    onCancel={() => cancelNote(job.job_code, row.email)}
-                  />
-                ) : (
-                  <>
-                    {row.notes && row.notes.length
-                      ? row.notes[row.notes.length - 1].text
-                      : row.note || ''}
-                    <button onClick={() => startNote(job.job_code, row.email)}>
-                      Comment
-                    </button>
-                  </>
-                )}
+                <>
+                  {row.notes && row.notes.length
+                    ? row.notes[row.notes.length - 1].text
+                    : row.note || ''}
+                  <button onClick={() => openNotes(job, row)}>
+                    Comment
+                  </button>
+                </>
               </td>
             </tr>
           ))}
@@ -1329,6 +1269,17 @@ if (shouldRedirect) {
           </div>
         )}
       </div>
+      {modalNotes && (
+        <NotesHistoryModal
+          notes={modalNotes.notes}
+          jobCode={modalNotes.jobCode}
+          studentEmail={modalNotes.studentEmail}
+          canAdd={modalNotes.canAdd}
+          isAdmin={userRole === 'admin'}
+          onClose={() => setModalNotes(null)}
+          onSaved={modalNotes.onSaved}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -640,14 +640,9 @@ if (shouldRedirect) {
                       )}
                     </td>
                     <td>
-                      <>
-                        {row.notes && row.notes.length
-                          ? row.notes[row.notes.length - 1].text
-                          : row.note || ''}
-                        <button onClick={() => openNotes(job, row)}>
-                          View Notes{row.notes && ` (${row.notes.length})`}
-                        </button>
-                      </>
+                      <button onClick={() => openNotes(job, row)}>
+                        View Notes{row.notes && ` (${row.notes.length})`}
+                      </button>
                     </td>
                     <td className="status-cell">
                       {row.status === 'placed' ? (
@@ -718,14 +713,9 @@ if (shouldRedirect) {
                 )}
               </td>
               <td>
-                <>
-                  {row.notes && row.notes.length
-                    ? row.notes[row.notes.length - 1].text
-                    : row.note || ''}
-                  <button onClick={() => openNotes(job, row)}>
-                    View Notes{row.notes && ` (${row.notes.length})`}
-                  </button>
-                </>
+                <button onClick={() => openNotes(job, row)}>
+                  View Notes{row.notes && ` (${row.notes.length})`}
+                </button>
               </td>
               <td className="status-cell">
                 <span className="badge assigned inline">Assigned</span>
@@ -768,14 +758,9 @@ if (shouldRedirect) {
               <td>{row.email}</td>
               <td>{row.score?.toFixed(2)}</td>
               <td>
-                <>
-                  {row.notes && row.notes.length
-                    ? row.notes[row.notes.length - 1].text
-                    : row.note || ''}
-                  <button onClick={() => openNotes(job, row)}>
-                    View Notes{row.notes && ` (${row.notes.length})`}
-                  </button>
-                </>
+                <button onClick={() => openNotes(job, row)}>
+                  View Notes{row.notes && ` (${row.notes.length})`}
+                </button>
               </td>
             </tr>
           ))}

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -83,6 +83,7 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
           <thead>
             <tr>
               <th>#</th>
+              <th>Date</th>
               <th>Note</th>
               {isAdmin && <th>Actions</th>}
             </tr>
@@ -92,6 +93,7 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
               localNotes.map((n, idx) => (
                 <tr key={idx}>
                   <td>{idx + 1}</td>
+                  <td>{n.timestamp ? new Date(n.timestamp).toLocaleString() : ''}</td>
                   <td>
                     {editingIndex === idx ? (
                       <textarea
@@ -118,10 +120,10 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
                     </td>
                   )}
                 </tr>
-              ))
+            ))
             ) : (
               <tr>
-                <td colSpan={isAdmin ? 3 : 2}>No notes available.</td>
+                <td colSpan={isAdmin ? 4 : 3}>No notes available.</td>
               </tr>
             )}
           </tbody>

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import api from './api';
 import NoteEditor from './NoteEditor';
 
-function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = false, jobCode, studentEmail }) {
+function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = false, jobCode, studentEmail, onSaved }) {
   const [localNotes, setLocalNotes] = useState(notes);
   const [adding, setAdding] = useState(false);
   const [editingIndex, setEditingIndex] = useState(null);
@@ -12,6 +12,7 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
   const handleAddSaved = (newNote) => {
     setLocalNotes(prev => [...prev, newNote]);
     setAdding(false);
+    onSaved && onSaved(newNote);
   };
 
   const startEdit = (idx) => {

--- a/frontend/src/NotesHistoryModal.test.js
+++ b/frontend/src/NotesHistoryModal.test.js
@@ -36,3 +36,17 @@ test('no add button when not allowed', () => {
   );
   expect(screen.queryByText('Add Note')).not.toBeInTheDocument();
 });
+
+test('shows note timestamp in local time', () => {
+  render(
+    <NotesHistoryModal
+      notes={[{ text: 'hi', timestamp: '2024-01-01T00:00:00Z' }]}
+      onClose={() => {}}
+      jobCode="J1"
+      studentEmail="s@example.com"
+      canAdd={false}
+      isAdmin={false}
+    />
+  );
+  expect(screen.getByText(/2024/)).toBeInTheDocument();
+});

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -776,7 +776,7 @@ function StudentProfiles() {
                 </tbody>
               </table>
             ) : (
-              <p>No students found for your school.</p>
+              <p>You haven't created any student profiles.</p>
             )}
           </div>
         </div>

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -256,6 +256,9 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     emails = {m["email"] for m in data}
     assert emails == {"a@example.com", "b@example.com"}
     assert all(m["status"] == "assigned" for m in data)
+    names = {m["email"]: (m.get("first_name"), m.get("last_name")) for m in data}
+    assert names["a@example.com"] == ("A", "One")
+    assert names["b@example.com"] == ("B", "Two")
 
 
 def test_get_match_results_includes_notes(monkeypatch):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -258,6 +258,39 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     assert all(m["status"] == "assigned" for m in data)
 
 
+def test_get_match_results_includes_notes(monkeypatch):
+    token = login_admin()
+
+    store = {}
+
+    def fake_get(key):
+        return store.get(key)
+
+    def fake_set(key, value):
+        store[key] = value
+
+    monkeypatch.setattr(main_app.redis_client, "get", fake_get)
+    monkeypatch.setattr(main_app.redis_client, "set", fake_set)
+
+    job_code = "XYZ4"
+    store[f"match_results:{job_code}"] = json.dumps([
+        {"email": "a@example.com", "score": 1.0}
+    ])
+    store[f"job:{job_code}"] = json.dumps({
+        "job_code": job_code,
+        "assigned_students": [],
+        "placed_students": [],
+        "rejected_students": [],
+        "student_notes": {"a@example.com": [{"text": "hi"}]}
+    })
+
+    resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()["matches"][0]
+    assert data["notes"][0]["text"] == "hi"
+    assert data["note"] == "hi"
+
+
 def test_match_filters_by_license(monkeypatch):
     token = login_admin()
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -814,6 +814,68 @@ def test_not_interested_filters_out_student(monkeypatch):
     assert s2["email"] in stored.get("uninterested_students", [])
 
 
+def test_match_limit_ignores_assigned_students(monkeypatch):
+    token = login_admin()
+
+    class FakeResp:
+        def __init__(self, emb):
+            self.data = [type("obj", (), {"embedding": emb})]
+
+    monkeypatch.setattr(
+        main_app.client.embeddings,
+        "create",
+        lambda *a, **k: FakeResp([1.0, 0.0]),
+    )
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 1.0)
+
+    students = []
+    for i in range(13):
+        stu = {
+            "first_name": "Stu",
+            "last_name": str(i),
+            "email": f"s{i}@example.com",
+            "phone": "1",
+            "license": "ma",
+            "skills": ["python"],
+            "experience_summary": "s",
+            "interests": "i",
+            "city": "c",
+            "state": "s",
+            "lat": 0.0,
+            "lng": 0.0,
+            "max_travel": 10.0,
+            "school_code": "1001",
+        }
+        client.post("/students", json=stu, headers={"Authorization": f"Bearer {token}"})
+        students.append(stu)
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "desc",
+        "desired_skills": ["python"],
+        "min_pay": 1.0,
+        "max_pay": 2.0,
+        "city": "c",
+        "state": "s",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+    job_code = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"}).json()["job_code"]
+
+    for stu in students[:3]:
+        client.post(
+            "/assign",
+            json={"job_code": job_code, "student_email": stu["email"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    resp = client.post("/match", json={"job_code": job_code}, headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()["matches"]
+    assert len(data) == 10
+    assigned_emails = {s["email"] for s in students[:3]}
+    assert all(m["email"] not in assigned_emails for m in data)
+
+
 def test_recruiter_job_source_autopopulated(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -243,8 +243,8 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
 
     def fake_hgetall(key):
         data = {
-            "user:a@example.com": {b"first_name": b"A", b"last_name": b"One"},
-            "user:b@example.com": {b"first_name": b"B", b"last_name": b"Two"},
+            "user:a@example.com": {"first_name": "A", "last_name": "One"},
+            "user:b@example.com": {"first_name": "B", "last_name": "Two"},
         }
         return data.get(key, {})
 
@@ -256,6 +256,9 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     emails = {m["email"] for m in data}
     assert emails == {"a@example.com", "b@example.com"}
     assert all(m["status"] == "assigned" for m in data)
+    names = {m["email"]: (m.get("first_name"), m.get("last_name")) for m in data}
+    assert names["a@example.com"] == ("A", "One")
+    assert names["b@example.com"] == ("B", "Two")
 
 
 def test_get_match_results_includes_notes(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1729,6 +1729,7 @@ def test_students_by_school_fallback():
         "experience_summary": "",
         "interests": "",
         "school_code": "1001",
+        "created_by": "counselor@example.com",
         "city": "City",
         "state": "ST",
     }
@@ -1792,6 +1793,7 @@ def test_student_endpoints_handle_string_notes():
         "last_name": "Dent",
         "email": "student@example.com",
         "institutional_code": "001",
+        "created_by": "counselor@example.com",
         "city": "City",
         "state": "ST",
     }


### PR DESCRIPTION
## Summary
- ensure assigned students don't reduce available matches
- show recruiters a notes history modal instead of inline editor
- cover assigned-limit behavior with a new test

## Testing
- `pytest`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb0e4bb1c83338369eb0f65e144ab