### PR TITLE
feat: add design tokens and apply across styles

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,22 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Design Tokens
+
+Spacing and border radius values are standardized in `src/index.css` using CSS variables:
+
+```css
+:root {
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --radius-sm: 0.3125rem;
+  --radius-lg: 0.625rem;
+}
+```
+
+Use these tokens for `padding`, `margin`, and `border-radius` in components. Values not matching the exact tokens can be derived with `calc()`, for example `calc(var(--space-md) * 2)` for `2rem`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/frontend/src/ActivityLog.css
+++ b/frontend/src/ActivityLog.css
@@ -2,9 +2,9 @@
   background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
   min-height: 100vh;
   color: white;
-  padding: 2rem;
+  padding: calc(var(--space-md) * 2);
   position: relative;
-  border-radius: 1.25rem;
+  border-radius: calc(var(--radius-lg) * 2);
   max-width: 98vw;
   margin: 0 auto;
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
@@ -14,11 +14,11 @@
   background-color: #0074d9;
   color: white;
   border: none;
-  padding: 0.4rem 0.8rem;
-  border-radius: 5px;
+  padding: calc(var(--space-md) * 0.4) calc(var(--space-md) * 0.8);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-weight: 600;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-md);
 }
 
 .log-table {
@@ -29,7 +29,7 @@
 .log-table th,
 .log-table td {
   border: 1px solid #ccc;
-  padding: 0.5rem;
+  padding: var(--space-sm);
 }
 
 .log-table th {

--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -2,13 +2,13 @@
   background: linear-gradient(135deg, #001f3f, #003366 50%, #004080);
   min-height: 100vh;
   color: white;
-  padding: 2rem;
+  padding: calc(var(--space-md) * 2);
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1.5rem;
+  gap: calc(var(--space-md) * 1.5);
   text-align: center;
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
@@ -32,8 +32,8 @@
   background-color: rgba(255, 255, 255, 0.9);
   color: #002244;
   text-decoration: none;
-  padding: 1.5rem;
-  border-radius: 10px;
+  padding: calc(var(--space-md) * 1.5);
+  border-radius: var(--radius-lg);
   text-align: center;
   font-weight: 600;
   animation: fadeSlide 0.6s ease forwards;

--- a/frontend/src/LoginForm.css
+++ b/frontend/src/LoginForm.css
@@ -15,13 +15,13 @@
 
 .login-container.with-info .login-content {
   flex-direction: row;
-  gap: 2rem;
+  gap: calc(var(--space-md) * 2);
 }
 
 .info-panel {
   background-color: #003366;
-  padding: 2rem;
-  border-radius: 10px;
+  padding: calc(var(--space-md) * 2);
+  border-radius: var(--radius-lg);
   color: white;
   max-width: 400px;
   border-left: 2px solid white;
@@ -29,8 +29,8 @@
 
 .login-form {
   background-color: #003366;
-  padding: 2rem;
-  border-radius: 10px;
+  padding: calc(var(--space-md) * 2);
+  border-radius: var(--radius-lg);
   color: white;
   display: flex;
   flex-direction: column;
@@ -38,9 +38,9 @@
 }
 
 .login-form input {
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  border-radius: 5px;
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
   border: none;
 }
 
@@ -48,18 +48,18 @@
   background-color: #0074d9;
   color: white;
   border: none;
-  padding: 0.7rem;
-  border-radius: 5px;
+  padding: calc(var(--space-md) * 0.7);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
 .error {
-  margin-top: 1rem;
+  margin-top: var(--space-md);
   color: #ff4136;
 }
 
 .register-link {
-  margin-top: 1rem;
+  margin-top: var(--space-md);
   color: #61dafb;
   text-align: center;
   display: block;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,11 @@
   --line-height-h2: 1.3;
   --font-size-h3: 1.5rem;
   --line-height-h3: 1.3;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --radius-sm: 0.3125rem;
+  --radius-lg: 0.625rem;
 }
 
 body {


### PR DESCRIPTION
## Summary
- define spacing and radius CSS variables
- replace hard-coded spacing in LoginForm, Dashboard, and ActivityLog styles
- document design token usage in frontend README

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a245589f3c83339b9f57f2953f7118