### PR TITLE
Add licenses listing endpoint and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -204,7 +204,7 @@ app.add_middleware(
 )
 
 
-from app.routes import auth, admin, students, jobs, matching, notes
+from app.routes import auth, admin, students, jobs, matching, notes, licenses
 
 
 app.include_router(auth.router)
@@ -213,6 +213,7 @@ app.include_router(students.router)
 app.include_router(jobs.router)
 app.include_router(matching.router)
 app.include_router(notes.router)
+app.include_router(licenses.router)
 
 
 @app.get("/school-codes")

--- a/app/routes/licenses.py
+++ b/app/routes/licenses.py
@@ -1,0 +1,34 @@
+"""License listing API routes.
+
+This module provides a simple endpoint for retrieving license codes and their
+labels from the Redis data store.  It mirrors other lightweight route modules
+by exposing an ``APIRouter`` that can be included in the main application
+without special permissions.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+import app.main as main
+
+
+router = APIRouter()
+
+
+@router.get("/licenses")
+def list_licenses() -> dict:
+    """Return all license entries stored in Redis.
+
+    Each license is stored under ``license:<code>`` with its human readable
+    label as the value.  The endpoint returns a structure compatible with the
+    expectations of the frontend tests: ``{"licenses": [{"code": ..., "label": ...}, ...]}``.
+    """
+
+    licenses: list[dict[str, str]] = []
+    if main.redis_client is not None:
+        for key in main.redis_client.scan_iter("license:*"):
+            code = key.split(":", 1)[1]
+            label = main.redis_client.get(key)
+            licenses.append({"code": code, "label": label})
+    return {"licenses": licenses}

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -32,6 +32,20 @@ test('renders StudentProfiles without errors', () => {
   }).not.toThrow();
 });
 
+test('fetches licenses on load', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/licenses');
+  });
+  localStorage.clear();
+});
+
 test('displays student count in tab bar', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2163,3 +2163,15 @@ def test_malformed_user_skipped_in_listings():
     user_emails = [u["email"] for u in users.json()["users"]]
     assert "bad@example.com" not in user_emails
 
+
+def test_list_licenses():
+    main_app.redis_client.flushdb()
+    main_app.redis_client.set("license:rn", "Registered Nurse")
+    main_app.redis_client.set("license:lpn", "Licensed Practical Nurse")
+
+    resp = client.get("/licenses")
+    assert resp.status_code == 200
+    data = resp.json()["licenses"]
+    assert {"code": "rn", "label": "Registered Nurse"} in data
+    assert {"code": "lpn", "label": "Licensed Practical Nurse"} in data
+


### PR DESCRIPTION
## Summary
- add `/licenses` endpoint to return license codes from Redis
- wire new router into main app and fetch from StudentProfiles
- test license endpoint and expect front-end to call it

## Testing
- `pytest tests/test_main.py::test_list_licenses -q`
- `CI=1 npm test -- --runTestsByPath src/StudentProfiles.test.js`
- `pytest` *(fails: assert 404 == 500, KeyError: 'source', KeyError: 'students', assert 403 == 200, assert 200 == 403, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa73b58883338b3df4e7c64e186a