### PR TITLE
Use user profile keys when generating resumes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2095,7 +2095,11 @@ def generate_resume(req: ResumeRequest, current_user: dict = Depends(get_current
             return {"status": "exists"}
 
     job_raw = redis_client.get(f"job:{req.job_code}")
-    student_raw = redis_client.get(student_key(req.student_email))
+    # Prefer profile stored under "user:" key, falling back to legacy "student:" key
+    profile_key = find_user_key(req.student_email) or user_key(req.student_email)
+    student_raw = redis_client.get(profile_key)
+    if not student_raw:
+        student_raw = redis_client.get(student_key(req.student_email))
     if not job_raw or not student_raw:
         log.warning("❌ Job or student not found")
         raise HTTPException(status_code=404, detail="Job or student not found")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1072,6 +1072,86 @@ def test_generate_resume_preview(monkeypatch):
     assert main_app.redis_client.get("resumehtml:coder:stud@example.com") is None
 
 
+def test_generate_resume_user_key_lookup(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    # store profile using a mixed-case user key to exercise find_user_key()
+    main_app.redis_client.set(
+        "user:Stud@Example.com",
+        json.dumps({"first_name": "Stud", "last_name": "S", "skills": ["python"]}),
+    )
+    main_app.redis_client.set(
+        "job:coder",
+        json.dumps({
+            "job_code": "coder",
+            "job_title": "Dev",
+            "job_description": "desc",
+            "desired_skills": ["python"],
+            "assigned_students": ["stud@example.com"],
+        }),
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "<h2>Summary</h2>"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/generate-resume",
+        json={"student_email": "stud@example.com", "job_code": "coder"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+
+def test_generate_resume_student_key_fallback(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    # only legacy student: key exists
+    main_app.redis_client.set(
+        "student:stud@example.com",
+        json.dumps({"first_name": "Stud", "last_name": "S", "skills": ["python"]}),
+    )
+    main_app.redis_client.set(
+        "job:coder",
+        json.dumps({
+            "job_code": "coder",
+            "job_title": "Dev",
+            "job_description": "desc",
+            "desired_skills": ["python"],
+            "assigned_students": ["stud@example.com"],
+        }),
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "<h2>Summary</h2>"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/generate-resume",
+        json={"student_email": "stud@example.com", "job_code": "coder"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+
 def test_generate_resume_requires_assignment():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- Prefer `user:` profile keys in resume generation, falling back to legacy `student:` keys
- Add tests covering user profile lookup and student key fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6c330fa948333871c3072d15e41ef