### PR TITLE
Add request logging middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ import json
 import os
 from typing import Any
 import bcrypt
+import logging
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -27,9 +28,14 @@ except Exception:  # pragma: no cover - redis not installed
 
 from backend.app.school_codes import SCHOOL_CODE_MAP
 from backend.app.services.job import resolve_student_key as _resolve_student_key
+from backend.app.logging_utils import RequestIdFilter, RequestLoggingMiddleware
 
 
 load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s [%(request_id)s] %(message)s")
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIdFilter())
 
 # ---------------------------------------------------------------------------
 # Global settings used by the auth routes and tests
@@ -158,6 +164,8 @@ NURSING_FEEDS = [("Example", "http://example.com/feed")]
 # ---------------------------------------------------------------------------
 
 app = FastAPI()
+
+app.add_middleware(RequestLoggingMiddleware)
 
 
 @app.on_event("startup")

--- a/backend/app/logging_utils.py
+++ b/backend/app/logging_utils.py
@@ -2,6 +2,12 @@
 
 from contextvars import ContextVar
 import logging
+import time
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
 
 # Context variable to store the current request ID
 request_id_ctx_var: ContextVar[str] = ContextVar("request_id", default="-")
@@ -32,3 +38,38 @@ def get_logger(name: str | None = None) -> RequestIdAdapter:
 
     logger = logging.getLogger(name)
     return RequestIdAdapter(logger)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware that assigns a request ID and logs request/response details."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.logger = get_logger(__name__)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = request.headers.get("X-Request-ID", uuid.uuid4().hex)
+        token = request_id_ctx_var.set(request_id)
+        start = time.perf_counter()
+        self.logger.info("Started %s %s", request.method, request.url.path)
+        response: Response | None = None
+        try:
+            response = await call_next(request)
+            response.headers["X-Request-ID"] = request_id
+            return response
+        except Exception:
+            self.logger.exception(
+                "Unhandled error for %s %s", request.method, request.url.path
+            )
+            raise
+        finally:
+            duration = (time.perf_counter() - start) * 1000
+            status = response.status_code if response is not None else 500
+            self.logger.info(
+                "Completed %s %s with status %s in %.2fms",
+                request.method,
+                request.url.path,
+                status,
+                duration,
+            )
+            request_id_ctx_var.reset(token)


### PR DESCRIPTION
## Summary
- add middleware to attach request IDs and log each HTTP request/response
- configure global logging to include request IDs and enable middleware in FastAPI

## Testing
- `pytest -q` *(fails: 18 failed, 73 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9ecf16988333ae9b8ace247baa07