### PR TITLE
feat: add slide-out animation for job subtable

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -260,6 +260,11 @@
   will-change: max-height;
 }
 
+.job-subrow.opening .job-subrow-content {
+  max-height: 0;
+  opacity: 0;
+}
+
 .job-subrow.open .job-subrow-content {
   max-height: 500px;
   opacity: 1;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -242,26 +242,43 @@
   margin-top: 0.5rem;
 }
 
-/* Smooth slide-out animation for job rows */
+/* Smooth slide animation for job rows */
 .job-subrow {
-  animation: slideDownFade 0.25s ease-out;
+  animation: slideDown 0.25s ease-out;
   transform-origin: top;
-  will-change: transform, opacity;
+  will-change: transform;
+  background-color: #fff;
 }
 
-@keyframes slideDownFade {
+.job-subrow td {
+  background-color: #fff;
+}
+
+.job-subrow.closing {
+  animation: slideUp 0.25s ease-in forwards;
+}
+
+@keyframes slideDown {
   from {
-    opacity: 0;
     transform: translateY(-6px);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
 }
 
+@keyframes slideUp {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-6px);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .job-subrow {
+  .job-subrow,
+  .job-subrow.closing {
     animation: none;
   }
 }

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -244,18 +244,25 @@
 
 /* Smooth slide-out animation for job rows */
 .job-subrow {
-  animation: slideDownFade 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: slideDownFade 0.25s ease-out;
   transform-origin: top;
+  will-change: transform, opacity;
 }
 
 @keyframes slideDownFade {
   from {
     opacity: 0;
-    transform: translateY(-10px) scaleY(0.95);
+    transform: translateY(-6px);
   }
   to {
     opacity: 1;
-    transform: translateY(0) scaleY(1);
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .job-subrow {
+    animation: none;
   }
 }
 

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -242,6 +242,23 @@
   margin-top: 0.5rem;
 }
 
+/* Smooth slide-out animation for job rows */
+.job-subrow {
+  animation: slideDownFade 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: top;
+}
+
+@keyframes slideDownFade {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scaleY(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+}
+
 .expand-toggle {
   cursor: pointer;
   font-weight: bold;

--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -244,42 +244,37 @@
 
 /* Smooth slide animation for job rows */
 .job-subrow {
-  animation: slideDown 0.25s ease-out;
-  transform-origin: top;
-  will-change: transform;
   background-color: #fff;
 }
 
 .job-subrow td {
   background-color: #fff;
+  padding: 0;
 }
 
-.job-subrow.closing {
-  animation: slideUp 0.25s ease-in forwards;
+.job-subrow-content {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  will-change: max-height;
 }
 
-@keyframes slideDown {
-  from {
-    transform: translateY(-6px);
-  }
-  to {
-    transform: translateY(0);
-  }
+.job-subrow.open .job-subrow-content {
+  max-height: 500px;
+  opacity: 1;
 }
 
-@keyframes slideUp {
-  from {
-    transform: translateY(0);
-  }
-  to {
-    transform: translateY(-6px);
-  }
+.job-subrow.closing .job-subrow-content {
+  max-height: 0;
+  opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .job-subrow,
-  .job-subrow.closing {
-    animation: none;
+  .job-subrow-content,
+  .job-subrow.open .job-subrow-content,
+  .job-subrow.closing .job-subrow-content {
+    transition: none;
   }
 }
 

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -228,13 +228,22 @@ function StudentProfiles() {
 
   const toggleRow = (email, assignedJobs = []) => {
     setExpandedRows((prev) => {
-      const expanded = !prev[email];
-      if (!prev[email]) {
+      const isOpen = prev[email] === 'open';
+      if (!isOpen) {
         for (const job of assignedJobs) {
           fetchJobDescriptionStatus(email, job.job_code);
         }
+        return { ...prev, [email]: 'open' };
+      } else {
+        setTimeout(() => {
+          setExpandedRows((cur) => {
+            const updated = { ...cur };
+            delete updated[email];
+            return updated;
+          });
+        }, 250);
+        return { ...prev, [email]: 'closing' };
       }
-      return { ...prev, [email]: expanded };
     });
   };
 
@@ -772,7 +781,10 @@ function StudentProfiles() {
                           </td>
                         </tr>
                         {expandedRows[s.email] && (
-                          <tr className="job-subrow" key={`${s.email}-jobs`}>
+                          <tr
+                            className={`job-subrow${expandedRows[s.email] === 'closing' ? ' closing' : ''}`}
+                            key={`${s.email}-jobs`}
+                          >
                             <td colSpan="100%">
                               <table className="job-subtable">
                                 <thead>

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -241,7 +241,7 @@ function StudentProfiles() {
             delete updated[email];
             return updated;
           });
-        }, 250);
+        }, 300);
         return { ...prev, [email]: 'closing' };
       }
     });
@@ -782,11 +782,12 @@ function StudentProfiles() {
                         </tr>
                         {expandedRows[s.email] && (
                           <tr
-                            className={`job-subrow${expandedRows[s.email] === 'closing' ? ' closing' : ''}`}
+                            className={`job-subrow ${expandedRows[s.email]}`}
                             key={`${s.email}-jobs`}
                           >
                             <td colSpan="100%">
-                              <table className="job-subtable">
+                              <div className="job-subrow-content">
+                                <table className="job-subtable">
                                 <thead>
                                   <tr>
                                     <th>Job Title</th>
@@ -873,6 +874,7 @@ function StudentProfiles() {
                                   )}
                                 </tbody>
                               </table>
+                              </div>
                             </td>
                           </tr>
                         )}

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -228,12 +228,13 @@ function StudentProfiles() {
 
   const toggleRow = (email, assignedJobs = []) => {
     setExpandedRows((prev) => {
-      const isOpen = prev[email] === 'open';
+      const state = prev[email];
+      const isOpen = state === 'open' || state === 'opening';
       if (!isOpen) {
         for (const job of assignedJobs) {
           fetchJobDescriptionStatus(email, job.job_code);
         }
-        return { ...prev, [email]: 'open' };
+        return { ...prev, [email]: 'opening' };
       } else {
         setTimeout(() => {
           setExpandedRows((cur) => {
@@ -244,6 +245,12 @@ function StudentProfiles() {
         }, 300);
         return { ...prev, [email]: 'closing' };
       }
+    });
+
+    requestAnimationFrame(() => {
+      setExpandedRows((prev) =>
+        prev[email] === 'opening' ? { ...prev, [email]: 'open' } : prev
+      );
     });
   };
 


### PR DESCRIPTION
## Summary
- add slide-down fade animation when revealing a student's assigned jobs

## Testing
- `pytest -q`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a287e253ac83339580688709745da6