### PR TITLE
Fix student form wiping input

### DIFF
--- a/frontend/src/StudentForm.js
+++ b/frontend/src/StudentForm.js
@@ -18,13 +18,15 @@ const initialState = {
   max_travel: ''
 };
 
-function StudentForm({ title, initialData = {}, licenses = [], onSubmit, onCancel, isSaving }) {
-  const [formData, setFormData] = useState({ ...initialState, ...initialData });
+function StudentForm({ title, initialData, licenses = [], onSubmit, onCancel, isSaving }) {
+  const [formData, setFormData] = useState({ ...initialState, ...(initialData || {}) });
   const [formError, setFormError] = useState('');
   const cityRef = useRef(null);
 
   useEffect(() => {
-    setFormData({ ...initialState, ...initialData });
+    if (initialData) {
+      setFormData({ ...initialState, ...initialData });
+    }
   }, [initialData]);
 
   useEffect(() => {

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -809,7 +809,7 @@ function StudentProfiles() {
           <div className="drawer-panel">
             <StudentForm
               title="Edit Student Profile"
-              initialData={editingStudent || {}}
+              initialData={editingStudent}
               licenses={licenses}
               onSubmit={handleUpdate}
               onCancel={closeDrawer}


### PR DESCRIPTION
## Summary
- avoid resetting student form state unless initial data changes
- pass editing student data directly to form to keep fields stable while typing

## Testing
- `pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a393e6e81483339a96517d912b9e13