### PR TITLE
Initialize default admin and school codes on startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -132,6 +132,24 @@ NURSING_FEEDS = [("Example", "http://example.com/feed")]
 app = FastAPI()
 
 
+@app.on_event("startup")
+def startup() -> None:
+    """Populate Redis with baseline data when the API starts.
+
+    The tests monkeypatch ``redis_client`` with an in-memory stand in, so we
+    guard against ``None`` to keep import side effects minimal.  When the
+    application runs normally with a real Redis backend we pre-create the
+    default administrator account and load the initial set of school codes so
+    that a fresh deployment can be used immediately.
+    """
+
+    if redis_client is None:  # pragma: no cover - depends on deployment
+        return
+
+    init_default_admin()
+    init_default_school_codes()
+
+
 @app.get("/")
 def read_root() -> dict[str, str]:
     return {"message": "Hello, World"}


### PR DESCRIPTION
## Summary
- populate Redis with default admin user and school codes during API startup

## Testing
- `pytest` *(fails: AttributeError, 404, KeyError, etc. – 36 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa066348f883338a79892976516040