### PR TITLE
Prevent overscroll bounce on student profile page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,6 +25,11 @@
   --line-height-h3: 1.3;
 }
 
+html,
+body {
+  overscroll-behavior: none;
+}
+
 body {
   margin: 0;
   background: #032c4d;
@@ -33,6 +38,7 @@ body {
   line-height: var(--line-height-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 h1,


### PR DESCRIPTION
## Summary
- stop overscroll bounce by disabling scroll chaining on the page and hiding horizontal overflow

## Testing
- `CI=true npm test --silent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26a7d73b48333ae86903fa9366576