### PR TITLE
Add drawer-based student form

### DIFF
--- a/frontend/src/StudentForm.css
+++ b/frontend/src/StudentForm.css
@@ -18,8 +18,10 @@
   background: rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(10px);
   padding: 1.5rem;
+  box-sizing: border-box;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   z-index: 1001;
 }
 
@@ -27,6 +29,9 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  overflow-y: auto;
+  padding-bottom: 1rem;
+  flex: 1 1 auto;
 }
 
 .student-form label {
@@ -46,6 +51,11 @@
   display: flex;
   gap: 0.5rem;
   margin-top: 1rem;
+  position: sticky;
+  bottom: 0;
+  padding-top: 1rem;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(10px);
 }
 
 .form-actions button {

--- a/frontend/src/StudentForm.css
+++ b/frontend/src/StudentForm.css
@@ -1,0 +1,69 @@
+.drawer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 400px;
+  max-width: 100%;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(10px);
+  padding: 1.5rem;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.2);
+  overflow-y: auto;
+  z-index: 1001;
+}
+
+.student-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.student-form label {
+  font-weight: 600;
+}
+
+.student-form input,
+.student-form select,
+.student-form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.form-actions button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: #0074d9;
+  color: white;
+  font-weight: 600;
+}
+
+.form-actions .cancel-btn {
+  background-color: transparent;
+  color: #0074d9;
+  border: 1px solid #0074d9;
+}
+
+.error {
+  color: #ff4136;
+}

--- a/frontend/src/StudentForm.css
+++ b/frontend/src/StudentForm.css
@@ -30,7 +30,7 @@
   flex-direction: column;
   gap: 0.75rem;
   overflow-y: auto;
-  padding-bottom: 1rem;
+  padding-bottom: 2rem;
   flex: 1 1 auto;
 }
 
@@ -51,11 +51,6 @@
   display: flex;
   gap: 0.5rem;
   margin-top: 1rem;
-  position: sticky;
-  bottom: 0;
-  padding-top: 1rem;
-  background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(10px);
 }
 
 .form-actions button {

--- a/frontend/src/StudentForm.css
+++ b/frontend/src/StudentForm.css
@@ -47,6 +47,10 @@
   border-radius: 4px;
 }
 
+.student-form textarea {
+  min-height: 6rem;
+}
+
 .form-actions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/StudentForm.js
+++ b/frontend/src/StudentForm.js
@@ -1,0 +1,124 @@
+import React, { useState, useEffect, useRef } from 'react';
+import loadGoogleMaps from './utils/loadGoogleMaps';
+import './StudentForm.css';
+
+const initialState = {
+  first_name: '',
+  last_name: '',
+  email: '',
+  phone: '',
+  license: '',
+  skills: '',
+  experience_summary: '',
+  interests: '',
+  city: '',
+  state: '',
+  lat: '',
+  lng: '',
+  max_travel: ''
+};
+
+function StudentForm({ title, initialData = {}, licenses = [], onSubmit, onCancel, isSaving }) {
+  const [formData, setFormData] = useState({ ...initialState, ...initialData });
+  const [formError, setFormError] = useState('');
+  const cityRef = useRef(null);
+
+  useEffect(() => {
+    setFormData({ ...initialState, ...initialData });
+  }, [initialData]);
+
+  useEffect(() => {
+    const initAutocomplete = () => {
+      if (cityRef.current && window.google) {
+        const ac = new window.google.maps.places.Autocomplete(cityRef.current, { types: ['(cities)'] });
+        ac.addListener('place_changed', () => {
+          const place = ac.getPlace();
+          const comps = place.address_components || [];
+          const city = comps.find(c => c.types.includes('locality'))?.long_name || '';
+          const state = comps.find(c => c.types.includes('administrative_area_level_1'))?.short_name || '';
+          const lat = place.geometry.location.lat();
+          const lng = place.geometry.location.lng();
+          setFormData(prev => ({ ...prev, city, state, lat, lng }));
+        });
+      }
+    };
+    loadGoogleMaps(initAutocomplete);
+  }, []);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const validate = () => {
+    if (!formData.first_name || !formData.last_name || !formData.email) {
+      setFormError('First name, last name and email are required.');
+      return false;
+    }
+    setFormError('');
+    return true;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    const studentData = {
+      ...formData,
+      skills: formData.skills.split(',').map((s) => s.trim()),
+      interests: formData.interests.trim(),
+      lat: parseFloat(formData.lat || 0),
+      lng: parseFloat(formData.lng || 0),
+      max_travel: parseFloat(formData.max_travel || 0)
+    };
+    const result = await onSubmit(studentData);
+    if (result !== false) {
+      setFormData(initialState);
+    }
+  };
+
+  return (
+    <form className="student-form" onSubmit={handleSubmit}>
+      <h2>{title}</h2>
+      <label htmlFor="first_name">First Name</label>
+      <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
+      <label htmlFor="last_name">Last Name</label>
+      <input id="last_name" name="last_name" type="text" value={formData.last_name} onChange={handleChange} />
+      <label htmlFor="email">Email</label>
+      <input id="email" name="email" type="text" value={formData.email} onChange={handleChange} />
+      <label htmlFor="phone">Phone</label>
+      <input id="phone" name="phone" type="text" value={formData.phone} onChange={handleChange} />
+      <label htmlFor="license">License</label>
+      <select id="license" name="license" value={formData.license} onChange={handleChange}>
+        <option value="">Select...</option>
+        {licenses.map((l) => (
+          <option key={l.code} value={l.code}>{l.label}</option>
+        ))}
+      </select>
+      <label htmlFor="skills">Skills</label>
+      <input id="skills" name="skills" type="text" value={formData.skills} onChange={handleChange} />
+      <label htmlFor="experience_summary">Experience Summary</label>
+      <textarea id="experience_summary" name="experience_summary" value={formData.experience_summary} onChange={handleChange} />
+      <label htmlFor="interests">Interests</label>
+      <input id="interests" name="interests" type="text" value={formData.interests} onChange={handleChange} />
+      <label htmlFor="city">City</label>
+      <input id="city" name="city" type="text" value={formData.city} onChange={handleChange} ref={cityRef} />
+      <label htmlFor="state">State</label>
+      <input id="state" name="state" type="text" value={formData.state} onChange={handleChange} readOnly />
+      <label htmlFor="max_travel">Max Travel</label>
+      <input id="max_travel" name="max_travel" type="number" value={formData.max_travel} onChange={handleChange} />
+      <input type="hidden" id="lat" name="lat" value={formData.lat} readOnly />
+      <input type="hidden" id="lng" name="lng" value={formData.lng} readOnly />
+      <div className="form-actions">
+        <button type="submit" disabled={isSaving}>
+          {isSaving ? <><span className="spinner" /> Saving...</> : 'Save'}
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} className="cancel-btn">Cancel</button>
+        )}
+      </div>
+      {formError && <p className="error">{formError}</p>}
+    </form>
+  );
+}
+
+export default StudentForm;
+

--- a/frontend/src/StudentForm.js
+++ b/frontend/src/StudentForm.js
@@ -96,7 +96,7 @@ function StudentForm({ title, initialData = {}, licenses = [], onSubmit, onCance
       <label htmlFor="skills">Skills</label>
       <input id="skills" name="skills" type="text" value={formData.skills} onChange={handleChange} />
       <label htmlFor="experience_summary">Experience Summary</label>
-      <textarea id="experience_summary" name="experience_summary" value={formData.experience_summary} onChange={handleChange} />
+      <textarea id="experience_summary" name="experience_summary" rows={4} value={formData.experience_summary} onChange={handleChange} />
       <label htmlFor="interests">Interests</label>
       <input id="interests" name="interests" type="text" value={formData.interests} onChange={handleChange} />
       <label htmlFor="city">City</label>

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Joyride from 'react-joyride';
 import api from './api';
-import loadGoogleMaps from './utils/loadGoogleMaps';
 import { useNavigate } from 'react-router-dom';
 
 import AdminMenu from './AdminMenu';
@@ -10,30 +9,14 @@ import './StudentProfiles.css';
 import './Tour.css';
 import NotesHistoryModal from './NotesHistoryModal';
 import Tooltip from './components/Tooltip';
+import StudentForm from './StudentForm';
 
 function StudentProfiles() {
-  const [formData, setFormData] = useState({
-    first_name: '',
-    last_name: '',
-    email: '',
-    phone: '',
-    license: '',
-    skills: '',
-    experience_summary: '',
-    interests: '',
-    city: '',
-    state: '',
-    lat: '',
-    lng: '',
-    max_travel: ''
-  });
   const [licenses, setLicenses] = useState([]);
   const licenseLabel = (code) => {
     const l = licenses.find((x) => x.code === code);
     return l ? l.label : code;
   };
-  const [formError, setFormError] = useState('');
-  const [resumeFile, setResumeFile] = useState(null);
   const [toast, setToast] = useState('');
 
   const [showTour, setShowTour] = useState(
@@ -50,7 +33,7 @@ function StudentProfiles() {
       content: "Click 'New Student Profile' when you need to add a student."
     },
     {
-      target: '.profile-form',
+      target: '.student-form',
       content:
         "Fill in the student's contact info, skills, and travel range here."
     },
@@ -94,8 +77,9 @@ function StudentProfiles() {
   const [licenseFilter, setLicenseFilter] = useState('');
   const [assignedFilter, setAssignedFilter] = useState('');
   const [placementFilter, setPlacementFilter] = useState('');
-  const [isEditing, setIsEditing] = useState(false);
   const [editingEmail, setEditingEmail] = useState('');
+  const [editingStudent, setEditingStudent] = useState(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const [activeTab, setActiveTab] = useState('students');
 
@@ -112,28 +96,8 @@ function StudentProfiles() {
     }
   };
 
-  const cityRef = useRef(null);
   const tableWrapperRef = useRef(null);
   const headerRowRef = useRef(null);
-
-  const initAutocomplete = () => {
-    if (cityRef.current && window.google) {
-      const ac = new window.google.maps.places.Autocomplete(cityRef.current, { types: ['(cities)'] });
-      ac.addListener('place_changed', () => {
-        const place = ac.getPlace();
-        const comps = place.address_components || [];
-        const city = comps.find(c => c.types.includes('locality'))?.long_name || '';
-        const state = comps.find(c => c.types.includes('administrative_area_level_1'))?.short_name || '';
-        const lat = place.geometry.location.lat();
-        const lng = place.geometry.location.lng();
-        setFormData(prev => ({ ...prev, city, state, lat, lng }));
-      });
-    }
-  };
-
-  useEffect(() => {
-    loadGoogleMaps(initAutocomplete);
-  }, [activeTab, isEditing]);
 
   useEffect(() => {
     const wrapper = tableWrapperRef.current;
@@ -222,10 +186,6 @@ function StudentProfiles() {
     fetchStudents();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleChange = (e) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
-  };
-
   const toggleRow = (email, assignedJobs = []) => {
     setExpandedRows((prev) => {
       const expanded = !prev[email];
@@ -241,29 +201,25 @@ function StudentProfiles() {
   const handleEdit = (email) => {
     const student = schoolStudents.find((s) => s.email === email);
     if (student) {
-      setFormData({
-        first_name: student.first_name || '',
-        last_name: student.last_name || '',
-        email: student.email || '',
-        phone: student.phone || '',
-        license: student.license || student.education_level || '',
+      const editData = {
+        ...student,
         skills: Array.isArray(student.skills)
           ? student.skills.join(', ')
           : student.skills || '',
-        experience_summary: student.experience_summary || '',
         interests: Array.isArray(student.interests)
           ? student.interests.join(', ')
-          : student.interests || '',
-        city: student.city || '',
-        state: student.state || '',
-        lat: student.lat || '',
-        lng: student.lng || '',
-        max_travel: student.max_travel || '',
-      });
-      setIsEditing(true);
+          : student.interests || ''
+      };
+      setEditingStudent(editData);
       setEditingEmail(student.email);
-      setActiveTab('new');
+      setDrawerOpen(true);
     }
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setEditingStudent(null);
+    setEditingEmail('');
   };
 
   const handleDelete = async (email) => {
@@ -353,66 +309,51 @@ function StudentProfiles() {
   };
 
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setFormError('');
+  const handleCreate = async (data) => {
     setIsSaving(true);
-    const studentData = {
-      first_name: formData.first_name,
-      last_name: formData.last_name,
-      email: formData.email,
-      phone: formData.phone,
-      license: formData.license,
-      skills: formData.skills.split(',').map((s) => s.trim()),
-      experience_summary: formData.experience_summary,
-      interests: formData.interests.trim(),
-      city: formData.city,
-      state: formData.state,
-      lat: parseFloat(formData.lat || 0),
-      lng: parseFloat(formData.lng || 0),
-      max_travel: parseFloat(formData.max_travel || 0),
-    };
     try {
-      const method = isEditing ? 'put' : 'post';
-      const url = isEditing ? `/students/${editingEmail}` : '/students';
-      await api[method](url, studentData, {
+      await api.post('/students', data, {
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
       });
-      const msg = isEditing ? 'Student profile updated!' : 'Student profile submitted!';
-      setToast(msg);
+      setToast('Student profile submitted!');
       setTimeout(() => setToast(''), 3000);
-      setFormData({
-        first_name: '',
-        last_name: '',
-        email: '',
-        phone: '',
-        license: '',
-        skills: '',
-        experience_summary: '',
-        interests: '',
-        city: '',
-        state: '',
-        lat: '',
-        lng: '',
-        max_travel: ''
-      });
-      setResumeFile(null);
-      setIsEditing(false);
-      setEditingEmail('');
       fetchStudents();
+      return true;
     } catch (err) {
       console.error('Submission failed:', err);
-      setFormError('Submission failed. Please check all required fields.');
+      setToast('Submission failed. Please check all required fields.');
+      setTimeout(() => setToast(''), 3000);
+      return false;
     } finally {
       setIsSaving(false);
     }
   };
 
-  const handleResumeChange = (e) => {
-    setResumeFile(e.target.files[0] || null);
+  const handleUpdate = async (data) => {
+    setIsSaving(true);
+    try {
+      await api.put(`/students/${editingEmail}`, data, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      setToast('Student profile updated!');
+      setTimeout(() => setToast(''), 3000);
+      fetchStudents();
+      closeDrawer();
+      return true;
+    } catch (err) {
+      console.error('Submission failed:', err);
+      setToast('Submission failed. Please check all required fields.');
+      setTimeout(() => setToast(''), 3000);
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
   };
 
 
@@ -528,55 +469,12 @@ function StudentProfiles() {
       <div className="tab-content">
         {activeTab === 'new' && (
           <div className="form-panel">
-            <form className="profile-form" onSubmit={handleSubmit}>
-              <h2>{isEditing ? 'Edit Student Profile' : 'New Student Profile'}</h2>
-            <label htmlFor="first_name">First Name</label>
-            <input id="first_name" name="first_name" type="text" value={formData.first_name} onChange={handleChange} />
-            <label htmlFor="last_name">Last Name</label>
-            <input id="last_name" name="last_name" type="text" value={formData.last_name} onChange={handleChange} />
-            <label htmlFor="email">Email</label>
-            <input id="email" name="email" type="text" value={formData.email} onChange={handleChange} />
-            <label htmlFor="phone">Phone</label>
-            <input id="phone" name="phone" type="text" value={formData.phone} onChange={handleChange} />
-            <label htmlFor="license">License</label>
-            <select id="license" name="license" value={formData.license} onChange={handleChange}>
-              <option value="">Select...</option>
-              {licenses.map((l) => (
-                <option key={l.code} value={l.code}>{l.label}</option>
-              ))}
-            </select>
-            <label htmlFor="skills">Skills</label>
-            <input id="skills" name="skills" type="text" value={formData.skills} onChange={handleChange} />
-            <label htmlFor="experience_summary">Experience Summary</label>
-            <textarea id="experience_summary" name="experience_summary" value={formData.experience_summary} onChange={handleChange} />
-            <label htmlFor="interests">Interests</label>
-            <input id="interests" name="interests" type="text" value={formData.interests} onChange={handleChange} />
-            <label htmlFor="city">City</label>
-            <input id="city" name="city" type="text" value={formData.city} onChange={handleChange} ref={cityRef} />
-            <label htmlFor="state">State</label>
-            <input id="state" name="state" type="text" value={formData.state} onChange={handleChange} readOnly />
-            <label htmlFor="max_travel">Max Travel</label>
-            <input id="max_travel" name="max_travel" type="number" value={formData.max_travel} onChange={handleChange} />
-            <input type="hidden" id="lat" name="lat" value={formData.lat} readOnly />
-            <input type="hidden" id="lng" name="lng" value={formData.lng} readOnly />
-            {/* Uploading documents is temporarily disabled */}
-            {false && (
-              <>
-                <label htmlFor="resume">Upload Resume (PDF or DOCX)</label>
-                <input id="resume" name="resume" type="file" onChange={handleResumeChange} />
-              </>
-            )}
-            <button type="submit" disabled={isSaving}>
-              {isSaving ? (
-                <>
-                  <span className="spinner" /> Saving...
-                </>
-              ) : (
-                isEditing ? 'Update' : 'Submit'
-              )}
-            </button>
-            {formError && <p className="error">{formError}</p>}
-            </form>
+            <StudentForm
+              title="New Student Profile"
+              licenses={licenses}
+              onSubmit={handleCreate}
+              isSaving={isSaving}
+            />
           </div>
         )}
         {activeTab === 'students' && (
@@ -877,6 +775,21 @@ function StudentProfiles() {
         </div>
         )}
       </div>
+      {drawerOpen && (
+        <>
+          <div className="drawer-overlay" onClick={closeDrawer}></div>
+          <div className="drawer-panel">
+            <StudentForm
+              title="Edit Student Profile"
+              initialData={editingStudent || {}}
+              licenses={licenses}
+              onSubmit={handleUpdate}
+              onCancel={closeDrawer}
+              isSaving={isSaving}
+            />
+          </div>
+        </>
+      )}
       {modalNotes && (
         <NotesHistoryModal
           notes={modalNotes.notes}


### PR DESCRIPTION
## Summary
- replace inline profile form with reusable `StudentForm`
- open edit form in glassy slide-in drawer
- style form and drawer with consistent spacing

## Testing
- `cd frontend && npm test -- StudentProfiles.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a288ee3d908333b56a4a80d73b59ca