### PR TITLE
Improve login error messages

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -133,14 +133,19 @@ def login(payload: LoginRequest):
         main.init_default_admin()
         raw = main.redis_client.get(key)
     if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        # Differentiate between non-existent users and password errors while
+        # keeping the same 401 status code for authentication failures.
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     user = json.loads(raw)
     if user.get("password") != payload.password:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password")
 
     if not user.get("approved"):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User not approved")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not approved. Contact an administrator for approval.",
+        )
     if not user.get("active", True):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User disabled")
 


### PR DESCRIPTION
## Summary
- Differentiate between missing users and bad passwords in the login endpoint
- Provide guidance for unapproved accounts during login

## Testing
- `pytest` *(fails: KeyError: 'source'; 17 more failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0fcdcdf8833395d679dbcbad9d61