### PR TITLE
Hash passwords with bcrypt and update tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Any
+import bcrypt
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -123,11 +124,12 @@ def init_default_admin() -> None:
 
     key = "user:admin@example.com"
     if not redis_client.exists(key):
+        hashed = bcrypt.hashpw("admin123".encode(), bcrypt.gensalt()).decode()
         admin = {
             "email": "admin@example.com",
             "first_name": "Admin",
             "last_name": "User",
-            "password": "admin123",
+            "password": hashed,
             "role": "admin",
             "approved": True,
             "rejected": False,

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -14,6 +14,7 @@ from typing import List
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from jose import JWTError, jwt
 from pydantic import BaseModel, EmailStr
+import bcrypt
 
 from backend.app.logging_utils import get_logger
 
@@ -120,7 +121,8 @@ def register(payload: RegisterRequest):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
 
     data = payload.model_dump()
-    data.update({"approved": False, "rejected": False, "active": True})
+    hashed = bcrypt.hashpw(payload.password.encode(), bcrypt.gensalt()).decode()
+    data.update({"password": hashed, "approved": False, "rejected": False, "active": True})
     main.redis_client.set(key, json.dumps(data))
 
     logger.info("User %s registered successfully", payload.email)
@@ -156,7 +158,8 @@ def login(payload: LoginRequest):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     user = json.loads(raw)
-    if user.get("password") != payload.password:
+    stored_password = user.get("password")
+    if not stored_password or not bcrypt.checkpw(payload.password.encode(), stored_password.encode()):
 
         logger.warning("Login failed for %s: incorrect password", payload.email)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ from jose import jwt
 import json
 import app.main as main_app
 from datetime import datetime, timedelta
+import bcrypt
 
 
 class DummyRedis:
@@ -70,6 +71,7 @@ def test_default_admin_exists():
     assert admin is not None
     assert admin["role"] == "admin"
     assert admin["approved"] is True
+    assert bcrypt.checkpw("admin123".encode(), admin["password"].encode())
 
 
 def test_applicant_registration_without_code():
@@ -122,6 +124,9 @@ def test_registration_flow():
     resp = client.post("/register", json=user_data)
     assert resp.status_code == 200
     assert "Awaiting admin approval" in resp.json()["message"]
+    stored = json.loads(main_app.redis_client.get(f"user:{user_data['email']}"))
+    assert stored["password"] != user_data["password"]
+    assert bcrypt.checkpw(user_data["password"].encode(), stored["password"].encode())
 
     # Duplicate registration
     dup_resp = client.post("/register", json=user_data)
@@ -151,6 +156,28 @@ def test_registration_flow():
     payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
     assert payload["sub"] == user_data["email"]
     assert payload["role"] == "career"
+
+
+def test_login_rejects_bad_password():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    user = {
+        "email": "badpwd@example.com",
+        "first_name": "Bad",
+        "last_name": "Pwd",
+        "school_code": "1001",
+        "password": "secret",
+        "role": "applicant",
+    }
+    client.post("/register", json=user)
+    key = f"user:{user['email']}"
+    data = json.loads(main_app.redis_client.get(key))
+    data["approved"] = True
+    main_app.redis_client.set(key, json.dumps(data))
+    resp = client.post(
+        "/login", json={"email": user["email"], "password": "wrong"}
+    )
+    assert resp.status_code == 401
 
 
 def test_non_admin_cannot_approve():


### PR DESCRIPTION
## Summary
- Hash and verify passwords with bcrypt in auth routes
- Store default admin password as a bcrypt hash
- Expand auth tests to cover hashed password behavior

## Testing
- `pytest tests/test_main.py::test_default_admin_exists tests/test_main.py::test_registration_flow tests/test_main.py::test_login_rejects_bad_password -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa69d56e908333b0c90cf591139965