### PR TITLE
Add detailed logging for malformed Redis user records

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -705,8 +705,16 @@ def pending_users(current_user: dict = Depends(get_current_user)):
             continue
         try:
             info = json.loads(raw)
-        except json.JSONDecodeError:
-            log.warning("Invalid JSON for key %s", key)
+        except json.JSONDecodeError as exc:
+            sample = raw[:200] + ("..." if len(raw) > 200 else "")
+            log.error(
+                "Malformed JSON for Redis key %s (len=%d) sample=%r: %s",
+                key,
+                len(raw),
+                sample,
+                exc,
+                exc_info=True,
+            )
             continue
         if info.get("approved") or info.get("rejected"):
             continue
@@ -726,8 +734,16 @@ def list_users(current_user: dict = Depends(get_current_user)):
             continue
         try:
             data = json.loads(raw)
-        except json.JSONDecodeError:
-            log.warning("Invalid JSON for key %s", key)
+        except json.JSONDecodeError as exc:
+            sample = raw[:200] + ("..." if len(raw) > 200 else "")
+            log.error(
+                "Malformed JSON for Redis key %s (len=%d) sample=%r: %s",
+                key,
+                len(raw),
+                sample,
+                exc,
+                exc_info=True,
+            )
             continue
         email = key.split("user:", 1)[1]
         data.pop("password", None)


### PR DESCRIPTION
## Summary
- Improve admin user listings by reporting malformed JSON records with key, length, and sample payload
- Add matching logging to pending user listing

## Testing
- `pytest tests/test_main.py::test_malformed_user_skipped_in_listings -q`


------
https://chatgpt.com/codex/tasks/task_e_68a94185465883338d4fddbe2e08e3a5