### PR TITLE
Fix landing page layout and reduce initial distortion

### DIFF
--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -6,11 +6,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding-top: 2rem;
+  padding-top: 0rem;
   text-align: center;
   position: relative;
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
-  gap: 1rem;
 }
 
 .landing-logo {
@@ -18,59 +17,19 @@
   width: 50vw;
   max-width: 475px;
   height: auto;
-}
-
-.landing-menu {
-  margin-top: -10vh;
+  margin-bottom: -10rem;
 }
 
 .landing-title {
-  font-size: var(--font-size-h1);
-  line-height: var(--line-height-h1);
-  margin: 0 0 1.5rem;
+  font-size: 3rem;
+  margin-bottom: 1rem;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
 .landing-buttons {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-}
-
-@media (min-width: var(--bp-md)) {
-  .landing-container {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-      'logo title'
-      'logo buttons';
-    align-items: center;
-    justify-items: center;
-    text-align: left;
-  }
-  .landing-logo {
-    grid-area: logo;
-    width: 100%;
-    max-width: 400px;
-    margin-bottom: 0;
-  }
-  .landing-menu {
-    margin-top: 0;
-  }
-  .landing-title {
-    grid-area: title;
-    margin-bottom: 0.5rem;
-  }
-  .landing-buttons {
-    grid-area: buttons;
-    align-items: flex-start;
-  }
-}
-
-@media (min-width: var(--bp-lg)) {
-  .landing-container {
-    gap: 3rem;
-  }
+  gap: 0.75rem;
 }
 
 .landing-btn {

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -10,7 +10,7 @@
   text-align: center;
   position: relative;
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
-  gap: 2rem;
+  gap: 1rem;
 }
 
 .landing-logo {
@@ -18,13 +18,12 @@
   width: 50vw;
   max-width: 475px;
   height: auto;
-  margin-bottom: -8rem;
 }
 
 .landing-title {
   font-size: var(--font-size-h1);
   line-height: var(--line-height-h1);
-  margin-bottom: 1.5rem;
+  margin: 0 0 1.5rem;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -20,6 +20,10 @@
   height: auto;
 }
 
+.landing-menu {
+  margin-top: -10vh;
+}
+
 .landing-title {
   font-size: var(--font-size-h1);
   line-height: var(--line-height-h1);
@@ -49,6 +53,9 @@
     width: 100%;
     max-width: 400px;
     margin-bottom: 0;
+  }
+  .landing-menu {
+    margin-top: 0;
   }
   .landing-title {
     grid-area: title;

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -8,12 +8,20 @@ function LandingPage() {
   return (
     <div className="landing-container">
       <TopMenu />
-      <img src={logo} width={1024} height={1024} className="landing-logo" alt="TalentMatch AI logo" />
-      <h1 className="landing-title">Who Are You?</h1>
-      <div className="landing-buttons">
-        <Link to="/login/career" className="landing-btn">Career Services Login</Link>
-        <Link to="/login/recruiter" className="landing-btn">Recruiter</Link>
-        <Link to="/login/applicant" className="landing-btn">Job Seekers</Link>
+      <img
+        src={logo}
+        width={1024}
+        height={1024}
+        className="landing-logo"
+        alt="TalentMatch AI logo"
+      />
+      <div className="landing-menu">
+        <h1 className="landing-title">Who Are You?</h1>
+        <div className="landing-buttons">
+          <Link to="/login/career" className="landing-btn">Career Services Login</Link>
+          <Link to="/login/recruiter" className="landing-btn">Recruiter</Link>
+          <Link to="/login/applicant" className="landing-btn">Job Seekers</Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -15,13 +15,11 @@ function LandingPage() {
         className="landing-logo"
         alt="TalentMatch AI logo"
       />
-      <div className="landing-menu">
-        <h1 className="landing-title">Who Are You?</h1>
-        <div className="landing-buttons">
-          <Link to="/login/career" className="landing-btn">Career Services Login</Link>
-          <Link to="/login/recruiter" className="landing-btn">Recruiter</Link>
-          <Link to="/login/applicant" className="landing-btn">Job Seekers</Link>
-        </div>
+      <h1 className="landing-title">Who Are You?</h1>
+      <div className="landing-buttons">
+        <Link to="/login/career" className="landing-btn">Career Services Login</Link>
+        <Link to="/login/recruiter" className="landing-btn">Recruiter</Link>
+        <Link to="/login/applicant" className="landing-btn">Job Seekers</Link>
       </div>
     </div>
   );

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -8,7 +8,7 @@ function LandingPage() {
   return (
     <div className="landing-container">
       <TopMenu />
-      <img src={logo} className="landing-logo" alt="TalentMatch AI logo" />
+      <img src={logo} width={1024} height={1024} className="landing-logo" alt="TalentMatch AI logo" />
       <h1 className="landing-title">Who Are You?</h1>
       <div className="landing-buttons">
         <Link to="/login/career" className="landing-btn">Career Services Login</Link>


### PR DESCRIPTION
## Summary
- Adjust landing page layout spacing to avoid menu being pushed down
- Add intrinsic logo dimensions to prevent first-load distortion

## Testing
- `CI=true npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2960a8c9883338e492aef06d26494