### PR TITLE
feat: enhance top menu visuals

### DIFF
--- a/frontend/src/TopMenu.css
+++ b/frontend/src/TopMenu.css
@@ -1,8 +1,12 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+
 .top-menu {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
-  background-color: #003366;
+  background-color: rgba(0, 51, 102, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   padding: 0.5rem 1rem;
   border-radius: 8px;
   display: flex;
@@ -14,10 +18,21 @@
   color: #ffffff;
   text-decoration: none;
   font-weight: 500;
+  text-decoration-color: transparent;
+  transition: color 0.3s ease, text-decoration-color 0.3s ease;
 }
 
-.top-menu a:hover {
+.top-menu a:hover,
+.top-menu a:focus {
+  color: #e0e0e0;
   text-decoration: underline;
+  text-decoration-color: #e0e0e0;
+}
+
+.top-menu .material-icons {
+  font-size: 1.1rem;
+  vertical-align: middle;
+  margin-right: 0.25rem;
 }
 
 /* Stack links vertically on small screens */

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -5,11 +5,26 @@ import './TopMenu.css';
 function TopMenu() {
   return (
     <nav className="top-menu">
-      <Link to="/">Home</Link>
-      <Link to="/about">About TalentMatch-AI</Link>
-      <Link to="/about/applicants">Applicants</Link>
-      <Link to="/about/career-service">Career Service</Link>
-      <Link to="/about/recruiters">Recruiters</Link>
+      <Link to="/">
+        <span className="material-icons">home</span>
+        Home
+      </Link>
+      <Link to="/about">
+        <span className="material-icons">info</span>
+        About TalentMatch-AI
+      </Link>
+      <Link to="/about/applicants">
+        <span className="material-icons">person</span>
+        Applicants
+      </Link>
+      <Link to="/about/career-service">
+        <span className="material-icons">work</span>
+        Career Service
+      </Link>
+      <Link to="/about/recruiters">
+        <span className="material-icons">group</span>
+        Recruiters
+      </Link>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- add glass-like styling with hover transitions to top menu
- integrate Material Icons with top menu links for visual clarity

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a23816638083338c2c97a597dc47ea