### PR TITLE
feat: add responsive typography and layouts

### DIFF
--- a/frontend/src/Dashboard.css
+++ b/frontend/src/Dashboard.css
@@ -15,17 +15,30 @@
 
 .dashboard-heading {
   margin-top: 0;
-  font-size: 3rem;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
   animation: fadeSlide 0.6s ease forwards;
 }
 
 .tile-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1.5rem;
   width: 90%;
   max-width: 800px;
+}
+
+@media (min-width: var(--bp-md)) {
+  .tile-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: var(--bp-lg)) {
+  .tile-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .dashboard-tile {

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -34,6 +34,39 @@
   gap: 1rem;
 }
 
+@media (min-width: var(--bp-md)) {
+  .landing-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'logo title'
+      'logo buttons';
+    align-items: center;
+    justify-items: center;
+    text-align: left;
+  }
+  .landing-logo {
+    grid-area: logo;
+    width: 100%;
+    max-width: 400px;
+    margin-bottom: 0;
+  }
+  .landing-title {
+    grid-area: title;
+    margin-bottom: 0.5rem;
+  }
+  .landing-buttons {
+    grid-area: buttons;
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: var(--bp-lg)) {
+  .landing-container {
+    gap: 3rem;
+  }
+}
+
 .landing-btn {
   background-color: #0074d9;
   color: white;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -15,6 +15,14 @@
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
 
+@media (min-width: var(--bp-lg)) {
+  .profiles-container {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    align-items: flex-start;
+  }
+}
+
 /* Match the job posting panel width and styling */
 .form-panel {
   flex: 1;
@@ -379,8 +387,20 @@
 
 .news-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1rem;
+}
+
+@media (min-width: var(--bp-md)) {
+  .news-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: var(--bp-lg)) {
+  .news-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .news-card {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,16 +1,27 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 :root {
+  /* Breakpoints */
+  --bp-sm: 480px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+
+  /* Typography */
   --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
     'Helvetica Neue', sans-serif;
-  --font-size-body: 1rem;
+
+  /* Fluid type scales */
+  --font-size-body: clamp(0.875rem, 0.5vw + 0.75rem, 1.125rem);
   --line-height-body: 1.5;
-  --font-size-h1: 3rem;
+
+  --font-size-h1: clamp(2.5rem, 5vw + 1rem, 3.5rem);
   --line-height-h1: 1.2;
-  --font-size-h2: 2.25rem;
+
+  --font-size-h2: clamp(1.75rem, 3.5vw + 0.5rem, 2.5rem);
   --line-height-h2: 1.3;
-  --font-size-h3: 1.5rem;
+
+  --font-size-h3: clamp(1.25rem, 2vw + 0.5rem, 1.75rem);
   --line-height-h3: 1.3;
 }
 


### PR DESCRIPTION
## Summary
- define breakpoint variables and fluid clamp-based font sizes
- implement responsive grid/flex layouts for landing, dashboard, and student profiles pages
- ensure headings and body copy scale smoothly across viewports

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a246081648833387ab23f07e30f448