### PR TITLE
Add rematch endpoint

### DIFF
--- a/app/routes/matching.py
+++ b/app/routes/matching.py
@@ -154,6 +154,25 @@ def run_match(data: dict) -> dict:
     return {"matches": matches}
 
 
+@router.post("/rematches/{job_code}")
+def queue_rematch(job_code: str) -> dict:
+    """Remove existing match results and record a rematch request."""
+
+    _get_job(job_code)
+
+    key = f"match_results:{job_code}"
+    if hasattr(main.redis_client, "delete"):
+        main.redis_client.delete(key)
+    else:  # fallback for simple test doubles
+        try:
+            main.redis_client.store.pop(key, None)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - very defensive
+            main.redis_client.set(key, None)
+
+    main.redis_client.incr("metrics:total_rematches")
+    return {"message": "Rematch queued"}
+
+
 @router.get("/match/{job_code}")
 def get_match_results(job_code: str) -> dict:
     """Return stored match results with job status/notes merged in."""


### PR DESCRIPTION
## Summary
- add `/rematches/{job_code}` endpoint to clear cached match results and bump rematch metric

## Testing
- `pytest` *(fails: test_update_job_with_corrupted_data, test_recruiter_job_source_autopopulated, test_reject_assigned, test_assign_note_persists_on_reject, test_student_note_assigned, test_recruiter_can_add_note_for_assigned_student, test_recruiter_cannot_modify_unowned_job, test_upload_students, test_student_creation_records_metadata, test_metrics_endpoint, test_update_student, test_generate_description, test_notify_interest_generates_description, test_notify_interest_multiple_times, test_admin_weekly_summary, test_match_metrics_increment, test_student_endpoints_handle_string_notes, test_malformed_user_skipped_in_listings)*
- `pytest tests/test_jobs.py::test_rematches_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa090ba334833386e3af5c4c5664ac