### PR TITLE
feat: add reusable form components

### DIFF
--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -37,22 +37,6 @@
   width: 300px;
 }
 
-.login-form input {
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  border-radius: 5px;
-  border: none;
-}
-
-.login-form button {
-  background-color: #0074d9;
-  color: white;
-  border: none;
-  padding: 0.7rem;
-  border-radius: 5px;
-  cursor: pointer;
-}
-
 .error {
   margin-top: 1rem;
   color: #ff4136;

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -3,11 +3,14 @@ import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 import TopMenu from './TopMenu';
+import Button from './components/Button';
+import Input from './components/Input';
 
 function LoginForm({ infoContent }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -20,10 +23,9 @@ function LoginForm({ infoContent }) {
       return;
     }
 
+    setLoading(true);
     try {
-      const resp = await api.post('/login',
-        { email, password }
-      );
+      const resp = await api.post('/login', { email, password });
 
       console.log('Response data:', resp.data);
 
@@ -52,6 +54,8 @@ function LoginForm({ infoContent }) {
       } else {
         setError(err.response?.data?.detail || 'Login failed');
       }
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -63,22 +67,26 @@ function LoginForm({ infoContent }) {
         <h2>Login</h2>
 
         <label htmlFor="email">Email</label>
-        <input
+        <Input
           id="email"
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          disabled={loading}
+          error={error}
         />
 
         <label htmlFor="password">Password</label>
-        <input
+        <Input
           id="password"
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          disabled={loading}
+          error={error}
         />
 
-        <button type="submit">Login</button>
+        <Button type="submit" loading={loading}>Login</Button>
 
         <Link to="/register" className="register-link">Register</Link>
 

--- a/frontend/src/RegisterForm.css
+++ b/frontend/src/RegisterForm.css
@@ -16,30 +16,12 @@
   width: 300px;
 }
 
-.register-form input {
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  border-radius: 5px;
-  border: none;
-  color: black;
-}
-
 .register-form select {
   margin-bottom: 1rem;
   padding: 0.5rem;
   border-radius: 5px;
   border: none;
   color: black;
-}
-
-.register-form button {
-  background-color: #0074d9;
-  color: white;
-  border: none;
-  padding: 0.7rem;
-  border-radius: 5px;
-  cursor: pointer;
-  margin-top: 0.5rem;
 }
 
 .message {

--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import api from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './RegisterForm.css';
+import Button from './components/Button';
+import Input from './components/Input';
 
 function RegisterForm() {
   const [formData, setFormData] = useState({
@@ -14,6 +16,7 @@ function RegisterForm() {
   const [institutionalCode, setInstitutionalCode] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleChange = (e) => {
@@ -36,6 +39,7 @@ function RegisterForm() {
       return;
     }
 
+    setLoading(true);
     try {
       const resp = await api.post('/register', {
         email: formData.email,
@@ -54,6 +58,8 @@ function RegisterForm() {
       } else {
         setError(detail || 'Registration failed');
       }
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -62,55 +68,65 @@ function RegisterForm() {
       <form className="register-form" onSubmit={handleSubmit}>
         <h2>Register</h2>
         <label htmlFor="email">Email</label>
-        <input
+        <Input
           id="email"
           name="email"
           type="email"
           value={formData.email}
           onChange={handleChange}
+          disabled={loading}
+          error={error}
         />
         <label htmlFor="firstName">First Name</label>
-        <input
+        <Input
           id="firstName"
           name="firstName"
           type="text"
           value={formData.firstName}
           onChange={handleChange}
+          disabled={loading}
+          error={error}
         />
         <label htmlFor="lastName">Last Name</label>
-        <input
+        <Input
           id="lastName"
           name="lastName"
           type="text"
           value={formData.lastName}
           onChange={handleChange}
+          disabled={loading}
+          error={error}
         />
         <label htmlFor="role">Role</label>
-        <select id="role" name="role" value={formData.role} onChange={handleChange}>
+        <select id="role" name="role" value={formData.role} onChange={handleChange} disabled={loading}>
           <option value="applicant">Applicant</option>
           <option value="career">Career Services</option>
           <option value="recruiter">Recruiter</option>
         </select>
         <label htmlFor="institutional_code">Institutional Code</label>
-        <input
+        <Input
           id="institutional_code"
           name="institutional_code"
           type="text"
           maxLength={4}
           value={institutionalCode}
           onChange={(e) => setInstitutionalCode(e.target.value)}
+          disabled={loading}
+          error={error}
         />
         <Link to="/request-code" className="request-code-link">Request an institutional code</Link>
         {error && <p className="error">{error}</p>}
         <label htmlFor="password">Password</label>
-        <input
+        <Input
           id="password"
           name="password"
           type="password"
           value={formData.password}
           onChange={handleChange}
+          disabled={loading}
+          error={error}
         />
-        <button type="submit">Register</button>
+        <Button type="submit" loading={loading}>Register</Button>
         <Link to="/login" className="login-link">Back to Login</Link>
         {message && <p className="message">{message}</p>}
       </form>

--- a/frontend/src/components/Button.js
+++ b/frontend/src/components/Button.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from './Button.module.css';
+
+const Button = ({ children, loading = false, disabled = false, className = '', ...props }) => {
+  const isDisabled = disabled || loading;
+  return (
+    <button
+      className={`${styles.button} ${isDisabled ? styles.disabled : ''} ${loading ? styles.loading : ''} ${className}`}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      aria-busy={loading}
+      {...props}
+    >
+      {loading ? 'Loading…' : children}
+    </button>
+  );
+};
+
+export default Button;

--- a/frontend/src/components/Button.module.css
+++ b/frontend/src/components/Button.module.css
@@ -1,0 +1,34 @@
+.button {
+  background-color: #0074d9;
+  color: white;
+  border: none;
+  padding: 0.7rem;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover:not(.disabled) {
+  transform: scale(1.03);
+  box-shadow: 0 0 8px rgba(0, 116, 217, 0.6);
+}
+
+.button:active:not(.disabled) {
+  transform: scale(0.97);
+}
+
+.button:focus-visible {
+  outline: 2px solid #0056b3;
+  outline-offset: 2px;
+}
+
+.disabled,
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.loading {
+  position: relative;
+}

--- a/frontend/src/components/Input.js
+++ b/frontend/src/components/Input.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './Input.module.css';
+
+const Input = React.forwardRef(({ error, className = '', disabled = false, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={`${styles.input} ${error ? styles.error : ''} ${className}`}
+      aria-invalid={!!error}
+      disabled={disabled}
+      {...props}
+    />
+  );
+});
+
+export default Input;

--- a/frontend/src/components/Input.module.css
+++ b/frontend/src/components/Input.module.css
@@ -1,0 +1,30 @@
+.input {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.input:hover,
+.input:focus {
+  transform: scale(1.02);
+  box-shadow: 0 0 5px rgba(0, 116, 217, 0.4);
+  border-color: #0074d9;
+  outline: none;
+}
+
+.input:disabled {
+  background-color: #f0f0f0;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.error {
+  border-color: #ff4136;
+}
+
+.error:hover,
+.error:focus {
+  box-shadow: 0 0 5px rgba(255, 65, 54, 0.5);
+}


### PR DESCRIPTION
## Summary
- add Button and Input components with hover and active CSS transitions
- replace inline elements in login and registration forms
- improve accessibility with loading and error states

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a241f87cfc8333b0903f09bd8836b3