### PR TITLE
Include first and last names in match results

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1203,6 +1203,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{student.get('first_name', '')} {student.get('last_name', '')}",
+                "first_name": student.get("first_name", ""),
+                "last_name": student.get("last_name", ""),
                 "email": student.get("email"),
                 "score": score,
                 "distance_miles": round(dist, 1),
@@ -1241,6 +1243,8 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
         matches.append(
             {
                 "name": f"{udata.get('first_name', '')} {udata.get('last_name', '')}",
+                "first_name": udata.get("first_name", ""),
+                "last_name": udata.get("last_name", ""),
                 "email": email,
                 "score": 0.0,
                 "distance_miles": None,
@@ -1337,6 +1341,13 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         matches = json.loads(results_json)
         print(f"📦 Returning {len(matches)} stored matches for job {job_code}")
 
+        # Ensure each match has first and last name fields
+        for m in matches:
+            if "first_name" not in m or "last_name" not in m:
+                parts = m.get("name", "").split(" ", 1)
+                m.setdefault("first_name", parts[0] if parts else "")
+                m.setdefault("last_name", parts[1] if len(parts) > 1 else "")
+
         job_raw = redis_client.get(f"job:{job_code}")
         if not job_raw:
             raise HTTPException(status_code=404, detail="Job not found")
@@ -1349,12 +1360,30 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         existing = {m["email"] for m in matches}
         for email in assigned:
             if email not in existing:
-                udata = redis_client.hgetall(f"user:{email}") or {}
-                first = udata.get(b"first_name", b"").decode()
-                last = udata.get(b"last_name", b"").decode()
+                first = ""
+                last = ""
+                try:
+                    raw_user = redis_client.get(f"user:{email}")
+                    if raw_user:
+                        udata = json.loads(raw_user)
+                        first = udata.get("first_name", "")
+                        last = udata.get("last_name", "")
+                except Exception:
+                    pass
+                if not first or not last:
+                    try:
+                        raw_student = redis_client.get(f"student:{email}")
+                        if raw_student:
+                            sdata = json.loads(raw_student)
+                            first = first or sdata.get("first_name", "")
+                            last = last or sdata.get("last_name", "")
+                    except Exception:
+                        pass
                 name = f"{first} {last}".strip()
                 matches.append({
                     "name": name,
+                    "first_name": first,
+                    "last_name": last,
                     "email": email,
                     "score": None,
                 })

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -240,15 +240,8 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
         "assigned_students": ["a@example.com", "b@example.com"],
         "placed_students": []
     })
-
-    def fake_hgetall(key):
-        data = {
-            "user:a@example.com": {b"first_name": b"A", b"last_name": b"One"},
-            "user:b@example.com": {b"first_name": b"B", b"last_name": b"Two"},
-        }
-        return data.get(key, {})
-
-    monkeypatch.setattr(main_app.redis_client, "hgetall", fake_hgetall, raising=False)
+    store["user:a@example.com"] = json.dumps({"first_name": "A", "last_name": "One"})
+    store["user:b@example.com"] = json.dumps({"first_name": "B", "last_name": "Two"})
 
     resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
@@ -256,6 +249,9 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     emails = {m["email"] for m in data}
     assert emails == {"a@example.com", "b@example.com"}
     assert all(m["status"] == "assigned" for m in data)
+    names = {m["email"]: (m.get("first_name"), m.get("last_name")) for m in data}
+    assert names["a@example.com"] == ("A", "One")
+    assert names["b@example.com"] == ("B", "Two")
 
 
 def test_get_match_results_includes_notes(monkeypatch):


### PR DESCRIPTION
## Summary
- retrieve names for newly assigned students from stored user or student records so match tables show first and last names
- update tests to verify assigned matches include student names when sourced from JSON strings

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a1f74302b48333b0b79563158ea5ae