### PR TITLE
Add glass modal styling to note editor and history modal

### DIFF
--- a/frontend/src/NoteEditor.css
+++ b/frontend/src/NoteEditor.css
@@ -1,0 +1,29 @@
+.glass-modal {
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.5);
+  animation: glass-fade-in 0.3s ease forwards;
+}
+
+.glass-modal.fade-out {
+  animation: glass-fade-out 0.3s ease forwards;
+}
+
+@keyframes glass-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes glass-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+

--- a/frontend/src/NoteEditor.js
+++ b/frontend/src/NoteEditor.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import api from './api';
+import './NoteEditor.css';
 
 export default function NoteEditor({ jobCode, email, notes = [], onSaved, onCancel }) {
   const [note, setNote] = useState('');
@@ -21,22 +22,24 @@ export default function NoteEditor({ jobCode, email, notes = [], onSaved, onCanc
   };
 
   return (
-    <div className="note-editor">
-      <textarea
-        value={note}
-        onChange={(e) => setNote(e.target.value)}
-      />
-      <button onClick={save}>Save</button>
-      {onCancel && <button onClick={onCancel}>Cancel</button>}
-      {notes.length > 0 && (
-        <div className="note-history">
-          {notes.map((n, i) => (
-            <div key={i} className="note-history-item">
-              {n.text}
-            </div>
-          ))}
-        </div>
-      )}
+    <div className="glass-modal">
+      <div className="note-editor">
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <button onClick={save}>Save</button>
+        {onCancel && <button onClick={onCancel}>Cancel</button>}
+        {notes.length > 0 && (
+          <div className="note-history">
+            {notes.map((n, i) => (
+              <div key={i} className="note-history-item">
+                {n.text}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/NotesHistoryModal.css
+++ b/frontend/src/NotesHistoryModal.css
@@ -1,0 +1,29 @@
+.glass-modal {
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.5);
+  animation: glass-fade-in 0.3s ease forwards;
+}
+
+.glass-modal.fade-out {
+  animation: glass-fade-out 0.3s ease forwards;
+}
+
+@keyframes glass-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes glass-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import api from './api';
 import NoteEditor from './NoteEditor';
+import './NotesHistoryModal.css';
 
 function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = false, jobCode, studentEmail, onSaved }) {
   const [localNotes, setLocalNotes] = useState(notes);
@@ -65,69 +66,71 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
 
   return (
     <div className="notes-modal-overlay">
-      <div className="notes-modal">
-        <button className="close-button" onClick={onClose}>X</button>
-        <h3>Notes History</h3>
-        {canAdd && !adding && (
-          <button onClick={() => setAdding(true)}>Add Note</button>
-        )}
-        {canAdd && adding && (
-          <NoteEditor
-            jobCode={jobCode}
-            email={studentEmail}
-            onSaved={handleAddSaved}
-            onCancel={() => setAdding(false)}
-          />
-        )}
-        <table>
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>Date</th>
-              <th>Note</th>
-              {isAdmin && <th>Actions</th>}
-            </tr>
-          </thead>
-          <tbody>
-            {localNotes.length > 0 ? (
-              localNotes.map((n, idx) => (
-                <tr key={idx}>
-                  <td>{idx + 1}</td>
-                  <td>{n.timestamp ? new Date(n.timestamp).toLocaleString() : ''}</td>
-                  <td>
-                    {editingIndex === idx ? (
-                      <textarea
-                        value={editText}
-                        onChange={(e) => setEditText(e.target.value)}
-                      />
-                    ) : (
-                      n.text
-                    )}
-                  </td>
-                  {isAdmin && (
+      <div className="glass-modal">
+        <div className="notes-modal">
+          <button className="close-button" onClick={onClose}>X</button>
+          <h3>Notes History</h3>
+          {canAdd && !adding && (
+            <button onClick={() => setAdding(true)}>Add Note</button>
+          )}
+          {canAdd && adding && (
+            <NoteEditor
+              jobCode={jobCode}
+              email={studentEmail}
+              onSaved={handleAddSaved}
+              onCancel={() => setAdding(false)}
+            />
+          )}
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Date</th>
+                <th>Note</th>
+                {isAdmin && <th>Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {localNotes.length > 0 ? (
+                localNotes.map((n, idx) => (
+                  <tr key={idx}>
+                    <td>{idx + 1}</td>
+                    <td>{n.timestamp ? new Date(n.timestamp).toLocaleString() : ''}</td>
                     <td>
                       {editingIndex === idx ? (
-                        <>
-                          <button onClick={saveEdit}>Save</button>
-                          <button onClick={cancelEdit}>Cancel</button>
-                        </>
+                        <textarea
+                          value={editText}
+                          onChange={(e) => setEditText(e.target.value)}
+                        />
                       ) : (
-                        <>
-                          <button onClick={() => startEdit(idx)}>Edit</button>
-                          <button onClick={() => deleteNote(idx)}>Delete</button>
-                        </>
+                        n.text
                       )}
                     </td>
-                  )}
+                    {isAdmin && (
+                      <td>
+                        {editingIndex === idx ? (
+                          <>
+                            <button onClick={saveEdit}>Save</button>
+                            <button onClick={cancelEdit}>Cancel</button>
+                          </>
+                        ) : (
+                          <>
+                            <button onClick={() => startEdit(idx)}>Edit</button>
+                            <button onClick={() => deleteNote(idx)}>Delete</button>
+                          </>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+              ))
+              ) : (
+                <tr>
+                  <td colSpan={isAdmin ? 4 : 3}>No notes available.</td>
                 </tr>
-            ))
-            ) : (
-              <tr>
-                <td colSpan={isAdmin ? 4 : 3}>No notes available.</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap NoteEditor modal and NotesHistoryModal with glass styling
- add `.glass-modal` class providing blur, transparency, and fade animations

## Testing
- `CI=true npm test -- src/NoteEditor.test.js src/NotesHistoryModal.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a248d735088333a70d8f6e9624b894