### PR TITLE
Restrict career staff to their own students

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2472,7 +2472,10 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
 
 @app.get("/students/by-school")
 def students_by_school(current_user: dict = Depends(get_current_user)):
-    """Return all student profiles belonging to the current user's school."""
+    """Return student profiles for the current user's school.
+
+    Career service users only see profiles they created themselves.
+    """
     user_key = f"user:{current_user.get('sub')}"
     raw_user = redis_client.get(user_key)
     if not raw_user:
@@ -2511,6 +2514,9 @@ def students_by_school(current_user: dict = Depends(get_current_user)):
             continue
 
         if (student.get("institutional_code") or student.get("school_code")) != institutional_code:
+            continue
+
+        if current_user.get("role") == "career" and student.get("created_by") != current_user.get("sub"):
             continue
 
         email = student.get("email")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1729,6 +1729,7 @@ def test_students_by_school_fallback():
         "experience_summary": "",
         "interests": "",
         "school_code": "1001",
+        "created_by": "counselor@example.com",
         "city": "City",
         "state": "ST",
     }
@@ -1792,6 +1793,7 @@ def test_student_endpoints_handle_string_notes():
         "last_name": "Dent",
         "email": "student@example.com",
         "institutional_code": "001",
+        "created_by": "counselor@example.com",
         "city": "City",
         "state": "ST",
     }


### PR DESCRIPTION
## Summary
- Limit `/students/by-school` so career users see only student profiles they created
- Update tests to include `created_by` metadata for career-owned students

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1ff1ae4ec8333b199209bfcd4ad0b