### PR TITLE
Handle malformed job records in update endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1148,8 +1148,10 @@ def update_job(job_code: str, updated: dict, token_data: dict = Depends(get_curr
 
     if not raw:
         raise HTTPException(status_code=404, detail="Job not found")
-
-    job = json.loads(raw)
+    try:
+        job = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Malformed job record")
 
     if token_data.get("role") != "admin" and token_data.get("sub") != job.get("posted_by"):
         raise HTTPException(status_code=403, detail="Not authorized to edit this job")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -441,6 +441,21 @@ def test_license_label_vs_code_matching(monkeypatch):
     assert any(m["email"] == "code@example.com" for m in match_resp2.json()["matches"])
 
 
+def test_update_job_with_corrupted_data():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    token = login_admin()
+    job_code = "CORRUPT1"
+    main_app.redis_client.set(f"job:{job_code}", "not-json")
+    resp = client.put(
+        f"/jobs/{job_code}",
+        json={"job_title": "New"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Malformed job record"
+
+
 def test_match_respects_travel_distance(monkeypatch):
     token = login_admin()
 


### PR DESCRIPTION
## Summary
- guard against invalid JSON when updating jobs
- test job update path with corrupted job data

## Testing
- `pytest tests/test_jobs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a720fb16188333bedadcacdd60e8d3