### PR TITLE
refactor: scope job and resume routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,7 +33,14 @@ redis_client = None  # replaced by tests with a dummy implementation
 
 # Placeholder OpenAI client used by tests.  The ``embeddings.create`` method is
 # monkeypatched in the unit tests to avoid external API calls.
-client = type("Client", (), {"embeddings": type("Emb", (), {"create": lambda *a, **k: None})()})()
+client = type(
+    "Client",
+    (),
+    {
+        "embeddings": type("Emb", (), {"create": lambda *a, **k: None})(),
+        "chat": type("Chat", (), {"completions": type("Comp", (), {"create": lambda *a, **k: None})()})(),
+    },
+)()
 
 
 def send_email(recipient: str, subject: str, body: str) -> None:
@@ -128,7 +135,7 @@ from app.routes import auth, admin, students, jobs, matching, notes
 app.include_router(auth.router)
 app.include_router(admin.router)
 app.include_router(students.router)
-app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
+app.include_router(jobs.router)
 app.include_router(matching.router, prefix="/matching", tags=["matching"])
 app.include_router(notes.router, prefix="/notes", tags=["notes"])
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -1,3 +1,225 @@
-from fastapi import APIRouter
+from __future__ import annotations
 
-router = APIRouter()
+import json
+import re
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+
+import app.main as main
+from app.routes.auth import get_current_user
+from backend.app.schemas.resume import ResumeRequest
+from backend.app.services.job import generate_job_description_html, normalize_email, resolve_student_key
+from backend.app.services.resume import generate_resume_text
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+def find_user_key(email: str) -> str | None:
+    target = normalize_email(email)
+    exact = f"user:{target}"
+    if main.redis_client.exists(exact):
+        return exact
+    for key in main.redis_client.scan_iter("user:*"):
+        k = key if isinstance(key, str) else key.decode()
+        if k.split("user:", 1)[1].lower() == target:
+            return k
+    return None
+
+
+@router.post("")
+def create_job(job: dict, _: dict = Depends(get_current_user)) -> dict:
+    data = dict(job)
+    code = data.get("job_code") or str(uuid.uuid4())[:8]
+    data["job_code"] = code
+    data.setdefault("assigned_students", [])
+    data.setdefault("placed_students", [])
+    main.redis_client.set(f"job:{code}", json.dumps(data))
+    return {"message": "Job stored", "job_code": code}
+
+
+@router.post("/generate-job-description")
+def generate_job_description(req: ResumeRequest, _: dict = Depends(get_current_user)):
+    html, existed = generate_job_description_html(
+        main.client, main.redis_client, req.job_code, req.student_email
+    )
+    return {"status": "exists" if existed else "success"}
+
+
+@router.get("/job-description/{job_code}/{student_email}")
+def get_job_description(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
+    student_email = normalize_email(student_email)
+    key = f"job_description:{job_code}:{student_email}"
+    description = main.redis_client.get(key)
+    if not description:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {"status": "success", "description": description}
+
+
+@router.get("/job-description-html/{job_code}/{student_email}")
+def get_job_description_html(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
+    student_email = normalize_email(student_email)
+    key = f"jobdesc:{job_code}:{student_email}"
+    html = main.redis_client.get(key)
+    if not html:
+        raise HTTPException(status_code=404, detail="Job description not found")
+    return HTMLResponse(content=html, status_code=200)
+
+
+@router.get("/public/job-description-html/{job_code}/{student_email}")
+def get_public_job_description_html(job_code: str, student_email: str):
+    student_email = normalize_email(student_email)
+    key = f"jobdesc:{job_code}:{student_email}"
+    html = main.redis_client.get(key)
+    if not html:
+        raise HTTPException(status_code=404, detail="Job description not found")
+    return HTMLResponse(content=html, status_code=200)
+
+
+@router.post("/generate-resume")
+def generate_resume(req: ResumeRequest, _: dict = Depends(get_current_user)):
+    preview = getattr(req, "preview", False)
+    resume_key = f"resume:{req.job_code}:{req.student_email}"
+    html_key = f"resumehtml:{req.job_code}:{req.student_email}"
+    if not preview:
+        existing = main.redis_client.get(resume_key)
+        if existing:
+            main.redis_client.set(html_key, existing)
+            return {"status": "exists"}
+
+    job_raw = main.redis_client.get(f"job:{req.job_code}")
+    profile_key = find_user_key(req.student_email)
+    student_raw = main.redis_client.get(profile_key) if profile_key else None
+    if not student_raw:
+        skey = resolve_student_key(main.redis_client, req.student_email)
+        student_raw = main.redis_client.get(skey) if skey else None
+    if not job_raw or not student_raw:
+        raise HTTPException(status_code=404, detail="Job or student not found")
+
+    job = json.loads(job_raw)
+    student = json.loads(student_raw)
+
+    if not preview and req.student_email not in job.get("assigned_students", []) and req.student_email not in job.get("placed_students", []):
+        raise HTTPException(status_code=403, detail="Student not assigned to job")
+
+    raw_html = generate_resume_text(main.client, student, job, include_contact=not preview).strip()
+
+    if raw_html.startswith("```html"):
+        raw_html = raw_html.replace("```html", "", 1).strip()
+    if raw_html.endswith("```"):
+        raw_html = raw_html.rsplit("```", 1)[0].strip()
+
+    lower_html = raw_html.lower()
+    if "<!doctype" in lower_html or "<html" in lower_html:
+        body_match = re.search(r"<body[^>]*>(.*?)</body>", raw_html, re.IGNORECASE | re.DOTALL)
+        if body_match:
+            raw_html = body_match.group(1).strip()
+        else:
+            html_match = re.search(r"<html[^>]*>(.*?)</html>", raw_html, re.IGNORECASE | re.DOTALL)
+            if html_match:
+                raw_html = html_match.group(1).strip()
+
+    full_html = (
+        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>TalentMatch AI – Resume</title>"
+        "<style>body {font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6;} "
+        "h2 {color: #1a1a1a; border-bottom: 2px solid #eee; padding-bottom: 0.3rem;} "
+        ".section {margin-bottom: 1.5rem;}</style></head><body>"
+        f"{raw_html}</body></html>"
+    )
+
+    if not preview:
+        main.redis_client.set(resume_key, full_html)
+        main.redis_client.set(html_key, full_html)
+        return {"status": "success"}
+    else:
+        return {"status": "preview", "html": full_html}
+
+
+@router.get("/resume/{job_code}/{student_email}")
+def get_resume(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
+    student_email = normalize_email(student_email)
+    key = f"resume:{job_code}:{student_email}"
+
+    job_raw = main.redis_client.get(f"job:{job_code}")
+    if not job_raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    job = json.loads(job_raw)
+    if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        raise HTTPException(status_code=403, detail="Student not assigned to job")
+
+    resume = main.redis_client.get(key)
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+    return {
+        "status": "success",
+        "job_code": job_code,
+        "student_email": student_email,
+        "resume": resume,
+    }
+
+
+@router.get("/resume-html/{job_code}/{student_email}")
+def get_resume_html(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
+    student_email = normalize_email(student_email)
+    key = f"resumehtml:{job_code}:{student_email}"
+
+    job_raw = main.redis_client.get(f"job:{job_code}")
+    if not job_raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    job = json.loads(job_raw)
+    if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        raise HTTPException(status_code=403, detail="Student not assigned to job")
+
+    html = main.redis_client.get(key)
+    if not html:
+        html = main.redis_client.get(f"resume:{job_code}:{student_email}")
+    if not html:
+        raise HTTPException(status_code=404, detail="Resume not found")
+    return HTMLResponse(content=html, status_code=200)
+
+
+@router.post("/notify-interest")
+def notify_interest(data: dict, _: dict = Depends(get_current_user)):
+    job_code = data.get("job_code")
+    student_email = data.get("student_email")
+    if not job_code or not student_email:
+        raise HTTPException(status_code=400, detail="Missing job_code or student_email")
+
+    raw = main.redis_client.get(f"job:{job_code}")
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    job = json.loads(raw)
+    student_email = normalize_email(student_email)
+    if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        raise HTTPException(status_code=400, detail="Student not assigned to job")
+
+    generate_job_description_html(main.client, main.redis_client, job_code, student_email)
+
+    skey = resolve_student_key(main.redis_client, student_email)
+    student_raw = main.redis_client.get(skey) if skey else None
+    first_name = ""
+    if student_raw:
+        try:
+            student = json.loads(student_raw)
+            first_name = student.get("first_name", "")
+        except Exception:
+            pass
+
+    public_url = f"/jobs/public/job-description-html/{job_code}/{student_email}"
+    body = (
+        f"Hello {first_name},\n\n"
+        "Your resume has been matched with a job and the recruiter has reviewed your resume.\n\n"
+        "You are receiving this email because the Recruiter would like to notify you that you are a match "
+        "and will be contacting you to discuss your resume.\n\n"
+        f"Please review the job description here: {public_url}\n\n"
+        "Good Luck!\n\n"
+        "Support Team @ TalentMatch-AI"
+    )
+
+    main.send_email(
+        student_email,
+        f"Recruiter Interest: {job.get('job_title')}",
+        body,
+    )
+
+    return {"message": "Notification sent"}

--- a/backend/app/services/job.py
+++ b/backend/app/services/job.py
@@ -1,0 +1,102 @@
+import json
+from fastapi import HTTPException
+
+
+def normalize_email(email: str | None) -> str:
+    return (email or "").strip().lower()
+
+
+def resolve_student_key(redis_client, email: str) -> str | None:
+    idx = redis_client.get(f"student_email:{normalize_email(email)}")
+    if idx:
+        inst, sid = idx.split(":", 1)
+        return f"student:{inst}:{sid}"
+    legacy = f"student:{normalize_email(email)}"
+    if redis_client.exists(legacy):
+        return legacy
+    return None
+
+
+def generate_job_description_html(client, redis_client, job_code: str, student_email: str) -> tuple[str, bool]:
+    """Create or fetch an HTML job description for a student."""
+    student_email = normalize_email(student_email)
+    key = f"job_description:{job_code}:{student_email}"
+    html_key = f"jobdesc:{job_code}:{student_email}"
+
+    existing = redis_client.get(key)
+    if existing:
+        redis_client.set(html_key, existing)
+        return existing, True
+
+    job_raw = redis_client.get(f"job:{job_code}")
+    skey = resolve_student_key(redis_client, student_email)
+    student_raw = redis_client.get(skey) if skey else None
+    if not job_raw or not student_raw:
+        raise HTTPException(status_code=404, detail="Job or student not found")
+
+    job = json.loads(job_raw)
+    student = json.loads(student_raw)
+
+    prompt = f"""
+You are generating a job description document for internal career services staff. The document should first summarize the position itself, then connect it with the student's background.
+
+Use the student profile and job information below to:
+
+- Provide a **Job Summary** that comprehensively covers the job description **without referencing the applicant's experience**
+- Describe **key responsibilities** they might undertake as noted in the job description
+- List **areas of strength** with plenty of details to reinforce existing experience and how it connects with the job description and potential **areas for growth** with plenty of insightful and targeted recommendations for training that will improve the probability of success
+- Mention **school affiliation** and any relevant compliance or readiness info
+
+Format this as a printable HTML document titled "TalentMatch AI", styled professionally but without producing binary output.
+
+Student Info:
+Name: {student.get('first_name')} {student.get('last_name')}
+Email: {student.get('email')}
+Skills: {', '.join(student.get('skills', []))}
+Experience Summary: {student.get('experience_summary')}
+Interests: {student.get('interests')}
+
+Job Info:
+Title: {job.get('job_title')}
+Source: {job.get('source')}
+Description: {job.get('job_description')}
+Desired Skills: {', '.join(job.get('desired_skills', []))}
+Location: {job.get('city')}, {job.get('state')}
+Pay Range: {job.get('min_pay', '')} - {job.get('max_pay', '')}
+
+Output only valid HTML.
+"""
+
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.5,
+    )
+
+    raw_content = resp.choices[0].message.content.strip()
+
+    if raw_content.startswith("```html"):
+        raw_content = raw_content.replace("```html", "", 1).strip()
+    if raw_content.endswith("```"):
+        raw_content = raw_content.rsplit("```", 1)[0].strip()
+
+    details_html = """
+    <h2>Job Details</h2>
+    <ul>
+      <li><strong>Source:</strong> {source}</li>
+      <li><strong>Pay Range:</strong> {pay_min} - {pay_max}</li>
+      <li><strong>Location:</strong> {city}, {state}</li>
+    </ul>
+    """.format(
+        source=job.get("source", ""),
+        pay_min=job.get("min_pay", ""),
+        pay_max=job.get("max_pay", ""),
+        city=job.get("city", ""),
+        state=job.get("state", ""),
+    )
+
+    full_html = f"""<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>TalentMatch AI – Job Description</title><style>body {{font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6;}} h2 {{color: #1a1a1a; border-bottom: 2px solid #eee; padding-bottom: 0.3rem;}} .section {{margin-bottom: 1.5rem;}}</style></head><body>{details_html}{raw_content}</body></html>"""
+
+    redis_client.set(key, full_html)
+    redis_client.set(html_key, full_html)
+    return full_html, False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -747,7 +747,7 @@ def test_generate_job_description(monkeypatch):
     token = login_resp.json()["token"]
 
     resp = client.post(
-        "/generate-job-description",
+        "/jobs/generate-job-description",
         json={"student_email": "stud@example.com", "job_code": "code2"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -758,7 +758,7 @@ def test_generate_job_description(monkeypatch):
     assert "10.0" in captured["messages"][0]["content"]
 
     get_resp = client.get(
-        "/job-description/code2/stud@example.com",
+        "/jobs/job-description/code2/stud@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert get_resp.status_code == 200
@@ -785,7 +785,7 @@ def test_job_description_html_route():
     token = login_resp.json()["token"]
 
     resp = client.get(
-        "/job-description-html/codeh/stud@example.com",
+        "/jobs/job-description-html/codeh/stud@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -802,7 +802,7 @@ def test_public_job_description_html_route():
     )
 
     resp = client.get(
-        "/public/job-description-html/codep/stud@example.com",
+        "/jobs/public/job-description-html/codep/stud@example.com",
     )
     assert resp.status_code == 200
     assert "public" in resp.text.lower()
@@ -853,7 +853,7 @@ def test_notify_interest_generates_description(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/notify-interest",
+        "/jobs/notify-interest",
         json={"student_email": "stud@example.com", "job_code": "codei"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -862,7 +862,7 @@ def test_notify_interest_generates_description(monkeypatch):
     assert stored is not None and "done" in stored
     assert main_app.redis_client.get("jobdesc:codei:stud@example.com") == stored
     assert "Good Luck" in sent.get("body")
-    assert "/public/job-description-html/codei/stud@example.com" in sent.get("body")
+    assert "/jobs/public/job-description-html/codei/stud@example.com" in sent.get("body")
     assert sent.get("attachments") is None
 
 
@@ -910,12 +910,12 @@ def test_notify_interest_multiple_times(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp1 = client.post(
-        "/notify-interest",
+        "/jobs/notify-interest",
         json={"student_email": "stud@example.com", "job_code": "codei"},
         headers={"Authorization": f"Bearer {token}"},
     )
     resp2 = client.post(
-        "/notify-interest",
+        "/jobs/notify-interest",
         json={"student_email": "stud@example.com", "job_code": "codei"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -977,7 +977,7 @@ def test_generate_resume_html(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "stud@example.com", "job_code": "coder"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -985,7 +985,7 @@ def test_generate_resume_html(monkeypatch):
     assert resp.json()["status"] == "success"
 
     html_resp = client.get(
-        "/resume-html/coder/stud@example.com",
+        "/jobs/resume-html/coder/stud@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert html_resp.status_code == 200
@@ -1043,7 +1043,7 @@ def test_generate_resume_full_html(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "stud@example.com", "job_code": "coder"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1051,7 +1051,7 @@ def test_generate_resume_full_html(monkeypatch):
     assert resp.json()["status"] == "success"
 
     html_resp = client.get(
-        "/resume-html/coder/stud@example.com",
+        "/jobs/resume-html/coder/stud@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert html_resp.status_code == 200
@@ -1077,7 +1077,7 @@ def test_resume_html_route():
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.get(
-        "/resume-html/codeh/stud@example.com",
+        "/jobs/resume-html/codeh/stud@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -1125,7 +1125,7 @@ def test_generate_resume_preview(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "stud@example.com", "job_code": "coder", "preview": True},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1167,7 +1167,7 @@ def test_generate_resume_user_key_lookup(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "stud@example.com", "job_code": "coder"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1212,7 +1212,7 @@ def test_generate_resume_student_key_fallback(monkeypatch):
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "stud@example.com", "job_code": "coder"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1238,7 +1238,7 @@ def test_generate_resume_requires_assignment():
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.post(
-        "/generate-resume",
+        "/jobs/generate-resume",
         json={"student_email": "s1@example.com", "job_code": "j1"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1264,7 +1264,7 @@ def test_get_resume_requires_assignment():
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.get(
-        "/resume/j1/s1@example.com",
+        "/jobs/resume/j1/s1@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403
@@ -1289,7 +1289,7 @@ def test_get_resume_html_requires_assignment():
     token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
 
     resp = client.get(
-        "/resume-html/j1/s1@example.com",
+        "/jobs/resume-html/j1/s1@example.com",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- expose job description and resume endpoints under `/jobs`
- centralize job description HTML generation in `services/job.py`
- adjust tests to use new `/jobs` routes

## Testing
- `pytest tests/test_main.py -k "generate_job_description or job_description_html_route or public_job_description_html_route or notify_interest or generate_resume_html or generate_resume_full_html or resume_html_route or generate_resume_preview or generate_resume_user_key_lookup or generate_resume_student_key_fallback or generate_resume_requires_assignment or get_resume_requires_assignment or get_resume_html_requires_assignment" -q`
- `pytest -q` *(fails: AttributeError: <module 'app.main' ...> has no attribute 'get_driving_distance_miles', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9f8f19d3883339979b2d88c1a621d