### PR TITLE
Propagate request ID across backend logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,13 +45,22 @@ from backend.app.services.resume import generate_resume_text
 from backend.app.services.description import generate_description_text
 from backend.app.school_codes import SCHOOL_CODE_MAP
 from backend.app.services.summary import send_weekly_summary
+from backend.app.logging_utils import (
+    RequestIdFilter,
+    get_logger,
+    request_id_ctx_var,
+)
 
-log = logging.getLogger(__name__)
 logging.basicConfig(
     stream=sys.stdout,
     level=logging.INFO,
-    format="%(levelname)s %(message)s",
+    format="%(levelname)s [%(request_id)s] %(message)s",
 )
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIdFilter())
+
+
+log = get_logger(__name__)
 
 
 def init_default_school_codes():
@@ -303,34 +312,41 @@ app = FastAPI()
 # Simple request logging and activity tracking
 @app.middleware("http")
 async def log_requests(request, call_next):
-    log.info("Incoming %s %s", request.method, request.url)
-    user = None
-    auth = request.headers.get("Authorization")
-    if auth and auth.startswith("Bearer "):
-        token = auth.split(" ", 1)[1]
-        try:
-            payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
-            user = payload.get("sub")
-        except JWTError:
-            user = "invalid_token"
-
-    log_entry = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "method": request.method,
-        "path": request.url.path,
-        "user": user,
-    }
-    start = datetime.now()
-    response = await call_next(request)
-    duration = (datetime.now() - start).total_seconds()
-    log.info("Response %s in %.3fs", response.status_code, duration)
-    log_entry["status"] = response.status_code
-    log_entry["duration"] = duration
+    request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    request.state.request_id = request_id
+    token = request_id_ctx_var.set(request_id)
     try:
-        redis_client.rpush(ACTIVITY_LOG_KEY, json.dumps(log_entry))
-    except Exception as e:
-        log.error("Failed to store activity log: %s", e)
-    return response
+        log.info("Incoming %s %s", request.method, request.url)
+        user = None
+        auth = request.headers.get("Authorization")
+        if auth and auth.startswith("Bearer "):
+            token_val = auth.split(" ", 1)[1]
+            try:
+                payload = jwt.decode(token_val, JWT_SECRET, algorithms=[ALGORITHM])
+                user = payload.get("sub")
+            except JWTError:
+                user = "invalid_token"
+
+        log_entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "method": request.method,
+            "path": request.url.path,
+            "user": user,
+            "request_id": request_id,
+        }
+        start = datetime.now()
+        response = await call_next(request)
+        duration = (datetime.now() - start).total_seconds()
+        log.info("Response %s in %.3fs", response.status_code, duration)
+        log_entry["status"] = response.status_code
+        log_entry["duration"] = duration
+        try:
+            redis_client.rpush(ACTIVITY_LOG_KEY, json.dumps(log_entry))
+        except Exception as e:
+            log.error("Failed to store activity log: %s", e)
+        return response
+    finally:
+        request_id_ctx_var.reset(token)
 
 @app.get("/routes")
 def list_routes():
@@ -1172,11 +1188,21 @@ def update_job(job_code: str, updated: dict, token_data: dict = Depends(get_curr
     return {"message": "Job updated"}
 
 @app.post("/match")
-def match_job(req: JobCodeRequest, current_user: dict = Depends(get_current_user)):
+def match_job(
+    req: JobCodeRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
     """Enqueue a matching job and return immediately."""
     enq_time = datetime.now().timestamp()
     if hasattr(redis_client, "pipeline"):
-        get_queue().enqueue(match_worker, req.job_code, True, enq_time)
+        get_queue().enqueue(
+            match_worker,
+            req.job_code,
+            True,
+            enq_time,
+            meta={"request_id": request.state.request_id},
+        )
         return {"message": "Match job queued"}
     else:
         matches = match_worker(req.job_code, True, enq_time)
@@ -1184,11 +1210,21 @@ def match_job(req: JobCodeRequest, current_user: dict = Depends(get_current_user
 
 
 @app.post("/rematches/{job_code}")
-def rematch_job(job_code: str, current_user: dict = Depends(get_current_user)):
+def rematch_job(
+    job_code: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
     """Queue a rematch computation without notifying students."""
     enq_time = datetime.now().timestamp()
     if hasattr(redis_client, "pipeline"):
-        get_queue().enqueue(match_worker, job_code, False, enq_time)
+        get_queue().enqueue(
+            match_worker,
+            job_code,
+            False,
+            enq_time,
+            meta={"request_id": request.state.request_id},
+        )
         return {"message": "Rematch queued"}
     else:
         matches = match_worker(job_code, False, enq_time)

--- a/backend/app/logging_utils.py
+++ b/backend/app/logging_utils.py
@@ -1,0 +1,34 @@
+"""Utilities for request-scoped logging with request IDs."""
+
+from contextvars import ContextVar
+import logging
+
+# Context variable to store the current request ID
+request_id_ctx_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class RequestIdFilter(logging.Filter):
+    """Logging filter to inject request_id into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        record.request_id = request_id_ctx_var.get("-")
+        return True
+
+
+class RequestIdAdapter(logging.LoggerAdapter):
+    """Logger adapter that adds request_id from context var."""
+
+    def process(self, msg, kwargs):  # noqa: D401
+        extra = kwargs.get("extra")
+        if not extra:
+            extra = {}
+        extra["request_id"] = request_id_ctx_var.get("-")
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+
+def get_logger(name: str | None = None) -> RequestIdAdapter:
+    """Return a logger adapter that includes the request ID."""
+
+    logger = logging.getLogger(name)
+    return RequestIdAdapter(logger)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,1 +1,3 @@
-"""Placeholder module so tests can import backend.app.main."""
+"""Expose the FastAPI application for test imports."""
+
+from app.main import app  # noqa: F401

--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -10,13 +10,15 @@ from typing import Any, Dict, List, Tuple
 
 from openai import OpenAI
 
+from backend.app.logging_utils import get_logger
+
 ACTIVITY_LOG_KEY = "activity_logs"
 redis_client = None
 send_email = None
 
 # Reuse a single OpenAI client; reads OPENAI_API_KEY from env
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _ensure_dependencies() -> None:

--- a/worker.py
+++ b/worker.py
@@ -8,6 +8,11 @@ from rq import Worker, Queue
 
 from backend.app.services.summary import send_weekly_summary
 from scripts.schedule_weekly_summary import schedule_weekly_summary
+from backend.app.logging_utils import (
+    RequestIdFilter,
+    get_logger,
+    request_id_ctx_var,
+)
 
 load_dotenv()
 
@@ -34,7 +39,14 @@ if not redis_url:
 redis_client = redis.Redis.from_url(redis_url, decode_responses=True)
 rq_client = redis.Redis.from_url(redis_url)
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s [%(request_id)s] %(message)s",
+)
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIdFilter())
+
+logger = get_logger(__name__)
 
 def normalize_email(email: str | None) -> str:
     return (email or "").strip().lower()
@@ -63,8 +75,19 @@ def weekly_summary_worker() -> None:
                 logger.exception("Failed to send weekly summary to %s", email)
 
 
+class RequestIdWorker(Worker):
+    """RQ Worker that sets request ID context from job metadata."""
+
+    def execute_job(self, job, queue):  # type: ignore[override]
+        token = request_id_ctx_var.set(job.meta.get("request_id", "-"))
+        try:
+            return super().execute_job(job, queue)
+        finally:
+            request_id_ctx_var.reset(token)
+
+
 if __name__ == "__main__":
     schedule_weekly_summary()
     default_queue = Queue(connection=rq_client)
     weekly_queue = Queue("weekly", connection=rq_client)
-    Worker([default_queue, weekly_queue], connection=rq_client).work()
+    RequestIdWorker([default_queue, weekly_queue], connection=rq_client).work()


### PR DESCRIPTION
## Summary
- add request-scoped logging utilities
- attach/generate request IDs in FastAPI middleware and queue metadata
- update worker and services to log the propagated request ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7edc52288833384c5b6ef7e1d030b