### PR TITLE
Handle malformed user JSON in admin listings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -703,7 +703,11 @@ def pending_users(current_user: dict = Depends(get_current_user)):
         raw = redis_client.get(key)
         if not raw:
             continue
-        info = json.loads(raw)
+        try:
+            info = json.loads(raw)
+        except json.JSONDecodeError:
+            log.warning("Invalid JSON for key %s", key)
+            continue
         if info.get("approved") or info.get("rejected"):
             continue
         email = key.split("user:", 1)[1]
@@ -720,7 +724,11 @@ def list_users(current_user: dict = Depends(get_current_user)):
         raw = redis_client.get(key)
         if not raw:
             continue
-        data = json.loads(raw)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            log.warning("Invalid JSON for key %s", key)
+            continue
         email = key.split("user:", 1)[1]
         data.pop("password", None)
         users.append({"email": email, **data})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2064,3 +2064,30 @@ def test_student_endpoints_handle_string_notes():
     assert entry["note"] == "legacy"
     assert "posted_by" in entry
 
+
+def test_malformed_user_skipped_in_listings():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    )
+    token = login_resp.json()["token"]
+
+    # Insert one valid and one malformed user record
+    main_app.redis_client.set(
+        "user:good@example.com", json.dumps({"first_name": "Good", "password": "pw"})
+    )
+    main_app.redis_client.set("user:bad@example.com", "{not-json}")
+
+    pending = client.get("/pending-users", headers={"Authorization": f"Bearer {token}"})
+    assert pending.status_code == 200
+    emails = [u["email"] for u in pending.json()]
+    assert "good@example.com" in emails
+    assert "bad@example.com" not in emails
+
+    users = client.get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+    assert users.status_code == 200
+    user_emails = [u["email"] for u in users.json()["users"]]
+    assert "bad@example.com" not in user_emails
+


### PR DESCRIPTION
## Summary
- skip invalid user JSON entries when listing users or pending approvals
- test endpoints ignore malformed user records

## Testing
- `pytest tests/test_main.py::test_malformed_user_skipped_in_listings -q`


------
https://chatgpt.com/codex/tasks/task_e_68a940f963a4833386f66ed33181a855