### PR TITLE
Display student profile count

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -147,9 +147,22 @@
 }
 
 .student-count {
-  color: #002244;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  background: linear-gradient(135deg, #00b4db, #0083b0);
+  color: #ffffff;
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  font-size: 0.95rem;
+}
+
+.student-count .count-number {
+  margin-left: 0.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
 }
 
 .table-wrapper {
@@ -341,7 +354,7 @@
 /* Tab styles copied from JobPosting */
 .tab-bar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   margin-bottom: 0 !important;
   border-bottom: none !important;
   padding-left: 0.5rem;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -147,7 +147,6 @@
 }
 
 .student-count {
-  margin-left: auto;
   display: flex;
   align-items: center;
   background: linear-gradient(135deg, #00b4db, #0083b0);
@@ -355,9 +354,15 @@
 .tab-bar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
   margin-bottom: 0 !important;
   border-bottom: none !important;
-  padding-left: 0.5rem;
+  padding: 0 0.5rem;
+}
+
+.tabs {
+  display: flex;
 }
 
 .tab {

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -146,6 +146,12 @@
   box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
 }
 
+.student-count {
+  color: #002244;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
 .table-wrapper {
   max-height: 80vh;
   overflow-y: auto;

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -591,6 +591,9 @@ function StudentProfiles() {
           }}
         >
           <div style={{ flexGrow: 1, minHeight: 0, marginTop: '0' }}>
+            {!isLoading && (
+              <h2 className="student-count">Student Profiles: {schoolStudents.length}</h2>
+            )}
             {isLoading ? (
               <div className="loading-container">
                 <span className="spinner" />

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -511,18 +511,20 @@ function StudentProfiles() {
       {toast && <div className="toast">{toast}</div>}
 
       <div className="tab-bar">
-        <button
-          className={`tab students-tab ${activeTab === 'students' ? 'active' : ''}`}
-          onClick={() => setActiveTab('students')}
-        >
-          Students
-        </button>
-        <button
-          className={`tab new-tab ${activeTab === 'new' ? 'active' : ''}`}
-          onClick={() => setActiveTab('new')}
-        >
-          New Student Profile
-        </button>
+        <div className="tabs">
+          <button
+            className={`tab students-tab ${activeTab === 'students' ? 'active' : ''}`}
+            onClick={() => setActiveTab('students')}
+          >
+            Students
+          </button>
+          <button
+            className={`tab new-tab ${activeTab === 'new' ? 'active' : ''}`}
+            onClick={() => setActiveTab('new')}
+          >
+            New Student Profile
+          </button>
+        </div>
         {!isLoading && (
           <div className="student-count" data-testid="student-count">
             Student Profiles: <span className="count-number">{schoolStudents.length}</span>

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -523,6 +523,11 @@ function StudentProfiles() {
         >
           New Student Profile
         </button>
+        {!isLoading && (
+          <div className="student-count" data-testid="student-count">
+            Student Profiles: <span className="count-number">{schoolStudents.length}</span>
+          </div>
+        )}
       </div>
 
       <div className="tab-content">
@@ -591,9 +596,6 @@ function StudentProfiles() {
           }}
         >
           <div style={{ flexGrow: 1, minHeight: 0, marginTop: '0' }}>
-            {!isLoading && (
-              <h2 className="student-count">Student Profiles: {schoolStudents.length}</h2>
-            )}
             {isLoading ? (
               <div className="loading-container">
                 <span className="spinner" />

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -32,6 +32,51 @@ test('renders StudentProfiles without errors', () => {
   }).not.toThrow();
 });
 
+test('shows student count above table', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    return Promise.resolve({
+      data: {
+        students: [
+          {
+            first_name: 'A',
+            last_name: 'B',
+            email: 'a@example.com',
+            city: 'City',
+            state: 'ST',
+            institutional_code: 'ABC',
+            license: '',
+            assigned_jobs: [],
+            placed_jobs: []
+          },
+          {
+            first_name: 'C',
+            last_name: 'D',
+            email: 'c@example.com',
+            city: 'City',
+            state: 'ST',
+            institutional_code: 'ABC',
+            license: '',
+            assigned_jobs: [],
+            placed_jobs: []
+          }
+        ]
+      }
+    });
+  });
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  expect(await screen.findByText('Student Profiles: 2')).toBeInTheDocument();
+  localStorage.clear();
+});
+
 test('opens notes history modal when View Notes clicked', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -32,7 +32,7 @@ test('renders StudentProfiles without errors', () => {
   }).not.toThrow();
 });
 
-test('shows student count above table', async () => {
+test('displays student count in tab bar', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);
   api.get.mockImplementation((url) => {
@@ -73,7 +73,7 @@ test('shows student count above table', async () => {
       <StudentProfiles />
     </BrowserRouter>
   );
-  expect(await screen.findByText('Student Profiles: 2')).toBeInTheDocument();
+  expect(await screen.findByTestId('student-count')).toHaveTextContent('Student Profiles: 2');
   localStorage.clear();
 });
 


### PR DESCRIPTION
## Summary
- Show a "Student Profiles" heading with the number of profiles above the student table
- Style the new heading and add a test to ensure count is rendered

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a28694d3bc8333a9bac26d76ac498e