### PR TITLE
fix: use jobs-prefixed API routes

### DIFF
--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -142,7 +142,7 @@ function ApplicantProfile() {
 
   const fetchJobDescriptionStatus = async (jobCode) => {
     try {
-      const resp = await api.get(`/job-description/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
+      const resp = await api.get(`/jobs/job-description/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
       if (resp.data.status === 'success') {
         setJobDescriptionStatus(prev => ({ ...prev, [jobCode]: 'ready' }));
       }
@@ -154,7 +154,7 @@ function ApplicantProfile() {
   const generateJobDescription = async (jobCode) => {
     setLoadingJobDescriptions(prev => ({ ...prev, [jobCode]: true }));
     try {
-      await api.post('/generate-job-description', { job_code: jobCode, student_email: email }, { headers: { Authorization: `Bearer ${token}` } });
+      await api.post('/jobs/generate-job-description', { job_code: jobCode, student_email: email }, { headers: { Authorization: `Bearer ${token}` } });
       setJobDescriptionStatus(prev => ({ ...prev, [jobCode]: 'ready' }));
     } catch (err) {
       console.error('Generation failed', err);
@@ -165,7 +165,7 @@ function ApplicantProfile() {
 
   const viewJobDescription = async (jobCode) => {
     try {
-      const resp = await api.get(`/job-description-html/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
+      const resp = await api.get(`/jobs/job-description-html/${jobCode}/${email}`, { headers: { Authorization: `Bearer ${token}` } });
       const newWindow = window.open('', '_blank');
       if (newWindow) {
         newWindow.document.write(resp.data);

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -510,7 +510,7 @@ if (shouldRedirect) {
 
     try {
       const resp = await api.post(
-        '/generate-resume',
+        '/jobs/generate-resume',
         {
           student_email: email,
           job_code: jobCode,
@@ -536,7 +536,7 @@ if (shouldRedirect) {
     setPreviewingResumes((prev) => ({ ...prev, [key]: true }));
     try {
       const resp = await api.post(
-        '/generate-resume',
+        '/jobs/generate-resume',
         { student_email: email, job_code: jobCode, preview: true },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -274,7 +274,7 @@ function StudentProfiles() {
 
   const fetchJobDescriptionStatus = async (studentEmail, jobCode) => {
     try {
-      const resp = await api.get(`/job-description/${jobCode}/${studentEmail}`, {
+      const resp = await api.get(`/jobs/job-description/${jobCode}/${studentEmail}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (resp.data.status === 'success') {
@@ -292,7 +292,7 @@ function StudentProfiles() {
     setLoadingJobDescriptions((prev) => ({ ...prev, [jobCode]: true }));
     try {
       await api.post(
-        '/generate-job-description',
+        '/jobs/generate-job-description',
         { job_code: jobCode, student_email: studentEmail },
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -310,7 +310,7 @@ function StudentProfiles() {
 
   const viewJobDescription = async (jobCode, studentEmail) => {
     try {
-      const resp = await api.get(`/job-description-html/${jobCode}/${studentEmail}`, {
+      const resp = await api.get(`/jobs/job-description-html/${jobCode}/${studentEmail}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const newWindow = window.open('', '_blank');


### PR DESCRIPTION
## Summary
- align frontend job description calls with backend `/jobs` prefix
- route resume generation through `/jobs/generate-resume`

## Testing
- `npm test -- --watchAll=false`
- `pytest` *(fails: assert 403 == 200, 13 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0e2d8e483338aa66e776ecbc1f4