### PR TITLE
Add student key migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,21 @@ python scripts/backfill_codes.py
 The script scans all `user:*` and `student:*` keys and updates records where
 `institutional_code` is absent but `school_code` exists.
 
+## Migrating Student Keys
+
+Legacy student records were previously stored using `student:{email}` keys. Run
+the migration script to convert them to the new
+`student:{institutional_code}:{student_id}` format and create `student_email`
+index entries:
+
+```bash
+export REDIS_URL=redis://localhost:6379/0  # or your instance
+python scripts/migrate_student_keys.py
+```
+
+The script assigns a `student_id` when missing, adds the required index keys,
+and logs any records missing necessary data for manual review.
+
 ## Scheduling Weekly Summaries
 
 Run the scheduler script to enqueue weekly summary jobs:

--- a/scripts/migrate_student_keys.py
+++ b/scripts/migrate_student_keys.py
@@ -1,0 +1,79 @@
+import os
+import json
+import redis
+
+
+def normalize_email(email: str | None) -> str:
+    """Return a lowercase, stripped version of an email."""
+    return (email or "").strip().lower()
+
+
+def student_key(institution_code: str, student_id: str) -> str:
+    """Return the canonical redis key for a student."""
+    return f"student:{institution_code}:{student_id}"
+
+
+def student_email_key(email: str) -> str:
+    """Return the index key for a student email."""
+    return f"student_email:{normalize_email(email)}"
+
+
+def generate_student_id(client: redis.Redis) -> str:
+    """Generate a new student identifier."""
+    return str(client.incr("student_id"))
+
+
+def migrate_student_keys() -> None:
+    """Migrate legacy student:* keys to student:{institution_code}:{student_id}."""
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        raise RuntimeError("Missing REDIS_URL")
+
+    client = redis.Redis.from_url(redis_url, decode_responses=True)
+
+    migrated = 0
+    manual_review: list[str] = []
+
+    for key in list(client.scan_iter("student:*")):
+        # Skip new-style keys which already contain two colons
+        if key.count(":") != 1:
+            continue
+        email = key.split("student:", 1)[1]
+        raw = client.get(key)
+        if not raw:
+            manual_review.append(email)
+            client.delete(key)
+            continue
+        try:
+            data = json.loads(raw)
+        except Exception:
+            manual_review.append(email)
+            client.delete(key)
+            continue
+
+        inst_code = data.get("institutional_code")
+        rec_email = normalize_email(data.get("email") or email)
+        if not inst_code or not rec_email:
+            manual_review.append(email)
+            continue
+
+        student_id = data.get("student_id") or generate_student_id(client)
+        data["student_id"] = student_id
+        data["institutional_code"] = inst_code
+        data["email"] = rec_email
+
+        new_key = student_key(inst_code, student_id)
+        client.set(new_key, json.dumps(data))
+        client.set(student_email_key(rec_email), f"{inst_code}:{student_id}")
+        client.delete(key)
+        migrated += 1
+
+    print(
+        f"Migration complete. Migrated {migrated} students; {len(manual_review)} need manual review."
+    )
+    if manual_review:
+        print("Manual review:", ", ".join(sorted(manual_review)))
+
+
+if __name__ == "__main__":
+    migrate_student_keys()


### PR DESCRIPTION
## Summary
- add script to migrate legacy student keys to new format and index by email
- document migration script usage in README

## Testing
- `python -m py_compile scripts/migrate_student_keys.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac99d11883338af47856c477c9b6