### PR TITLE
Improve student and assignment loading behavior

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -68,7 +68,7 @@ function StudentProfiles() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
-  const [schoolStudents, setSchoolStudents] = useState([]);
+  const [schoolStudents, setSchoolStudents] = useState(null);
   const [firstNameFilter, setFirstNameFilter] = useState('');
   const [lastNameFilter, setLastNameFilter] = useState('');
   const [emailFilter, setEmailFilter] = useState('');
@@ -161,6 +161,7 @@ function StudentProfiles() {
         console.error('Failed to fetch students:', err);
         setToast('Failed to load students. Please try again later.');
         setTimeout(() => setToast(''), 3000);
+        setSchoolStudents([]);
       }
     } finally {
       setIsLoading(false);
@@ -196,6 +197,9 @@ function StudentProfiles() {
     fetchStudents();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const needsAssignments = (student) =>
+    !Array.isArray(student.assigned_jobs) && student.assigned_jobs !== 0;
+
   const fetchAssignments = async (student) => {
     const controller = new AbortController();
     assignmentControllers.current[student.email] = controller;
@@ -214,11 +218,28 @@ function StudentProfiles() {
     } catch (err) {
       if (err.name !== 'CanceledError') {
         console.error('Failed to fetch assignments', err);
+        setSchoolStudents((prev) =>
+          Array.isArray(prev)
+            ? prev.map((s) =>
+                s.email === student.email ? { ...s, assigned_jobs: [] } : s
+              )
+            : prev
+        );
       }
     } finally {
       delete assignmentControllers.current[student.email];
     }
   };
+
+  useEffect(() => {
+    if (!isLoading && Array.isArray(schoolStudents)) {
+      schoolStudents.forEach((student) => {
+        if (needsAssignments(student) && !assignmentControllers.current[student.email]) {
+          fetchAssignments(student);
+        }
+      });
+    }
+  }, [isLoading, schoolStudents]);
 
   const toggleRow = (student) => {
     const email = student.email;
@@ -226,7 +247,9 @@ function StudentProfiles() {
       const state = prev[email];
       const isOpen = state === 'open' || state === 'opening';
       if (!isOpen) {
-        fetchAssignments(student);
+        if (needsAssignments(student) && !assignmentControllers.current[email]) {
+          fetchAssignments(student);
+        }
         return { ...prev, [email]: 'opening' };
       } else {
         const ctrl = assignmentControllers.current[email];
@@ -260,7 +283,7 @@ function StudentProfiles() {
   }, [activeTab]);
 
   const handleEdit = (email) => {
-    const student = schoolStudents.find((s) => s.email === email);
+    const student = schoolStudents?.find((s) => s.email === email);
     if (student) {
       const editData = {
         ...student,
@@ -416,9 +439,8 @@ function StudentProfiles() {
       setIsSaving(false);
     }
   };
-
-
-  const filteredStudents = schoolStudents.filter((s) => {
+  const filteredStudents = Array.isArray(schoolStudents)
+    ? schoolStudents.filter((s) => {
     const firstMatch = s.first_name
       ?.toLowerCase()
       .includes(firstNameFilter.toLowerCase());
@@ -462,7 +484,8 @@ function StudentProfiles() {
       assignedMatch &&
       placementMatch
     );
-  });
+    })
+    : [];
 
   return (
 
@@ -527,7 +550,7 @@ function StudentProfiles() {
             New Student Profile
           </button>
         </div>
-        {!isLoading && (
+        {!isLoading && Array.isArray(schoolStudents) && (
           <div className="student-count" data-testid="student-count">
             Student Profiles: <span className="count-number">{schoolStudents.length}</span>
           </div>
@@ -557,7 +580,7 @@ function StudentProfiles() {
           }}
         >
           <div style={{ flexGrow: 1, minHeight: 0, marginTop: '0' }}>
-            {isLoading ? (
+            {isLoading || !Array.isArray(schoolStudents) ? (
               <div className="loading-container">
                 <span className="spinner" />
                 <span style={{ marginLeft: '0.5rem' }}>Loading students...</span>
@@ -668,7 +691,11 @@ function StudentProfiles() {
                 </thead>
                 <tbody>
                   {filteredStudents.map((s) => {
-                    const assigned = Array.isArray(s.assigned_jobs) ? s.assigned_jobs.length : s.assigned_jobs || 0;
+                    const assigned = Array.isArray(s.assigned_jobs)
+                      ? s.assigned_jobs.length
+                      : typeof s.assigned_jobs === 'number'
+                      ? s.assigned_jobs
+                      : null;
                     const placed = Array.isArray(s.placed_jobs) ? s.placed_jobs.length : s.placed_jobs || 0;
                     return (
                       <React.Fragment key={s.email}>
@@ -727,7 +754,9 @@ function StudentProfiles() {
                               )}
                             </div>
                           </td>
-                          <td className="assigned-col">{assigned}</td>
+                          <td className="assigned-col">
+                            {assigned === null ? 'Loading jobs...' : assigned}
+                          </td>
                           <td className="placement-status-col">{placed > 0 ? '✅' : '❌'}</td>
                           <td className="placement-controls-col">
                             {assigned > 0 && placed === 0 && userRole !== 'admin' && (
@@ -756,8 +785,9 @@ function StudentProfiles() {
                                   </tr>
                                 </thead>
                                 <tbody>
-                                  {s.assigned_jobs && s.assigned_jobs.length > 0 ? (
-                                    s.assigned_jobs.map((job, index) => (
+                                  {Array.isArray(s.assigned_jobs) ? (
+                                    s.assigned_jobs.length > 0 ? (
+                                      s.assigned_jobs.map((job, index) => (
                                       <tr key={index}>
                                         <td>{job.job_title}</td>
                                         <td>
@@ -824,9 +854,18 @@ function StudentProfiles() {
                                         </td>
                                       </tr>
                                     ))
-                                  ) : (
+                                    ) : (
+                                      <tr className="no-jobs-row">
+                                        <td colSpan="6">No jobs assigned by recruiters.</td>
+                                      </tr>
+                                    )
+                                  ) : s.assigned_jobs === 0 ? (
                                     <tr className="no-jobs-row">
                                       <td colSpan="6">No jobs assigned by recruiters.</td>
+                                    </tr>
+                                  ) : (
+                                    <tr className="no-jobs-row">
+                                      <td colSpan="6">Loading jobs...</td>
                                     </tr>
                                   )}
                                 </tbody>

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -18,6 +18,9 @@ beforeEach(() => {
     if (url === '/licenses') {
       return Promise.resolve({ data: { licenses: [] } });
     }
+    if (url.endsWith('/assignments')) {
+      return Promise.resolve({ data: { assigned_jobs: [] } });
+    }
     return Promise.resolve({ data: { students: [] } });
   });
 });
@@ -46,12 +49,51 @@ test('fetches licenses on load', async () => {
   localStorage.clear();
 });
 
+test('shows loading indicator then empty state when no students', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  let resolveStudents;
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    if (url === '/students/all') {
+      return new Promise((resolve) => {
+        resolveStudents = () => resolve({ data: { students: [] } });
+      });
+    }
+    if (url.endsWith('/assignments')) {
+      return Promise.resolve({ data: { assigned_jobs: [] } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  expect(screen.getByText(/Loading students/i)).toBeInTheDocument();
+  expect(
+    screen.queryByText("You haven't created any student profiles.")
+  ).not.toBeInTheDocument();
+  resolveStudents();
+  await waitFor(() => {
+    expect(
+      screen.getByText("You haven't created any student profiles.")
+    ).toBeInTheDocument();
+  });
+  localStorage.clear();
+});
+
 test('displays student count in tab bar', async () => {
   const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
   localStorage.setItem('token', token);
   api.get.mockImplementation((url) => {
     if (url === '/licenses') {
       return Promise.resolve({ data: { licenses: [] } });
+    }
+    if (url.endsWith('/assignments')) {
+      return Promise.resolve({ data: { assigned_jobs: [] } });
     }
     return Promise.resolve({
       data: {
@@ -90,6 +132,114 @@ test('displays student count in tab bar', async () => {
     </BrowserRouter>
   );
   expect(await screen.findByTestId('student-count')).toHaveTextContent('Student Profiles: 2');
+  localStorage.clear();
+});
+
+test('automatically fetches assignments for students with assigned jobs', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    if (url === '/students/all') {
+      return Promise.resolve({
+        data: {
+          students: [
+            {
+              first_name: 'A',
+              last_name: 'B',
+              email: 'a@example.com',
+              city: 'City',
+              state: 'ST',
+              institutional_code: 'ABC',
+              license: '',
+              student_id: '1',
+              assigned_jobs: 0,
+              placed_jobs: 0
+            },
+            {
+              first_name: 'C',
+              last_name: 'D',
+              email: 'c@example.com',
+              city: 'City',
+              state: 'ST',
+              institutional_code: 'ABC',
+              license: '',
+              student_id: '2',
+              assigned_jobs: 1,
+              placed_jobs: 0
+            }
+          ]
+        }
+      });
+    }
+    if (url === '/students/2/assignments') {
+      return Promise.resolve({ data: { assigned_jobs: [] } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/students/2/assignments', expect.any(Object));
+  });
+  expect(
+    api.get.mock.calls.some(([url]) => url === '/students/1/assignments')
+  ).toBe(false);
+  localStorage.clear();
+});
+
+test('shows assignment details after automatic loading', async () => {
+  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW4ifQ.signature';
+  localStorage.setItem('token', token);
+  api.get.mockImplementation((url) => {
+    if (url === '/licenses') {
+      return Promise.resolve({ data: { licenses: [] } });
+    }
+    if (url === '/students/all') {
+      return Promise.resolve({
+        data: {
+          students: [
+            {
+              first_name: 'A',
+              last_name: 'B',
+              email: 'a@example.com',
+              city: 'City',
+              state: 'ST',
+              institutional_code: 'ABC',
+              license: '',
+              student_id: '1',
+              assigned_jobs: 1,
+              placed_jobs: 0
+            }
+          ]
+        }
+      });
+    }
+    if (url === '/students/1/assignments') {
+      return Promise.resolve({
+        data: {
+          assigned_jobs: [
+            { job_code: 'J1', job_title: 'Job 1', source: 'N/A' }
+          ]
+        }
+      });
+    }
+    return Promise.resolve({ data: {} });
+  });
+  render(
+    <BrowserRouter>
+      <StudentProfiles />
+    </BrowserRouter>
+  );
+  // Expand the first student row
+  fireEvent.click(await screen.findByText('+'));
+  // Job title should appear after assignments load
+  expect(await screen.findByText('Job 1')).toBeInTheDocument();
   localStorage.clear();
 });
 


### PR DESCRIPTION
## Summary
- Fetch assignment details only for students who report assigned jobs and show counts immediately
- Display clear "No jobs assigned" messaging for students without assignments
- Verify assignment loading logic with targeted unit tests

## Testing
- `npm test --prefix frontend -- StudentProfiles.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac0255f5e48333aae98655b883ff86