### PR TITLE
Add skeleton loading placeholders to key pages

### DIFF
--- a/frontend/src/ActivityLog.js
+++ b/frontend/src/ActivityLog.js
@@ -4,10 +4,12 @@ import jwtDecode from 'jwt-decode';
 import AdminMenu from './AdminMenu';
 import api from './api';
 import './ActivityLog.css';
+import Skeleton from './components/Skeleton';
 
 function ActivityLog() {
   const [entries, setEntries] = useState([]);
   const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
 
   const token = localStorage.getItem('token');
   let role = '';
@@ -20,6 +22,7 @@ function ActivityLog() {
 
   useEffect(() => {
     const fetchLog = async () => {
+      setIsLoading(true);
       try {
         const resp = await api.get('/activity-log?limit=100', {
           headers: { Authorization: `Bearer ${token}` }
@@ -28,6 +31,8 @@ function ActivityLog() {
       } catch (err) {
         console.error('Failed to load log:', err);
         setError(err.response?.data?.detail || 'Failed to load log');
+      } finally {
+        setIsLoading(false);
       }
     };
     if (token) fetchLog();
@@ -61,26 +66,34 @@ function ActivityLog() {
       <button className="download-btn" onClick={downloadCSV}>
         Download CSV
       </button>
-      <table className="log-table">
-        <thead>
-          <tr>
-            <th>Timestamp</th>
-            <th>Method</th>
-            <th>Path</th>
-            <th>User</th>
-          </tr>
-        </thead>
-        <tbody>
-          {entries.map((e, idx) => (
-            <tr key={idx}>
-              <td>{e.timestamp}</td>
-              <td>{e.method}</td>
-              <td>{e.path}</td>
-              <td>{e.user}</td>
-            </tr>
+      {isLoading ? (
+        <div className="skeleton-container">
+          {[...Array(5)].map((_, idx) => (
+            <Skeleton key={idx} style={{ height: '20px', marginBottom: '10px' }} />
           ))}
-        </tbody>
-      </table>
+        </div>
+      ) : (
+        <table className="log-table fade-in">
+          <thead>
+            <tr>
+              <th>Timestamp</th>
+              <th>Method</th>
+              <th>Path</th>
+              <th>User</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, idx) => (
+              <tr key={idx}>
+                <td>{e.timestamp}</td>
+                <td>{e.method}</td>
+                <td>{e.path}</td>
+                <td>{e.user}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import api from './api';
 import jwtDecode from 'jwt-decode';
 import AdminMenu from './AdminMenu';
+import Skeleton from './components/Skeleton';
 import {
   BarChart,
   Bar,
@@ -24,7 +25,7 @@ import './Metrics.css';
 function Metrics() {
   const [metricsData, setMetricsData] = useState(null);
   const [role, setRole] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [interval] = useState('all');
 
   useEffect(() => {
@@ -45,17 +46,21 @@ function Metrics() {
       } catch (err) {
         console.error('Error fetching metrics:', err);
       } finally {
-        setLoading(false);
+        setIsLoading(false);
       }
     };
     fetchMetrics();
   }, []);
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="metrics-container">
         <AdminMenu />
-        Loading...
+        <div className="metric-grid">
+          {[...Array(4)].map((_, idx) => (
+            <Skeleton key={idx} style={{ height: '80px' }} />
+          ))}
+        </div>
       </div>
     );
   }
@@ -104,7 +109,7 @@ function Metrics() {
   const colors = ['#00BFFF', '#32CD32', '#FF69B4', '#FFA500', '#9370DB'];
 
   return (
-    <div className="metrics-container">
+    <div className="metrics-container fade-in">
       <AdminMenu />
       <div className="metric-grid">
         {highlight.map((h) => (

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -9,6 +9,7 @@ import jwt_decode from 'jwt-decode';
 import './StudentProfiles.css';
 import './Tour.css';
 import NotesHistoryModal from './NotesHistoryModal';
+import Skeleton from './components/Skeleton';
 
 function StudentProfiles() {
   const [formData, setFormData] = useState({
@@ -559,12 +560,13 @@ function StudentProfiles() {
         >
           <div style={{ flexGrow: 1, minHeight: 0, marginTop: '0' }}>
             {isLoading ? (
-              <div className="loading-container">
-                <span className="spinner" />
-                <span style={{ marginLeft: '0.5rem' }}>Loading students...</span>
+              <div className="skeleton-container">
+                {[...Array(5)].map((_, idx) => (
+                  <Skeleton key={idx} style={{ height: '20px', marginBottom: '10px' }} />
+                ))}
               </div>
             ) : schoolStudents.length > 0 ? (
-              <table className="school-table">
+              <table className="school-table fade-in">
                 <thead>
                   <tr>
                     <th></th>

--- a/frontend/src/components/Skeleton.css
+++ b/frontend/src/components/Skeleton.css
@@ -1,0 +1,22 @@
+.skeleton {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  width: 100%;
+  height: 1em;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+}
+
+.fade-in {
+  animation: fadeIn 0.3s ease forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/frontend/src/components/Skeleton.js
+++ b/frontend/src/components/Skeleton.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './Skeleton.css';
+
+function Skeleton({ className = '', style = {} }) {
+  return <div className={`skeleton ${className}`} style={style} />;
+}
+
+export default Skeleton;


### PR DESCRIPTION
## Summary
- add reusable Skeleton component with pulse animation
- show skeleton placeholders in StudentProfiles, Metrics, and ActivityLog while loading
- fade in content once data is ready for smoother transitions

## Testing
- `CI=true npm test --silent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2420971a48333879f76e39324405c