### PR TITLE
Improve logging for distance caching and summary generation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -319,23 +319,41 @@ async def get_driving_distance_miles(orig_lat: float, orig_lng: float, dest_lat:
     cached = redis_client.get(cache_key)
     if cached is not None:
         try:
-            return float(cached)
+            miles = float(cached)
+            log.info("Distance cache hit for %s", cache_key)
+            return miles
         except ValueError:
-            pass
+            log.exception("Invalid cached distance for %s", cache_key)
 
+    log.info("Distance cache miss for %s", cache_key)
     params = {
         "origins": f"{orig_lat},{orig_lng}",
         "destinations": f"{dest_lat},{dest_lng}",
         "units": "imperial",
         "key": key,
     }
+    url = "https://maps.googleapis.com/maps/api/distancematrix/json"
     async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            "https://maps.googleapis.com/maps/api/distancematrix/json",
-            params=params,
+        try:
+            log.info("Requesting %s params=%s", url, params)
+            resp = await client.get(url, params=params)
+        except Exception:
+            log.exception("Error requesting distance matrix")
+            raise
+
+    if resp.status_code != 200:
+        log.warning(
+            "Distance matrix non-200 response %s: %s", resp.status_code, resp.text
         )
-    data = resp.json()
-    value_meters = data["rows"][0]["elements"][0]["distance"]["value"]
+        resp.raise_for_status()
+
+    try:
+        data = resp.json()
+        value_meters = data["rows"][0]["elements"][0]["distance"]["value"]
+    except Exception:
+        log.exception("Error parsing distance matrix response")
+        raise
+
     miles = value_meters / 1609.34
     redis_client.setex(cache_key, int(timedelta(hours=24).total_seconds()), miles)
     return miles

--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -317,6 +317,7 @@ Stats JSON:
 """.strip()
 
     model = os.getenv("SUMMARY_MODEL", "gpt-4o")
+    logger.info("Generating weekly summary with model %s", model)
     try:
         no_temp_models = {"gpt-5-mini", "gpt-5-preview"}
         params = {
@@ -326,9 +327,23 @@ Stats JSON:
         if model not in no_temp_models:
             params["temperature"] = 0.4
         resp = openai_client.chat.completions.create(**params)
+        usage = getattr(resp, "usage", None)
+        if usage:
+            logger.info(
+                "Summary tokens used (model=%s): prompt=%s, completion=%s, total=%s",
+                model,
+                getattr(usage, "prompt_tokens", None),
+                getattr(usage, "completion_tokens", None),
+                getattr(usage, "total_tokens", None),
+            )
         return (resp.choices[0].message.content or "").strip()
-    except Exception:
+    except Exception as exc:
         api_key_present = bool(os.getenv("OPENAI_API_KEY"))
+        status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(
+            exc, "status", None
+        )
+        if status:
+            logger.warning("OpenAI summary HTTP error status=%s", status)
         logger.exception(
             "OpenAI summary generation failed (model=%s, api_key=%s)",
             model,


### PR DESCRIPTION
## Summary
- log cache hits, misses, request details and non-200 responses in `get_driving_distance_miles`
- log summary model choice, token usage and HTTP errors when generating weekly summaries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a94f13e0788333a7c2b1980120de6f