### PR TITLE
feat: configure log level via env

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,12 +37,15 @@ from backend.app.logging_utils import (
 
 
 load_dotenv()
-
-logging.basicConfig(level=logging.INFO, format="%(levelname)s [%(request_id)s] %(message)s")
+level_name = os.getenv("LOGLEVEL", "INFO").upper()
+logging.basicConfig(
+    level=level_name, format="%(levelname)s [%(request_id)s] %(message)s"
+)
 for handler in logging.getLogger().handlers:
     handler.addFilter(RequestIdFilter())
 
 logger = get_logger(__name__)
+logger.info("Logging configured with level %s", level_name)
 
 # ---------------------------------------------------------------------------
 # Global settings used by the auth routes and tests


### PR DESCRIPTION
## Summary
- allow LOGLEVEL env var to set logging level
- log chosen level at startup for transparency

## Testing
- `pytest` *(fails: KeyError: 'students'; AttributeError; assert mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68abeb52a6f08333a7571d749423267d