### PR TITLE
Support configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,17 @@ EMAIL_SENDER=noreply@example.com
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
 SITE_BASE_URL=https://yourdomain.com
+ALLOWED_ORIGINS=http://localhost:3000
 ```
 
 `SITE_BASE_URL` is used when building links in notification emails. It **must**
 point to the publicly reachable FastAPI backend (for example,
 `https://your-api.com`). If this value is set to the React frontend's address or
 left blank, the links in emails will lead to missing pages.
+
+`ALLOWED_ORIGINS` controls which origins may access the API via CORS. Provide a
+comma-separated list (e.g., `https://example.com,http://localhost:3000`). It
+defaults to `*` to allow requests from any origin.
 
 ## Registration Codes
 

--- a/app/main.py
+++ b/app/main.py
@@ -178,9 +178,13 @@ def read_root() -> dict[str, str]:
     return {"message": "Hello, World"}
 
 
+# Read allowed CORS origins from the environment.
+# Defaults to ["*"] to permit any origin when not set.
+allowed_origins = [origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "*").split(",")]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow configuring CORS origins via `ALLOWED_ORIGINS` environment variable
- document `ALLOWED_ORIGINS` in README

## Testing
- `pytest` *(fails: assert 404 == 500; assert 404 == 200; KeyError: 'source'; KeyError: 'students'; KeyError: 'students'; KeyError: 'students'; assert 403 == 200; assert 200 == 403; assert 404 == 200; AttributeError: <module 'app.main' ... has no attribute 'rebuild_vector_indices'>; AttributeError: <module 'app.main' ... has no attribute 'rebuild_vector_indices'>; json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1); 19 failed, 71 passed, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa09757a60833389812e3bb2a880d5