### PR TITLE
Remove student user records

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2552,6 +2552,7 @@ def reset_jobs(current_user: dict = Depends(get_current_user)):
 
 @app.delete("/admin/delete-student/{email}")
 def delete_student(email: str, current_user: dict = Depends(get_current_user)):
+    """Remove a student profile and any associated user record."""
     if current_user.get("role") != "admin":
         raise HTTPException(status_code=403, detail="Admin privileges required")
     email = normalize_email(email)
@@ -2562,6 +2563,11 @@ def delete_student(email: str, current_user: dict = Depends(get_current_user)):
     # Delete student profile
     redis_client.delete(skey)
     redis_client.delete(student_email_key(email))
+
+    # Remove any lingering user record to avoid bogus admin entries
+    ukey = find_user_key(email)
+    if ukey:
+        redis_client.delete(ukey)
 
     # Clean up from job assignments/placements
     for job_key in redis_client.scan_iter("job:*"):

--- a/scripts/remove_student_user_records.py
+++ b/scripts/remove_student_user_records.py
@@ -1,0 +1,22 @@
+import os
+import redis
+from typing import Any
+
+
+def remove_student_user_records() -> None:
+    """Delete user:* keys for emails with existing student profiles."""
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        raise RuntimeError("Missing REDIS_URL")
+    client = redis.Redis.from_url(redis_url, decode_responses=True)
+    removed = 0
+    for ukey in list(client.scan_iter("user:*")):
+        email = ukey.split("user:", 1)[1]
+        if client.exists(f"student:{email}") or client.exists(f"student_email:{email}"):
+            client.delete(ukey)
+            removed += 1
+    print(f"Removed {removed} user records linked to student profiles.")
+
+
+if __name__ == "__main__":
+    remove_student_user_records()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1308,6 +1308,10 @@ def test_admin_delete_student_cleans_up():
         student["email"], student, student["institutional_code"], student["student_id"]
     )
     skey = main_app.student_key(student["institutional_code"], student["student_id"])
+    # Simulate leftover user record
+    main_app.redis_client.set(
+        "user:del@example.com", json.dumps({"role": "applicant"})
+    )
     main_app.redis_client.set(
         "job:j1",
         json.dumps({"job_code": "j1", "assigned_students": ["del@example.com"], "placed_students": ["del@example.com"]}),
@@ -1327,6 +1331,7 @@ def test_admin_delete_student_cleans_up():
 
     assert not main_app.redis_client.exists(skey)
     assert main_app.redis_client.get(main_app.student_email_key("del@example.com")) is None
+    assert main_app.redis_client.get("user:del@example.com") is None
     job = json.loads(main_app.redis_client.get("job:j1"))
     assert "del@example.com" not in job.get("assigned_students", [])
     assert "del@example.com" not in job.get("placed_students", [])
@@ -1383,6 +1388,46 @@ def test_delete_student_forbidden_non_admin():
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403
+
+
+def test_creating_student_does_not_create_user(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    admin_token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    profile = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "stu@example.com",
+        "phone": "123",
+        "license": "lvn",
+        "skills": ["skill"],
+        "experience_summary": "summary",
+        "interests": "interest",
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10.0,
+    }
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.0, 0.0]})]
+
+    def fake_create(input, model):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+
+    resp = client.post(
+        "/students", json=profile, headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 200
+    assert main_app.redis_client.get("user:stu@example.com") is None
 
 
 def test_recruiter_cannot_place_student():


### PR DESCRIPTION
## Summary
- remove lingering user keys when deleting a student profile
- add maintenance script to purge user entries associated with student profiles
- test that student creation no longer writes a user record

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a949dd46b8833392006e003380f404