### PR TITLE
Load REDIS_URL from .env in removal script and add tests

### DIFF
--- a/scripts/remove_student_user_records.py
+++ b/scripts/remove_student_user_records.py
@@ -1,6 +1,8 @@
 import os
 import redis
-from typing import Any
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def remove_student_user_records() -> None:

--- a/tests/test_remove_student_user_records.py
+++ b/tests/test_remove_student_user_records.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+import scripts.remove_student_user_records as mod
+
+
+class DummyRedis:
+    def __init__(self, data):
+        self.store = dict(data)
+
+    def scan_iter(self, pattern="*"):
+        prefix = pattern.rstrip("*")
+        for k in list(self.store.keys()):
+            if k.startswith(prefix):
+                yield k
+
+    def exists(self, key):
+        return key in self.store
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+def test_removes_users_with_student_records(monkeypatch, capsys):
+    os.environ["REDIS_URL"] = "redis://example"  # dummy value
+    data = {
+        "user:a@example.com": "u1",
+        "user:b@example.com": "u2",
+        "student:a@example.com": "s1",
+        "student_email:b@example.com": "s2",
+        "user:c@example.com": "u3",
+    }
+    dummy = DummyRedis(data)
+    monkeypatch.setattr(mod.redis.Redis, "from_url", lambda *a, **k: dummy)
+
+    mod.remove_student_user_records()
+
+    assert "user:a@example.com" not in dummy.store
+    assert "user:b@example.com" not in dummy.store
+    assert "user:c@example.com" in dummy.store
+    captured = capsys.readouterr()
+    assert "Removed 2 user records" in captured.out
+
+
+def test_requires_redis_url(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    with pytest.raises(RuntimeError):
+        mod.remove_student_user_records()


### PR DESCRIPTION
## Summary
- load REDIS_URL from `.env` in `remove_student_user_records`
- add tests verifying user records removal and env var requirement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a959b4c17c83339f1e522f8f24b9fb