### PR TITLE
Use JSON user data for match results lookups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1450,7 +1450,7 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         existing = {m["email"] for m in matches}
         for email in assigned | placed | rejected:
             if email not in existing:
-                udata = redis_client.hgetall(f"user:{email}") or {}
+                udata = json.loads(redis_client.get(f"user:{email}") or "{}")
                 first = udata.get("first_name", "")
                 last = udata.get("last_name", "")
                 name = f"{first} {last}".strip()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -241,14 +241,8 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
         "placed_students": []
     })
 
-    def fake_hgetall(key):
-        data = {
-            "user:a@example.com": {"first_name": "A", "last_name": "One"},
-            "user:b@example.com": {"first_name": "B", "last_name": "Two"},
-        }
-        return data.get(key, {})
-
-    monkeypatch.setattr(main_app.redis_client, "hgetall", fake_hgetall, raising=False)
+    store["user:a@example.com"] = json.dumps({"first_name": "A", "last_name": "One"})
+    store["user:b@example.com"] = json.dumps({"first_name": "B", "last_name": "Two"})
 
     resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Retrieve user data via Redis `get` with JSON parsing in `get_match_results`
- Populate missing match entries with first/last names from parsed JSON
- Update tests to mock `redis_client.get` returning user JSON instead of `hgetall`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6afcc14908333a46f36917f2b0833