### PR TITLE
Fix null score error in job posting matches

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -626,7 +626,7 @@ if (shouldRedirect) {
                       {row.first_name || row.name?.split(' ')[0]}{' '}
                       {row.last_name || row.name?.split(' ')[1]}
                     </td>
-                    <td>{row.score.toFixed(2)}</td>
+                    <td>{row.score?.toFixed(2)}</td>
                     <td>
                       {previewingResumes[`${job.job_code}:${row.email}`] ? (
                         <span className="spinner" />


### PR DESCRIPTION
## Summary
- avoid calling `toFixed` when a candidate score is null on JobPosting

## Testing
- `CI=true npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2485f01308333809dae84769aed8a