### PR TITLE
Add comprehensive request-aware logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import json
 import os
+import logging
+import uuid
 from typing import Any
-import bcrypt
 
+import bcrypt
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 import httpx
@@ -25,11 +27,19 @@ try:  # pragma: no cover - optional dependency during tests
 except Exception:  # pragma: no cover - redis not installed
     redis = None
 
+from backend.app.logging_utils import RequestIdFilter, get_logger, request_id_ctx_var
 from backend.app.school_codes import SCHOOL_CODE_MAP
 from backend.app.services.job import resolve_student_key as _resolve_student_key
 
 
 load_dotenv()
+
+# Configure root logger with request ID support for structured troubleshooting
+logging.basicConfig(level=logging.INFO, format="%(levelname)s [%(request_id)s] %(message)s")
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIdFilter())
+
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Global settings used by the auth routes and tests
@@ -158,6 +168,26 @@ NURSING_FEEDS = [("Example", "http://example.com/feed")]
 # ---------------------------------------------------------------------------
 
 app = FastAPI()
+
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    """Attach a unique request ID to each request for correlation."""
+
+    request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    token = request_id_ctx_var.set(request_id)
+    logger.info("Incoming %s %s", request.method, request.url.path)
+    try:
+        response = await call_next(request)
+    except Exception:
+        logger.exception("Unhandled error for %s %s", request.method, request.url.path)
+        raise
+    finally:
+        request_id_ctx_var.reset(token)
+
+    response.headers.setdefault("X-Request-ID", request_id)
+    logger.info("Completed %s %s with status %s", request.method, request.url.path, response.status_code)
+    return response
 
 
 @app.on_event("startup")

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -11,19 +11,26 @@ from app.routes.auth import get_current_user
 from backend.app.schemas.resume import ResumeRequest
 from backend.app.services.job import generate_job_description_html, normalize_email, resolve_student_key
 from backend.app.services.resume import generate_resume_text
+from backend.app.logging_utils import get_logger
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 
+logger = get_logger(__name__)
+
 
 def find_user_key(email: str) -> str | None:
+    logger.debug("Searching for user key for %s", email)
     target = normalize_email(email)
     exact = f"user:{target}"
     if main.redis_client.exists(exact):
+        logger.debug("Found exact user key %s", exact)
         return exact
     for key in main.redis_client.scan_iter("user:*"):
         k = key if isinstance(key, str) else key.decode()
         if k.split("user:", 1)[1].lower() == target:
+            logger.debug("Found user key %s via scan", k)
             return k
+    logger.debug("User key for %s not found", email)
     return None
 
 
@@ -31,6 +38,7 @@ def find_user_key(email: str) -> str | None:
 def create_job(job: dict, _: dict = Depends(get_current_user)) -> dict:
     data = dict(job)
     code = data.get("job_code") or str(uuid.uuid4())[:8]
+    logger.info("Creating job %s", code)
     data["job_code"] = code
     data.setdefault("assigned_students", [])
     data.setdefault("placed_students", [])
@@ -42,23 +50,40 @@ def create_job(job: dict, _: dict = Depends(get_current_user)) -> dict:
         else:
             data["required_license"] = rl_clean.lower()
     main.redis_client.set(f"job:{code}", json.dumps(data))
+    logger.info("Job %s stored", code)
     return {"message": "Job stored", "job_code": code}
 
 
 @router.post("/generate-job-description")
 def generate_job_description(req: ResumeRequest, _: dict = Depends(get_current_user)):
+    logger.info(
+        "Generating job description for job %s and student %s",
+        req.job_code,
+        req.student_email,
+    )
     html, existed = generate_job_description_html(
         main.client, main.redis_client, req.job_code, req.student_email
     )
-    return {"status": "exists" if existed else "success"}
+    status = "exists" if existed else "success"
+    logger.info(
+        "Job description generation for job %s and student %s finished with %s",
+        req.job_code,
+        req.student_email,
+        status,
+    )
+    return {"status": status}
 
 
 @router.get("/job-description/{job_code}/{student_email}")
 def get_job_description(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
     student_email = normalize_email(student_email)
     key = f"job_description:{job_code}:{student_email}"
+    logger.info(
+        "Fetching job description for job %s and student %s", job_code, student_email
+    )
     description = main.redis_client.get(key)
     if not description:
+        logger.warning("Job description not found for job %s and student %s", job_code, student_email)
         raise HTTPException(status_code=404, detail="Not found")
     return {"status": "success", "description": description}
 
@@ -67,8 +92,14 @@ def get_job_description(job_code: str, student_email: str, _: dict = Depends(get
 def get_job_description_html(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
     student_email = normalize_email(student_email)
     key = f"jobdesc:{job_code}:{student_email}"
+    logger.info("Fetching job description HTML for job %s and student %s", job_code, student_email)
     html = main.redis_client.get(key)
     if not html:
+        logger.warning(
+            "Job description HTML not found for job %s and student %s",
+            job_code,
+            student_email,
+        )
         raise HTTPException(status_code=404, detail="Job description not found")
     return HTMLResponse(content=html, status_code=200)
 
@@ -77,8 +108,16 @@ def get_job_description_html(job_code: str, student_email: str, _: dict = Depend
 def get_public_job_description_html(job_code: str, student_email: str):
     student_email = normalize_email(student_email)
     key = f"jobdesc:{job_code}:{student_email}"
+    logger.info(
+        "Fetching public job description HTML for job %s and student %s", job_code, student_email
+    )
     html = main.redis_client.get(key)
     if not html:
+        logger.warning(
+            "Public job description HTML not found for job %s and student %s",
+            job_code,
+            student_email,
+        )
         raise HTTPException(status_code=404, detail="Job description not found")
     return HTMLResponse(content=html, status_code=200)
 
@@ -86,11 +125,20 @@ def get_public_job_description_html(job_code: str, student_email: str):
 @router.post("/generate-resume")
 def generate_resume(req: ResumeRequest, _: dict = Depends(get_current_user)):
     preview = getattr(req, "preview", False)
+    logger.info(
+        "Generating resume for job %s and student %s (preview=%s)",
+        req.job_code,
+        req.student_email,
+        preview,
+    )
     resume_key = f"resume:{req.job_code}:{req.student_email}"
     html_key = f"resumehtml:{req.job_code}:{req.student_email}"
     if not preview:
         existing = main.redis_client.get(resume_key)
         if existing:
+            logger.info(
+                "Existing resume found for job %s and student %s", req.job_code, req.student_email
+            )
             main.redis_client.set(html_key, existing)
             return {"status": "exists"}
 
@@ -101,12 +149,22 @@ def generate_resume(req: ResumeRequest, _: dict = Depends(get_current_user)):
         skey = resolve_student_key(main.redis_client, req.student_email)
         student_raw = main.redis_client.get(skey) if skey else None
     if not job_raw or not student_raw:
+        logger.warning(
+            "Job or student missing when generating resume for job %s and student %s",
+            req.job_code,
+            req.student_email,
+        )
         raise HTTPException(status_code=404, detail="Job or student not found")
 
     job = json.loads(job_raw)
     student = json.loads(student_raw)
 
     if not preview and req.student_email not in job.get("assigned_students", []) and req.student_email not in job.get("placed_students", []):
+        logger.warning(
+            "Student %s not assigned to job %s during resume generation",
+            req.student_email,
+            req.job_code,
+        )
         raise HTTPException(status_code=403, detail="Student not assigned to job")
 
     raw_html = generate_resume_text(main.client, student, job, include_contact=not preview).strip()
@@ -137,8 +195,16 @@ def generate_resume(req: ResumeRequest, _: dict = Depends(get_current_user)):
     if not preview:
         main.redis_client.set(resume_key, full_html)
         main.redis_client.set(html_key, full_html)
+        logger.info(
+            "Stored resume for job %s and student %s", req.job_code, req.student_email
+        )
         return {"status": "success"}
     else:
+        logger.info(
+            "Generated preview resume for job %s and student %s",
+            req.job_code,
+            req.student_email,
+        )
         return {"status": "preview", "html": full_html}
 
 
@@ -146,16 +212,26 @@ def generate_resume(req: ResumeRequest, _: dict = Depends(get_current_user)):
 def get_resume(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
     student_email = normalize_email(student_email)
     key = f"resume:{job_code}:{student_email}"
+    logger.info("Fetching resume for job %s and student %s", job_code, student_email)
 
     job_raw = main.redis_client.get(f"job:{job_code}")
     if not job_raw:
+        logger.warning("Job %s not found when fetching resume", job_code)
         raise HTTPException(status_code=404, detail="Job not found")
     job = json.loads(job_raw)
     if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        logger.warning(
+            "Student %s not assigned to job %s when fetching resume",
+            student_email,
+            job_code,
+        )
         raise HTTPException(status_code=403, detail="Student not assigned to job")
 
     resume = main.redis_client.get(key)
     if not resume:
+        logger.warning(
+            "Resume for job %s and student %s not found", job_code, student_email
+        )
         raise HTTPException(status_code=404, detail="Resume not found")
     return {
         "status": "success",
@@ -169,18 +245,30 @@ def get_resume(job_code: str, student_email: str, _: dict = Depends(get_current_
 def get_resume_html(job_code: str, student_email: str, _: dict = Depends(get_current_user)):
     student_email = normalize_email(student_email)
     key = f"resumehtml:{job_code}:{student_email}"
+    logger.info(
+        "Fetching resume HTML for job %s and student %s", job_code, student_email
+    )
 
     job_raw = main.redis_client.get(f"job:{job_code}")
     if not job_raw:
+        logger.warning("Job %s not found when fetching resume HTML", job_code)
         raise HTTPException(status_code=404, detail="Job not found")
     job = json.loads(job_raw)
     if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        logger.warning(
+            "Student %s not assigned to job %s when fetching resume HTML",
+            student_email,
+            job_code,
+        )
         raise HTTPException(status_code=403, detail="Student not assigned to job")
 
     html = main.redis_client.get(key)
     if not html:
         html = main.redis_client.get(f"resume:{job_code}:{student_email}")
     if not html:
+        logger.warning(
+            "Resume HTML for job %s and student %s not found", job_code, student_email
+        )
         raise HTTPException(status_code=404, detail="Resume not found")
     return HTMLResponse(content=html, status_code=200)
 

--- a/app/routes/matching.py
+++ b/app/routes/matching.py
@@ -13,24 +13,32 @@ from backend.app.services.job import (
     normalize_email,
     resolve_student_key,
 )
+from backend.app.logging_utils import get_logger
 
 
 router = APIRouter(prefix="", tags=["matching"])
 
+logger = get_logger(__name__)
+
 
 def _get_job(job_code: str) -> dict:
+    logger.debug("Retrieving job %s", job_code)
     raw = main.redis_client.get(f"job:{job_code}")
     if not raw:
+        logger.warning("Job %s not found", job_code)
         raise HTTPException(status_code=404, detail="Job not found")
     return json.loads(raw)
 
 
 def _get_student(email: str) -> tuple[dict, str]:
+    logger.debug("Resolving student %s", email)
     skey = resolve_student_key(main.redis_client, email)
     if not skey:
+        logger.warning("Student %s not found", email)
         raise HTTPException(status_code=404, detail="Student not found")
     raw = main.redis_client.get(skey)
     if not raw:
+        logger.warning("Student %s not found at key %s", email, skey)
         raise HTTPException(status_code=404, detail="Student not found")
     return json.loads(raw), skey
 
@@ -61,7 +69,7 @@ def run_match(data: dict) -> dict:
     job_code = data.get("job_code")
     if not job_code:
         raise HTTPException(status_code=400, detail="job_code required")
-
+    logger.info("Running match for job %s", job_code)
     job = _get_job(job_code)
     job_emb = _embedding_for(" ".join(job.get("desired_skills", [])) or job.get("job_description", ""))
 
@@ -150,6 +158,7 @@ def run_match(data: dict) -> dict:
     # Limit to 10 as expected by the tests
     matches = matches[:10]
 
+    logger.info("Storing %d match results for job %s", len(matches), job_code)
     main.redis_client.set(f"match_results:{job_code}", json.dumps(matches))
     return {"matches": matches}
 
@@ -157,7 +166,7 @@ def run_match(data: dict) -> dict:
 @router.post("/rematches/{job_code}")
 def queue_rematch(job_code: str) -> dict:
     """Remove existing match results and record a rematch request."""
-
+    logger.info("Queueing rematch for job %s", job_code)
     _get_job(job_code)
 
     key = f"match_results:{job_code}"
@@ -170,13 +179,14 @@ def queue_rematch(job_code: str) -> dict:
             main.redis_client.set(key, None)
 
     main.redis_client.incr("metrics:total_rematches")
+    logger.info("Rematch queued for job %s", job_code)
     return {"message": "Rematch queued"}
 
 
 @router.get("/match/{job_code}")
 def get_match_results(job_code: str) -> dict:
     """Return stored match results with job status/notes merged in."""
-
+    logger.info("Fetching match results for job %s", job_code)
     job = _get_job(job_code)
     raw = main.redis_client.get(f"match_results:{job_code}")
     matches = json.loads(raw) if raw else []
@@ -248,6 +258,7 @@ def get_match_results(job_code: str) -> dict:
         seen.add(email)
         final.append(m)
 
+    logger.info("Returning %d match results for job %s", len(final), job_code)
     return {"matches": final}
 
 
@@ -258,7 +269,7 @@ def assign_student(data: dict, user: dict = Depends(get_current_user)) -> dict:
     note = data.get("note")
     if not job_code or not student_email:
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
-
+    logger.info("Assigning student %s to job %s", student_email, job_code)
     job = _get_job(job_code)
     job.setdefault("assigned_students", [])
     if student_email not in job["assigned_students"]:
@@ -285,7 +296,7 @@ def assign_student(data: dict, user: dict = Depends(get_current_user)) -> dict:
     if note:
         entry.setdefault("notes", []).append({"text": note, "posted_by": user.get("email")})
     main.redis_client.set(skey, json.dumps(student))
-
+    logger.info("Student %s assigned to job %s", student_email, job_code)
     return {"message": "Student assigned"}
 
 
@@ -295,7 +306,7 @@ def place_student(data: dict, _: dict = Depends(require_admin)) -> dict:
     student_email = normalize_email(data.get("student_email"))
     if not job_code or not student_email:
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
-
+    logger.info("Placing student %s on job %s", student_email, job_code)
     job = _get_job(job_code)
     job.setdefault("placed_students", [])
     if student_email not in job["placed_students"]:
@@ -319,6 +330,7 @@ def place_student(data: dict, _: dict = Depends(require_admin)) -> dict:
             }
         )
     main.redis_client.set(skey, json.dumps(student))
+    logger.info("Student %s placed on job %s", student_email, job_code)
     return {"message": "Student placed"}
 
 
@@ -329,7 +341,7 @@ def reject_assigned(data: dict, user: dict = Depends(get_current_user)) -> dict:
     note = data.get("note")
     if not job_code or not student_email:
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
-
+    logger.info("Rejecting student %s for job %s", student_email, job_code)
     job = _get_job(job_code)
     if student_email in job.get("assigned_students", []):
         job["assigned_students"].remove(student_email)
@@ -358,7 +370,7 @@ def reject_assigned(data: dict, user: dict = Depends(get_current_user)) -> dict:
     if note:
         entry.setdefault("notes", []).append({"text": note, "posted_by": user.get("email")})
     main.redis_client.set(skey, json.dumps(student))
-
+    logger.info("Student %s rejected for job %s", student_email, job_code)
     return {"message": "Assignment rejected"}
 
 
@@ -368,12 +380,13 @@ def mark_not_interested(data: dict, _: dict = Depends(get_current_user)) -> dict
     student_email = normalize_email(data.get("student_email"))
     if not job_code or not student_email:
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
-
+    logger.info("Marking student %s not interested in job %s", student_email, job_code)
     job = _get_job(job_code)
     job.setdefault("uninterested_students", [])
     if student_email not in job["uninterested_students"]:
         job["uninterested_students"].append(student_email)
     main.redis_client.set(f"job:{job_code}", json.dumps(job))
+    logger.info("Student %s marked not interested in job %s", student_email, job_code)
     return {"message": "Student marked not interested"}
 
 
@@ -383,7 +396,7 @@ def notify_interest(data: dict, _: dict = Depends(get_current_user)) -> dict:
     student_email = data.get("student_email")
     if not job_code or not student_email:
         raise HTTPException(status_code=400, detail="Missing job_code or student_email")
-
+    logger.info("Notifying interest for student %s on job %s", student_email, job_code)
     job = _get_job(job_code)
     student_email = normalize_email(student_email)
     if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
@@ -416,6 +429,9 @@ def notify_interest(data: dict, _: dict = Depends(get_current_user)) -> dict:
         student_email,
         f"Recruiter Interest: {job.get('job_title')}",
         body,
+    )
+    logger.info(
+        "Sent interest notification for student %s on job %s", student_email, job_code
     )
 
     return {"message": "Notification sent"}

--- a/app/routes/notes.py
+++ b/app/routes/notes.py
@@ -16,9 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException
 import app.main as main
 from app.routes.auth import get_current_user, require_admin
 from backend.app.services.job import normalize_email, resolve_student_key
+from backend.app.logging_utils import get_logger
 
 
 router = APIRouter(prefix="/notes", tags=["notes"])
+
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -46,18 +49,23 @@ def _normalize_notes(notes: Any) -> list[dict[str, Any]]:
 
 
 def _get_job(job_code: str) -> dict:
+    logger.debug("Retrieving job %s for notes", job_code)
     raw = main.redis_client.get(f"job:{job_code}")
     if not raw:
+        logger.warning("Job %s not found when accessing notes", job_code)
         raise HTTPException(status_code=404, detail="Job not found")
     return json.loads(raw)
 
 
 def _get_student(email: str) -> tuple[dict | None, str | None]:
+    logger.debug("Resolving student %s for notes", email)
     skey = resolve_student_key(main.redis_client, email)
     if not skey:
+        logger.debug("No student key found for %s", email)
         return None, None
     raw = main.redis_client.get(skey)
     if not raw:
+        logger.debug("Student key %s resolved for %s but no record found", skey, email)
         return None, skey
     return json.loads(raw), skey
 
@@ -76,7 +84,7 @@ def add_student_note(data: dict, user: dict = Depends(get_current_user)) -> dict
     note_text = data.get("note")
     if not job_code or not student_email or not note_text:
         raise HTTPException(status_code=400, detail="Missing job_code, student_email or note")
-
+    logger.info("Adding note for student %s on job %s", student_email, job_code)
     job = _get_job(job_code)
     if user.get("role") != "admin":
         if job.get("posted_by") != user.get("email"):
@@ -100,6 +108,7 @@ def add_student_note(data: dict, user: dict = Depends(get_current_user)) -> dict
             entry["notes"] = entry_notes
             main.redis_client.set(skey, json.dumps(student))
 
+    logger.info("Added note for student %s on job %s", student_email, job_code)
     return {"notes": notes_dict[student_email]}
 
 
@@ -113,7 +122,9 @@ def update_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
     note_text = data.get("note")
     if job_code is None or student_email is None or index is None or note_text is None:
         raise HTTPException(status_code=400, detail="Missing fields")
-
+    logger.info(
+        "Updating note %s for student %s on job %s", index, student_email, job_code
+    )
     job = _get_job(job_code)
     notes_dict = job.setdefault("student_notes", {})
     notes = _normalize_notes(notes_dict.get(student_email, []))
@@ -134,6 +145,9 @@ def update_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
                 entry["notes"] = entry_notes
                 main.redis_client.set(skey, json.dumps(student))
 
+    logger.info(
+        "Updated note %s for student %s on job %s", index, student_email, job_code
+    )
     return {"notes": notes}
 
 
@@ -146,7 +160,9 @@ def delete_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
     index = data.get("index")
     if job_code is None or student_email is None or index is None:
         raise HTTPException(status_code=400, detail="Missing fields")
-
+    logger.info(
+        "Deleting note %s for student %s on job %s", index, student_email, job_code
+    )
     job = _get_job(job_code)
     notes_dict = job.setdefault("student_notes", {})
     notes = _normalize_notes(notes_dict.get(student_email, []))
@@ -173,5 +189,8 @@ def delete_student_note(data: dict, _: dict = Depends(require_admin)) -> dict:
                 entry.pop("notes", None)
             main.redis_client.set(skey, json.dumps(student))
 
+    logger.info(
+        "Deleted note %s for student %s on job %s", index, student_email, job_code
+    )
     return {"notes": notes_dict.get(student_email, [])}
 

--- a/app/routes/students.py
+++ b/app/routes/students.py
@@ -17,10 +17,13 @@ from fastapi import APIRouter, Depends, HTTPException
 
 import app.main as main
 from app.routes.auth import get_current_user, require_admin
+from backend.app.logging_utils import get_logger
 
 
 # Router configured with prefix and tag information as required by the tests.
 router = APIRouter(prefix="/students", tags=["students"])
+
+logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -38,12 +41,14 @@ def list_all_students(_: dict = Depends(require_admin)) -> dict:
     :func:`app.main.persist_student_record`.
     """
 
+    logger.info("Listing all students")
     students: list[dict[str, Any]] = []
     if main.redis_client is not None:
         for key in main.redis_client.scan_iter("student:*:*"):
             raw = main.redis_client.get(key)
             if raw:
                 students.append(json.loads(raw))
+    logger.info("Retrieved %d students", len(students))
     return {"students": students}
 
 
@@ -60,13 +65,14 @@ def list_students_by_school(
     inst = code or user.get("school_code")
     if not inst:
         raise HTTPException(status_code=400, detail="Institutional code required")
-
+    logger.info("Listing students for school %s", inst)
     students: list[dict[str, Any]] = []
     if main.redis_client is not None:
         for key in main.redis_client.scan_iter(f"student:{inst}:*"):
             raw = main.redis_client.get(key)
             if raw:
                 students.append(json.loads(raw))
+    logger.info("Retrieved %d students for school %s", len(students), inst)
     return {"students": students}
 
 
@@ -74,16 +80,20 @@ def list_students_by_school(
 def get_me(user: dict = Depends(get_current_user)) -> dict:
     """Return the student profile for the currently authenticated user."""
 
+    logger.info("Fetching profile for %s", user.get("email"))
     if main.redis_client is None:
+        logger.warning("Redis not configured when fetching profile for %s", user.get("email"))
         raise HTTPException(status_code=404, detail="Student not found")
 
     loc = main.redis_client.get(main.student_email_key(user["email"]))
     if not loc:
+        logger.warning("Student profile for %s not found", user.get("email"))
         raise HTTPException(status_code=404, detail="Student not found")
 
     inst, sid = loc.split(":", 1)
     raw = main.redis_client.get(main.student_key(inst, sid))
     if not raw:
+        logger.warning("Student record %s:%s not found", inst, sid)
         raise HTTPException(status_code=404, detail="Student not found")
     return json.loads(raw)
 
@@ -103,6 +113,7 @@ def get_placements(student_email: str, _: dict = Depends(get_current_user)) -> d
     """
 
     placements: list[dict[str, Any]] = []
+    logger.info("Fetching placements for %s", student_email)
     if main.redis_client is not None:
         for key in main.redis_client.scan_iter("job:*"):
             raw = main.redis_client.get(key)
@@ -111,6 +122,7 @@ def get_placements(student_email: str, _: dict = Depends(get_current_user)) -> d
             job = json.loads(raw)
             if student_email in job.get("placed_students", []):
                 placements.append(job)
+    logger.info("Found %d placements for %s", len(placements), student_email)
     return {"placements": placements}
 
 
@@ -154,6 +166,8 @@ def create_student(payload: dict, user: dict = Depends(get_current_user)) -> dic
     except Exception:
         payload["embedding"] = []
 
+    logger.info("Creating student profile for %s", email)
     main.persist_student_record(email, payload, inst, student_id)
+    logger.info("Student profile for %s stored", email)
     return {"message": "Student created"}
 


### PR DESCRIPTION
## Summary
- configure request-scoped logging with request IDs
- add detailed logging to job, matching, student, and notes routes for troubleshooting

## Testing
- `pytest` *(18 failures: see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68aa997e0aa0833389ebb79419cc2bc6