### PR TITLE
Add sticky headers and scrollable table to StudentProfiles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -162,13 +162,15 @@
   top: 0;
   background-color: #003366;
   z-index: 2;
+  border-bottom: 1px solid #003366;
 }
 
 .table-wrapper > table > thead tr.filter-row th {
   position: sticky;
-  top: var(--header-height, 44px);
+  top: calc(var(--header-height, 44px) - 1px);
   background-color: #001f3f;
   z-index: 1;
+  border-top: none;
 }
 
 .school-table {

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -147,7 +147,7 @@
 }
 
 .table-wrapper {
-  max-height: 400px;
+  max-height: 70vh;
   overflow-y: auto;
   transition: box-shadow 0.3s;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0);

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -146,6 +146,30 @@
   box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
 }
 
+.table-wrapper {
+  max-height: 400px;
+  overflow-y: auto;
+  transition: box-shadow 0.3s;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0);
+}
+
+.table-wrapper.scrolled {
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.table-wrapper > table > thead th {
+  position: sticky;
+  top: 0;
+  background-color: #003366;
+  z-index: 1;
+}
+
+.table-wrapper > table > thead tr.filter-row th {
+  top: 44px;
+  background-color: #001f3f;
+  z-index: 1;
+}
+
 .school-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -147,7 +147,7 @@
 }
 
 .table-wrapper {
-  max-height: 70vh;
+  max-height: 80vh;
   overflow-y: auto;
   transition: box-shadow 0.3s;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0);
@@ -161,11 +161,12 @@
   position: sticky;
   top: 0;
   background-color: #003366;
-  z-index: 1;
+  z-index: 2;
 }
 
 .table-wrapper > table > thead tr.filter-row th {
-  top: 44px;
+  position: sticky;
+  top: var(--header-height, 44px);
   background-color: #001f3f;
   z-index: 1;
 }

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -112,6 +112,7 @@ function StudentProfiles() {
   };
 
   const cityRef = useRef(null);
+  const tableWrapperRef = useRef(null);
 
   const initAutocomplete = () => {
     if (cityRef.current && window.google) {
@@ -131,6 +132,22 @@ function StudentProfiles() {
   useEffect(() => {
     loadGoogleMaps(initAutocomplete);
   }, [activeTab, isEditing]);
+
+  useEffect(() => {
+    const wrapper = tableWrapperRef.current;
+    if (!wrapper) return;
+
+    const handleScroll = () => {
+      if (wrapper.scrollTop > 0) {
+        wrapper.classList.add('scrolled');
+      } else {
+        wrapper.classList.remove('scrolled');
+      }
+    };
+
+    wrapper.addEventListener('scroll', handleScroll);
+    return () => wrapper.removeEventListener('scroll', handleScroll);
+  }, []);
 
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
@@ -564,8 +581,9 @@ function StudentProfiles() {
                 <span style={{ marginLeft: '0.5rem' }}>Loading students...</span>
               </div>
             ) : schoolStudents.length > 0 ? (
-              <table className="school-table">
-                <thead>
+              <div className="table-wrapper" ref={tableWrapperRef}>
+                <table className="school-table">
+                  <thead>
                   <tr>
                     <th></th>
                     <th>First Name</th>
@@ -827,7 +845,8 @@ function StudentProfiles() {
                     );
                   })}
                 </tbody>
-              </table>
+                </table>
+              </div>
             ) : (
               <p>You haven't created any student profiles.</p>
             )}

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -113,6 +113,7 @@ function StudentProfiles() {
 
   const cityRef = useRef(null);
   const tableWrapperRef = useRef(null);
+  const headerRowRef = useRef(null);
 
   const initAutocomplete = () => {
     if (cityRef.current && window.google) {
@@ -148,6 +149,15 @@ function StudentProfiles() {
     wrapper.addEventListener('scroll', handleScroll);
     return () => wrapper.removeEventListener('scroll', handleScroll);
   }, []);
+
+  useEffect(() => {
+    const header = headerRowRef.current;
+    const wrapper = tableWrapperRef.current;
+    if (header && wrapper) {
+      const height = header.getBoundingClientRect().height;
+      wrapper.style.setProperty('--header-height', `${height}px`);
+    }
+  }, [schoolStudents, activeTab]);
 
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
@@ -584,7 +594,7 @@ function StudentProfiles() {
               <div className="table-wrapper" ref={tableWrapperRef}>
                 <table className="school-table">
                   <thead>
-                  <tr>
+                  <tr ref={headerRowRef}>
                     <th></th>
                     <th>First Name</th>
                     <th>Last Name</th>


### PR DESCRIPTION
## Summary
- Wrap student table in scrollable wrapper with max height and dynamic shadow
- Make student list headers sticky for easier browsing

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24d18bfb883338014ec8e9b5a53af