### PR TITLE
Add sparkline metric cards to metrics page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.8.0",
     "react-joyride": "^2.9.3",
+    "react-sparklines": "^1.7.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/Metrics.js
+++ b/frontend/src/Metrics.js
@@ -19,6 +19,7 @@ import {
   RadialBar,
   Legend,
 } from 'recharts';
+import MetricCard from './components/MetricCard';
 import './Metrics.css';
 
 function Metrics() {
@@ -69,19 +70,37 @@ function Metrics() {
   }
 
   const highlight = [
-    { label: 'Students', value: metricsData.total_student_profiles },
-    { label: 'Jobs', value: metricsData.total_jobs_posted },
-    { label: 'Matches', value: metricsData.total_matches },
+    {
+      title: 'Students',
+      value: metricsData.total_student_profiles,
+      data: metricsData.students_over_time || [metricsData.total_student_profiles],
+    },
+    {
+      title: 'Jobs',
+      value: metricsData.total_jobs_posted,
+      data: metricsData.jobs_over_time || [metricsData.total_jobs_posted],
+    },
+    {
+      title: 'Matches',
+      value: metricsData.total_matches,
+      data: metricsData.matches_over_time || [metricsData.total_matches],
+    },
   ];
 
   if (role === 'admin') {
     highlight.push({
-      label: 'Placement Rate',
+      title: 'Placement Rate',
       value: `${(metricsData.placement_rate * 100).toFixed(0)} %`,
+      data: metricsData.placement_rate_over_time
+        ? metricsData.placement_rate_over_time.map((n) => n * 100)
+        : [metricsData.placement_rate * 100],
     });
     highlight.push({
-      label: 'Rematch Rate',
+      title: 'Rematch Rate',
       value: `${(metricsData.rematch_rate * 100).toFixed(0)} %`,
+      data: metricsData.rematch_rate_over_time
+        ? metricsData.rematch_rate_over_time.map((n) => n * 100)
+        : [metricsData.rematch_rate * 100],
     });
   }
 
@@ -108,10 +127,7 @@ function Metrics() {
       <AdminMenu />
       <div className="metric-grid">
         {highlight.map((h) => (
-          <div key={h.label} className="highlight-card">
-            <div className="value">{h.value}</div>
-            <div className="label">{h.label}</div>
-          </div>
+          <MetricCard key={h.title} title={h.title} value={h.value} data={h.data} />
         ))}
       </div>
       {role === 'admin' && (

--- a/frontend/src/components/MetricCard.css
+++ b/frontend/src/components/MetricCard.css
@@ -1,0 +1,29 @@
+.metric-card {
+  background: linear-gradient(135deg, #1a1a1a, #0d0d0d);
+  border-radius: 8px;
+  padding: 1rem;
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.metric-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+}
+
+.metric-card-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.metric-title {
+  font-size: 0.9rem;
+  color: #b3b3b3;
+}
+
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: bold;
+}

--- a/frontend/src/components/MetricCard.js
+++ b/frontend/src/components/MetricCard.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Sparklines, SparklinesLine } from 'react-sparklines';
+import './MetricCard.css';
+
+function MetricCard({ title, value, data }) {
+  const sparkData = data && data.length ? data : [0];
+
+  return (
+    <div className="metric-card">
+      <div className="metric-card-header">
+        <span className="metric-title">{title}</span>
+        <span className="metric-value">{value}</span>
+      </div>
+      <Sparklines data={sparkData} width={100} height={20} margin={5}>
+        <SparklinesLine color="#00BFFF" />
+      </Sparklines>
+    </div>
+  );
+}
+
+export default MetricCard;


### PR DESCRIPTION
## Summary
- create reusable `MetricCard` component with sparkline chart
- integrate metric cards into metrics page for each statistic
- add high-tech gradient styles and dependency on `react-sparklines`

## Testing
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a248d5e1488333afed1b3107afe563