### PR TITLE
Improve login error messages

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -15,6 +15,8 @@ from fastapi import APIRouter, Depends, Header, HTTPException, status
 from jose import JWTError, jwt
 from pydantic import BaseModel, EmailStr
 
+from backend.app.logging_utils import get_logger
+
 import app.main as main
 
 JWT_SECRET = main.JWT_SECRET
@@ -22,6 +24,8 @@ ALGORITHM = main.ALGORITHM
 
 
 router = APIRouter(prefix="", tags=["auth"])
+
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -66,16 +70,19 @@ def get_current_user(authorization: str = Header(..., alias="Authorization")):
             raise ValueError("Invalid auth scheme")
         payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
     except (ValueError, JWTError):
+        logger.warning("Invalid authorization token")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
     email = payload.get("sub")
     if not email:
+        logger.warning("Token missing subject")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
     raw = main.redis_client.get(f"user:{email}")
     if raw is None and hasattr(main.redis_client, "store"):
         raw = main.redis_client.store.get(f"user:{email}")
     if not raw:
+        logger.warning("User %s not found during token lookup", email)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     return json.loads(raw)
@@ -83,6 +90,7 @@ def get_current_user(authorization: str = Header(..., alias="Authorization")):
 
 def require_admin(user: dict = Depends(get_current_user)):
     if user.get("role") != "admin":
+        logger.warning("Access denied for %s: admin privileges required", user.get("email"))
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
     return user
 
@@ -101,23 +109,29 @@ def register(payload: RegisterRequest):
     defaulting to ``False``.
     """
 
+    logger.info("Registration attempt for %s", payload.email)
     if payload.role != "applicant" and not payload.school_code:
+        logger.warning("Registration failed for %s: missing school code", payload.email)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="School code required")
 
     key = f"user:{payload.email}"
     if main.redis_client.exists(key):
+        logger.warning("Registration failed for %s: user already exists", payload.email)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
 
     data = payload.model_dump()
     data.update({"approved": False, "rejected": False, "active": True})
     main.redis_client.set(key, json.dumps(data))
 
+    logger.info("User %s registered successfully", payload.email)
     return {"message": "Awaiting admin approval"}
 
 
 @router.post("/login")
 def login(payload: LoginRequest):
+    logger.info("Login attempt for %s", payload.email)
     if main.redis_client is None:  # pragma: no cover - depends on deployment
+        logger.error("Login attempt for %s failed: Redis not configured", payload.email)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Redis not configured",
@@ -125,6 +139,7 @@ def login(payload: LoginRequest):
     key = f"user:{payload.email}"
     raw = main.redis_client.get(key)
     if not raw and payload.email.lower() == "admin@example.com":
+        logger.debug("Default admin missing; initializing during login")
         # Ensure the default administrator account exists even if the startup
         # hook failed to populate Redis (e.g. when running with an empty data
         # store or when the application reloads).  This mirrors the behaviour
@@ -133,49 +148,66 @@ def login(payload: LoginRequest):
         main.init_default_admin()
         raw = main.redis_client.get(key)
     if not raw:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        # Differentiate between non-existent users and password errors while
+        # keeping the same 401 status code for authentication failures.
+        logger.warning("Login failed: user %s not found", payload.email)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     user = json.loads(raw)
     if user.get("password") != payload.password:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        logger.warning("Login failed for %s: incorrect password", payload.email)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password")
 
     if not user.get("approved"):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User not approved")
+        logger.warning("Login denied for %s: not approved", payload.email)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not approved. Contact an administrator for approval.",
+        )
     if not user.get("active", True):
+        logger.warning("Login denied for %s: user disabled", payload.email)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User disabled")
 
     token = jwt.encode({"sub": user["email"], "role": user["role"]}, JWT_SECRET, algorithm=ALGORITHM)
+    logger.info("Login successful for %s", payload.email)
     return {"token": token}
 
 
 @router.post("/approve")
 def approve(payload: ApproveRequest, _: dict = Depends(require_admin)):
+    logger.info("Approving user %s with role %s", payload.email, payload.role)
     key = f"user:{payload.email}"
     raw = main.redis_client.get(key)
     if not raw:
+        logger.warning("Approve failed: user %s not found", payload.email)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     user = json.loads(raw)
     user.update({"approved": True, "rejected": False, "role": payload.role})
     main.redis_client.set(key, json.dumps(user))
+    logger.info("User %s approved", payload.email)
     return {"message": "User approved"}
 
 
 @router.post("/reject")
 def reject(payload: RejectRequest, _: dict = Depends(require_admin)):
+    logger.info("Rejecting user %s", payload.email)
     key = f"user:{payload.email}"
     raw = main.redis_client.get(key)
     if not raw:
+        logger.warning("Reject failed: user %s not found", payload.email)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     user = json.loads(raw)
     user.update({"rejected": True, "approved": False})
     main.redis_client.set(key, json.dumps(user))
+    logger.info("User %s rejected", payload.email)
     return {"message": "User rejected"}
 
 
 @router.get("/pending-users")
 def pending_users(_: dict = Depends(require_admin)) -> List[dict]:
+    logger.debug("Listing pending users")
     users: List[dict] = []
     for key in main.redis_client.scan_iter("user:*"):
         raw = main.redis_client.get(key)
@@ -184,5 +216,6 @@ def pending_users(_: dict = Depends(require_admin)) -> List[dict]:
         user = json.loads(raw)
         if not user.get("approved") and not user.get("rejected"):
             users.append(user)
+    logger.debug("Found %d pending users", len(users))
     return users
 


### PR DESCRIPTION
## Summary
- Differentiate between missing users and bad passwords in the login endpoint
- Provide guidance for unapproved accounts during login
- Add detailed logging throughout authentication routes for better troubleshooting

## Testing
- `pytest` *(fails: assert 404 == 500; KeyError: 'source'; 16 more failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0fcdcdf8833395d679dbcbad9d61