### PR TITLE
Add glass-panel overlays to dashboard and student profiles

### DIFF
--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -22,10 +22,11 @@ function Dashboard() {
   // Tiles are conditionally rendered based on the user's role
 
   return (
-    <div className="dashboard-container">
-      <AdminMenu />
-      <h2 className="dashboard-heading">Dashboard</h2>
-      <div className="tile-grid">
+    <div className="glass-panel">
+      <div className="dashboard-container">
+        <AdminMenu />
+        <h2 className="dashboard-heading">Dashboard</h2>
+        <div className="tile-grid">
         {role === 'admin' && (
           <>
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
@@ -54,6 +55,7 @@ function Dashboard() {
             <div className="dashboard-tile">Job Matching</div>
           </Link>
         ) : null}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -462,18 +462,19 @@ function StudentProfiles() {
   });
 
   return (
-    <div className="profiles-container">
-      {showTour && (
-        <Joyride
-          steps={tourSteps}
-          continuous
-          showSkipButton
-          showProgress
-          callback={handleTourCallback}
-          styles={{ options: { zIndex: 10000 } }}
-        />
-      )}
-      <AdminMenu>
+    <div className="glass-panel">
+      <div className="profiles-container">
+        {showTour && (
+          <Joyride
+            steps={tourSteps}
+            continuous
+            showSkipButton
+            showProgress
+            callback={handleTourCallback}
+            styles={{ options: { zIndex: 10000 } }}
+          />
+        )}
+        <AdminMenu>
         {userRole === 'admin' && (
           <button
             className="admin-reset-button"
@@ -874,6 +875,7 @@ function StudentProfiles() {
           onClose={() => setModalNotes(null)}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,3 +78,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.glass-panel {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}


### PR DESCRIPTION
## Summary
- wrap Dashboard and StudentProfiles main containers in `glass-panel` for a frosted overlay effect
- add reusable `glass-panel` styles including blur and subtle border

## Testing
- `pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a2630c41b48333bda45580259cfced