### PR TITLE
Remove matching route prefix

### DIFF
--- a/app/routes/matching.py
+++ b/app/routes/matching.py
@@ -15,7 +15,7 @@ from backend.app.services.job import (
 )
 
 
-router = APIRouter(prefix="/matching", tags=["matching"])
+router = APIRouter(prefix="", tags=["matching"])
 
 
 def _get_job(job_code: str) -> dict:


### PR DESCRIPTION
## Summary
- Register matching routes at the API root instead of under `/matching`

## Testing
- `pytest -q` *(fails: module 'app.main' has no attribute 'get_driving_distance_miles', and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aa04c4be0c8333992fc9285a40c464