### PR TITLE
Parameterize default admin credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ left blank, the links in emails will lead to missing pages.
 comma-separated list (e.g., `https://example.com,http://localhost:3000`). It
 defaults to `*` to allow requests from any origin.
 
+`ADMIN_EMAIL` and `ADMIN_PASSWORD` set the credentials for the default
+administrator account created in Redis on startup. When these variables are not
+defined, the application falls back to `admin@example.com` and `admin123`.
+
 ## Registration Codes
 
 Career services staff and recruiters must supply an institutional code when registering.

--- a/app/main.py
+++ b/app/main.py
@@ -122,11 +122,14 @@ def init_default_admin() -> None:
     if redis_client is None:
         return
 
-    key = "user:admin@example.com"
+    email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    password = os.getenv("ADMIN_PASSWORD", "admin123")
+
+    key = f"user:{email}"
     if not redis_client.exists(key):
-        hashed = bcrypt.hashpw("admin123".encode(), bcrypt.gensalt()).decode()
+        hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         admin = {
-            "email": "admin@example.com",
+            "email": email,
             "first_name": "Admin",
             "last_name": "User",
             "password": hashed,


### PR DESCRIPTION
## Summary
- Allow default admin account email and password to be configured via `ADMIN_EMAIL` and `ADMIN_PASSWORD`
- Document new environment variables for configuring default admin credentials

## Testing
- `pytest` *(fails: 18 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa738a5cfc8333bc749202793f59cb