### PR TITLE
Refactor student note endpoints into dedicated router

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ both assigned and rejected students.
 
 ### Student Notes
 
-Use `POST /student-note` with a `job_code`, the `student_email`, and a `note` to
+Use `POST /notes/student-note` with a `job_code`, the `student_email`, and a `note` to
 record comments for a candidate. Recruiters may add notes only for jobs they
 created **and** students they have assigned to those jobs. Administrators may
 add notes for any job and are the only role permitted to edit or delete
@@ -155,7 +155,7 @@ Example recruiter request:
 }
 ```
 
-Example admin edit request (`PUT /student-note`):
+Example admin edit request (`PUT /notes/student-note`):
 
 ```json
 {

--- a/app/main.py
+++ b/app/main.py
@@ -137,7 +137,7 @@ app.include_router(admin.router)
 app.include_router(students.router)
 app.include_router(jobs.router)
 app.include_router(matching.router)
-app.include_router(notes.router, prefix="/notes", tags=["notes"])
+app.include_router(notes.router)
 
 
 @app.get("/school-codes")

--- a/app/routes/notes.py
+++ b/app/routes/notes.py
@@ -1,3 +1,177 @@
-from fastapi import APIRouter
+"""Endpoints for manipulating student notes.
 
-router = APIRouter()
+These endpoints were originally defined directly in :mod:`app.main`.  They are
+now collected under a dedicated router with the ``/notes`` prefix so they can be
+included into the application without additional arguments.  Notes are stored on
+both the job record and, when present, the student's assigned job entry.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+import app.main as main
+from app.routes.auth import get_current_user, require_admin
+from backend.app.services.job import normalize_email, resolve_student_key
+
+
+router = APIRouter(prefix="/notes", tags=["notes"])
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _normalize_notes(notes: Any) -> list[dict[str, Any]]:
+    """Return ``notes`` as a list of ``{"text": ..., "posted_by": ...}``.
+
+    Legacy records may store notes as plain strings or as a mix of strings and
+    dictionaries.  This helper ensures a consistent structure before the
+    endpoints manipulate the note list.
+    """
+
+    if isinstance(notes, str):
+        return [{"text": notes}]
+    out: list[dict[str, Any]] = []
+    for n in notes or []:
+        if isinstance(n, dict):
+            out.append({"text": n.get("text", ""), "posted_by": n.get("posted_by")})
+        else:
+            out.append({"text": str(n)})
+    return out
+
+
+def _get_job(job_code: str) -> dict:
+    raw = main.redis_client.get(f"job:{job_code}")
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return json.loads(raw)
+
+
+def _get_student(email: str) -> tuple[dict | None, str | None]:
+    skey = resolve_student_key(main.redis_client, email)
+    if not skey:
+        return None, None
+    raw = main.redis_client.get(skey)
+    if not raw:
+        return None, skey
+    return json.loads(raw), skey
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/student-note")
+def add_student_note(data: dict, user: dict = Depends(get_current_user)) -> dict:
+    """Append a note for ``student_email`` on ``job_code``."""
+
+    job_code = data.get("job_code")
+    student_email = normalize_email(data.get("student_email"))
+    note_text = data.get("note")
+    if not job_code or not student_email or not note_text:
+        raise HTTPException(status_code=400, detail="Missing job_code, student_email or note")
+
+    job = _get_job(job_code)
+    if user.get("role") != "admin":
+        if job.get("posted_by") != user.get("email"):
+            raise HTTPException(status_code=403, detail="Forbidden")
+        if student_email not in job.get("assigned_students", []):
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+    notes_dict = job.setdefault("student_notes", {})
+    existing = _normalize_notes(notes_dict.get(student_email, []))
+    existing.append({"text": note_text, "posted_by": user.get("email")})
+    notes_dict[student_email] = existing
+    main.redis_client.set(f"job:{job_code}", json.dumps(job))
+
+    student, skey = _get_student(student_email)
+    if student and skey:
+        assigned = student.setdefault("assigned_jobs", [])
+        entry = next((j for j in assigned if j.get("job_code") == job_code), None)
+        if entry:
+            entry_notes = _normalize_notes(entry.get("notes", []))
+            entry_notes.append({"text": note_text, "posted_by": user.get("email")})
+            entry["notes"] = entry_notes
+            main.redis_client.set(skey, json.dumps(student))
+
+    return {"notes": notes_dict[student_email]}
+
+
+@router.put("/student-note")
+def update_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
+    """Update an existing note identified by ``index``."""
+
+    job_code = data.get("job_code")
+    student_email = normalize_email(data.get("student_email"))
+    index = data.get("index")
+    note_text = data.get("note")
+    if job_code is None or student_email is None or index is None or note_text is None:
+        raise HTTPException(status_code=400, detail="Missing fields")
+
+    job = _get_job(job_code)
+    notes_dict = job.setdefault("student_notes", {})
+    notes = _normalize_notes(notes_dict.get(student_email, []))
+    if index < 0 or index >= len(notes):
+        raise HTTPException(status_code=404, detail="Note not found")
+    notes[index]["text"] = note_text
+    notes_dict[student_email] = notes
+    main.redis_client.set(f"job:{job_code}", json.dumps(job))
+
+    student, skey = _get_student(student_email)
+    if student and skey:
+        assigned = student.setdefault("assigned_jobs", [])
+        entry = next((j for j in assigned if j.get("job_code") == job_code), None)
+        if entry:
+            entry_notes = _normalize_notes(entry.get("notes", []))
+            if 0 <= index < len(entry_notes):
+                entry_notes[index]["text"] = note_text
+                entry["notes"] = entry_notes
+                main.redis_client.set(skey, json.dumps(student))
+
+    return {"notes": notes}
+
+
+@router.delete("/student-note")
+def delete_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
+    """Remove a note identified by ``index``."""
+
+    job_code = data.get("job_code")
+    student_email = normalize_email(data.get("student_email"))
+    index = data.get("index")
+    if job_code is None or student_email is None or index is None:
+        raise HTTPException(status_code=400, detail="Missing fields")
+
+    job = _get_job(job_code)
+    notes_dict = job.setdefault("student_notes", {})
+    notes = _normalize_notes(notes_dict.get(student_email, []))
+    if index < 0 or index >= len(notes):
+        raise HTTPException(status_code=404, detail="Note not found")
+    notes.pop(index)
+    if notes:
+        notes_dict[student_email] = notes
+    else:
+        notes_dict.pop(student_email, None)
+    main.redis_client.set(f"job:{job_code}", json.dumps(job))
+
+    student, skey = _get_student(student_email)
+    if student and skey:
+        assigned = student.setdefault("assigned_jobs", [])
+        entry = next((j for j in assigned if j.get("job_code") == job_code), None)
+        if entry:
+            entry_notes = _normalize_notes(entry.get("notes", []))
+            if 0 <= index < len(entry_notes):
+                entry_notes.pop(index)
+            if entry_notes:
+                entry["notes"] = entry_notes
+            else:
+                entry.pop("notes", None)
+            main.redis_client.set(skey, json.dumps(student))
+
+    return {"notes": notes_dict.get(student_email, [])}
+

--- a/frontend/src/NoteEditor.js
+++ b/frontend/src/NoteEditor.js
@@ -8,7 +8,7 @@ export default function NoteEditor({ jobCode, email, notes = [], onSaved, onCanc
 
   const save = async () => {
     const resp = await api.post(
-      '/student-note',
+      '/notes/student-note',
       {
         job_code: jobCode,
         student_email: email,

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -27,7 +27,7 @@ test('saves note via API', async () => {
   fireEvent.click(screen.getByText('Save'));
   await waitFor(() => {
     expect(api.post).toHaveBeenCalledWith(
-      '/student-note',
+      '/notes/student-note',
       {
         job_code: 'J1',
         student_email: 's1@example.com',

--- a/frontend/src/NotesHistoryModal.js
+++ b/frontend/src/NotesHistoryModal.js
@@ -29,7 +29,7 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
   const saveEdit = async () => {
     try {
       const resp = await api.put(
-        '/student-note',
+        '/notes/student-note',
         {
           job_code: jobCode,
           student_email: studentEmail,
@@ -54,7 +54,7 @@ function NotesHistoryModal({ notes = [], onClose, isAdmin = false, canAdd = fals
 
   const deleteNote = async (idx) => {
     try {
-      await api.delete('/student-note', {
+      await api.delete('/notes/student-note', {
         headers: { Authorization: `Bearer ${token}` },
         data: { job_code: jobCode, student_email: studentEmail, index: idx },
       });

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1142,7 +1142,7 @@ def test_student_note_school_code_fallback():
         "/login", json={"email": "admin@example.com", "password": "admin123"}
     ).json()["token"]
     r = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
@@ -1270,7 +1270,7 @@ def test_student_note_unassigned(monkeypatch):
 
     note = "standalone note"
     r = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1337,7 +1337,7 @@ def test_student_note_assigned(monkeypatch):
 
     note = "new note"
     r = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1421,12 +1421,12 @@ def test_student_note_multiple_posts_unassigned(monkeypatch):
     note1 = "first note"
     note2 = "second note"
     client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note1},
         headers={"Authorization": f"Bearer {token}"},
     )
     client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note2},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1504,7 +1504,7 @@ def test_recruiter_can_add_note_for_assigned_student():
 
     note = "follow up"
     r = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -1596,14 +1596,14 @@ def test_recruiter_note_forbidden_unassigned_or_unowned():
 
     note = "check"
     r_unassigned = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student2["email"], "note": note},
         headers={"Authorization": f"Bearer {token1}"},
     )
     assert r_unassigned.status_code == 403
 
     r_unowned = client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student1["email"], "note": note},
         headers={"Authorization": f"Bearer {token2}"},
     )
@@ -1754,12 +1754,12 @@ def test_student_note_multiple_posts_assigned(monkeypatch):
     note1 = "first note"
     note2 = "second note"
     client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note1},
         headers={"Authorization": f"Bearer {token}"},
     )
     client.post(
-        "/student-note",
+        "/notes/student-note",
         json={"job_code": job_code, "student_email": student["email"], "note": note2},
         headers={"Authorization": f"Bearer {token}"},
     )


### PR DESCRIPTION
## Summary
- move student note management into new `/notes` router
- support adding, updating, and deleting student notes with normalization helpers
- update paths in tests, frontend, and docs to `/notes/student-note`

## Testing
- `pytest` (fails: AttributeError and other missing features)


------
https://chatgpt.com/codex/tasks/task_e_68a9ff2ccb308333892c9de4223acf76