### PR TITLE
Deduplicate match results by email

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1430,11 +1430,11 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         return {"matches": []}
 
     try:
-        matches = json.loads(results_json)
+        matches = {m["email"]: m for m in json.loads(results_json)}
         log.info("📦 Returning %s stored matches for job %s", len(matches), job_code)
 
         # Ensure each match has first and last name fields
-        for m in matches:
+        for m in matches.values():
             if "first_name" not in m or "last_name" not in m:
                 parts = m.get("name", "").split(" ", 1)
                 m.setdefault("first_name", parts[0] if parts else "")
@@ -1449,38 +1449,38 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         placed = set(job.get("placed_students", []))
         rejected = set(job.get("rejected_students", []))
 
-        existing = {m["email"] for m in matches}
+        existing = set(matches)
         for email in assigned | placed | rejected:
             if email not in existing:
                 udata = json.loads(redis_client.get(f"user:{email}") or "{}")
                 first = udata.get("first_name", "")
                 last = udata.get("last_name", "")
                 name = f"{first} {last}".strip()
-                matches.append({
+                matches[email] = {
                     "name": name,
                     "first_name": first,
                     "last_name": last,
                     "email": email,
                     "score": None,
-                })
+                }
 
-        for m in matches:
-            if m["email"] in placed:
+        for email, m in matches.items():
+            if email in placed:
                 m["status"] = "placed"
-            elif m["email"] in assigned:
+            elif email in assigned:
                 m["status"] = "assigned"
-            elif m["email"] in rejected:
+            elif email in rejected:
                 m["status"] = "rejected"
             else:
                 m["status"] = None
 
-            notes_raw = job.get("student_notes", {}).get(m["email"], [])
+            notes_raw = job.get("student_notes", {}).get(email, [])
             notes, latest_note = _normalize_notes(notes_raw)
             m["notes"] = notes
             if latest_note is not None:
                 m["note"] = latest_note
 
-        return {"matches": matches}
+        return {"matches": list(matches.values())}
     except Exception as e:
         log.error("❌ Failed to load match results for %s: %s", job_code, e)
         return {"matches": []}

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -288,6 +288,39 @@ def test_get_match_results_includes_notes(monkeypatch):
     assert data["note"] == "hi"
 
 
+def test_get_match_results_no_duplicate_emails(monkeypatch):
+    token = login_admin()
+
+    store = {}
+
+    def fake_get(key):
+        return store.get(key)
+
+    def fake_set(key, value):
+        store[key] = value
+
+    monkeypatch.setattr(main_app.redis_client, "get", fake_get)
+    monkeypatch.setattr(main_app.redis_client, "set", fake_set)
+
+    job_code = "XYZ5"
+    store[f"match_results:{job_code}"] = json.dumps([
+        {"email": "dup@example.com", "score": 1.0},
+        {"email": "dup@example.com", "score": 2.0},
+    ])
+    store[f"job:{job_code}"] = json.dumps({
+        "job_code": job_code,
+        "assigned_students": [],
+        "placed_students": [],
+    })
+
+    resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()["matches"]
+    emails = [m["email"] for m in data]
+    assert emails == ["dup@example.com"]
+    assert len(emails) == len(set(emails))
+
+
 def test_match_filters_by_license(monkeypatch):
     token = login_admin()
 


### PR DESCRIPTION
## Summary
- Deduplicate match results by converting loaded matches to a dict keyed by email before processing
- Ensure job-related status and notes logic works with the deduplicated structure
- Add regression test confirming match results do not contain duplicate emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7245977c88333b8e009bafae0adc3