### PR TITLE
Add tooltip component for icon hints

### DIFF
--- a/frontend/src/ActivityLog.js
+++ b/frontend/src/ActivityLog.js
@@ -4,6 +4,7 @@ import jwtDecode from 'jwt-decode';
 import AdminMenu from './AdminMenu';
 import api from './api';
 import './ActivityLog.css';
+import Tooltip from './components/Tooltip';
 
 function ActivityLog() {
   const [entries, setEntries] = useState([]);
@@ -59,6 +60,9 @@ function ActivityLog() {
       <h2>Activity Log</h2>
       {error && <p className="error">{error}</p>}
       <button className="download-btn" onClick={downloadCSV}>
+        <Tooltip text="Download CSV">
+          <span className="material-icons">download</span>
+        </Tooltip>
         Download CSV
       </button>
       <table className="log-table">

--- a/frontend/src/ActivityLog.js
+++ b/frontend/src/ActivityLog.js
@@ -60,7 +60,7 @@ function ActivityLog() {
       <h2>Activity Log</h2>
       {error && <p className="error">{error}</p>}
       <button className="download-btn" onClick={downloadCSV}>
-        <Tooltip text="Download CSV">
+        <Tooltip text="Download CSV" position="bottom">
           <span className="material-icons">download</span>
         </Tooltip>
         Download CSV

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -703,7 +703,10 @@ function StudentProfiles() {
                       <React.Fragment key={s.email}>
                         <tr>
                           <td>
-                            <Tooltip text={expandedRows[s.email] ? 'Collapse' : 'Expand'}>
+                            <Tooltip
+                              text={expandedRows[s.email] ? 'Collapse' : 'Expand'}
+                              position="bottom"
+                            >
                               <button
                                 className="expand-toggle"
                                 onClick={() => toggleRow(s.email, s.assigned_jobs)}
@@ -722,7 +725,7 @@ function StudentProfiles() {
                           <td>{licenseLabel(s.license)}</td>
                           <td className="edit-col">
                             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                              <Tooltip text="Edit">
+                              <Tooltip text="Edit" position="bottom">
                                 <button
                                   onClick={() => handleEdit(s.email)}
                                   style={{
@@ -736,7 +739,7 @@ function StudentProfiles() {
                                 </button>
                               </Tooltip>
                               {userRole === 'admin' && (
-                                <Tooltip text="Delete Student">
+                                <Tooltip text="Delete Student" position="bottom">
                                   <button
                                     onClick={() => handleDelete(s.email)}
                                     style={{

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -9,6 +9,7 @@ import jwt_decode from 'jwt-decode';
 import './StudentProfiles.css';
 import './Tour.css';
 import NotesHistoryModal from './NotesHistoryModal';
+import Tooltip from './components/Tooltip';
 
 function StudentProfiles() {
   const [formData, setFormData] = useState({
@@ -702,14 +703,16 @@ function StudentProfiles() {
                       <React.Fragment key={s.email}>
                         <tr>
                           <td>
-                            <button
-                              className="expand-toggle"
-                              onClick={() => toggleRow(s.email, s.assigned_jobs)}
-                              title={expandedRows[s.email] ? 'Collapse' : 'Expand'}
-                              type="button"
-                            >
-                            {expandedRows[s.email] ? '–' : '+'}
-                            </button>
+                            <Tooltip text={expandedRows[s.email] ? 'Collapse' : 'Expand'}>
+                              <button
+                                className="expand-toggle"
+                                onClick={() => toggleRow(s.email, s.assigned_jobs)}
+                                type="button"
+                                title={expandedRows[s.email] ? 'Collapse' : 'Expand'}
+                              >
+                                {expandedRows[s.email] ? '–' : '+'}
+                              </button>
+                            </Tooltip>
                           </td>
                           <td>{s.first_name}</td>
                           <td>{s.last_name}</td>
@@ -719,32 +722,34 @@ function StudentProfiles() {
                           <td>{licenseLabel(s.license)}</td>
                           <td className="edit-col">
                             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                              <button
-                                onClick={() => handleEdit(s.email)}
-                                style={{
-                                  background: 'none',
-                                  border: 'none',
-                                  cursor: 'pointer',
-                                  fontSize: '1.2rem',
-                                }}
-                                title="Edit"
-                              >
-                                ✏️
-                              </button>
-                              {userRole === 'admin' && (
+                              <Tooltip text="Edit">
                                 <button
-                                  onClick={() => handleDelete(s.email)}
+                                  onClick={() => handleEdit(s.email)}
                                   style={{
                                     background: 'none',
                                     border: 'none',
                                     cursor: 'pointer',
                                     fontSize: '1.2rem',
-                                    color: 'red',
                                   }}
-                                  title="Delete Student"
                                 >
-                                  🗑️
+                                  ✏️
                                 </button>
+                              </Tooltip>
+                              {userRole === 'admin' && (
+                                <Tooltip text="Delete Student">
+                                  <button
+                                    onClick={() => handleDelete(s.email)}
+                                    style={{
+                                      background: 'none',
+                                      border: 'none',
+                                      cursor: 'pointer',
+                                      fontSize: '1.2rem',
+                                      color: 'red',
+                                    }}
+                                  >
+                                    🗑️
+                                  </button>
+                                </Tooltip>
                               )}
                             </div>
                           </td>

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -1,28 +1,39 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import './TopMenu.css';
+import Tooltip from './components/Tooltip';
 
 function TopMenu() {
   return (
     <nav className="top-menu">
       <Link to="/">
-        <span className="material-icons">home</span>
+        <Tooltip text="Home">
+          <span className="material-icons">home</span>
+        </Tooltip>
         Home
       </Link>
       <Link to="/about">
-        <span className="material-icons">info</span>
+        <Tooltip text="About">
+          <span className="material-icons">info</span>
+        </Tooltip>
         About TalentMatch-AI
       </Link>
       <Link to="/about/applicants">
-        <span className="material-icons">person</span>
+        <Tooltip text="Applicants">
+          <span className="material-icons">person</span>
+        </Tooltip>
         Applicants
       </Link>
       <Link to="/about/career-service">
-        <span className="material-icons">work</span>
+        <Tooltip text="Career Service">
+          <span className="material-icons">work</span>
+        </Tooltip>
         Career Service
       </Link>
       <Link to="/about/recruiters">
-        <span className="material-icons">group</span>
+        <Tooltip text="Recruiters">
+          <span className="material-icons">group</span>
+        </Tooltip>
         Recruiters
       </Link>
     </nav>

--- a/frontend/src/TopMenu.js
+++ b/frontend/src/TopMenu.js
@@ -7,31 +7,31 @@ function TopMenu() {
   return (
     <nav className="top-menu">
       <Link to="/">
-        <Tooltip text="Home">
+        <Tooltip text="Home" position="bottom">
           <span className="material-icons">home</span>
         </Tooltip>
         Home
       </Link>
       <Link to="/about">
-        <Tooltip text="About">
+        <Tooltip text="About" position="bottom">
           <span className="material-icons">info</span>
         </Tooltip>
         About TalentMatch-AI
       </Link>
       <Link to="/about/applicants">
-        <Tooltip text="Applicants">
+        <Tooltip text="Applicants" position="bottom">
           <span className="material-icons">person</span>
         </Tooltip>
         Applicants
       </Link>
       <Link to="/about/career-service">
-        <Tooltip text="Career Service">
+        <Tooltip text="Career Service" position="bottom">
           <span className="material-icons">work</span>
         </Tooltip>
         Career Service
       </Link>
       <Link to="/about/recruiters">
-        <Tooltip text="Recruiters">
+        <Tooltip text="Recruiters" position="bottom">
           <span className="material-icons">group</span>
         </Tooltip>
         Recruiters

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -12,13 +12,22 @@
   border-radius: 4px;
   padding: 4px 8px;
   position: absolute;
-  z-index: 10;
-  bottom: 125%;
-  left: 50%;
-  transform: translateX(-50%);
+  z-index: 1000;
   transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
   white-space: nowrap;
   pointer-events: none;
+}
+
+.tooltip-top {
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip-bottom {
+  top: 125%;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .tooltip-container:hover .tooltip {

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -1,0 +1,27 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  visibility: hidden;
+  opacity: 0;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 4px;
+  padding: 4px 8px;
+  position: absolute;
+  z-index: 10;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.tooltip-container:hover .tooltip {
+  visibility: visible;
+  opacity: 1;
+}

--- a/frontend/src/components/Tooltip.js
+++ b/frontend/src/components/Tooltip.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import './Tooltip.css';
 
-function Tooltip({ text, children }) {
+function Tooltip({ text, children, position = 'top' }) {
   return (
     <span className="tooltip-container">
       {children}
-      <span className="tooltip">{text}</span>
+      <span className={`tooltip tooltip-${position}`}>{text}</span>
     </span>
   );
 }

--- a/frontend/src/components/Tooltip.js
+++ b/frontend/src/components/Tooltip.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import './Tooltip.css';
+
+function Tooltip({ text, children }) {
+  return (
+    <span className="tooltip-container">
+      {children}
+      <span className="tooltip">{text}</span>
+    </span>
+  );
+}
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- build reusable Tooltip component with fade transitions
- wrap menu and action icons with tooltips across TopMenu, StudentProfiles, and ActivityLog

## Testing
- `pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2630f0d04833390beb00c34493111