### PR TITLE
Add jobs listing API with defaults

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -38,6 +38,9 @@ def create_job(job: dict, user: dict = Depends(get_current_user)) -> dict:
     data["job_code"] = code
     data.setdefault("assigned_students", [])
     data.setdefault("placed_students", [])
+    data.setdefault("rejected_students", [])
+    data.setdefault("student_notes", {})
+    data["posted_by"] = user.get("email")
     rl = data.get("required_license")
     if isinstance(rl, str):
         rl_clean = rl.strip()
@@ -55,6 +58,40 @@ def create_job(job: dict, user: dict = Depends(get_current_user)) -> dict:
     main.redis_client.set(f"job:{code}", json.dumps(data))
     logger.info("Job %s created", code)
     return {"message": "Job stored", "job_code": code}
+
+
+@router.get("")
+def list_jobs(_: dict = Depends(get_current_user)) -> dict:
+    """Return all stored jobs with sensible defaults.
+
+    Older job records may pre-date some of the fields added by the POST
+    handler (e.g. ``posted_by`` or ``student_notes``).  The front-end expects
+    these keys to exist, so we normalise each job before returning it.  Missing
+    ``job_code`` values are derived from the redis key.
+    """
+
+    jobs = []
+    for key in main.redis_client.scan_iter("job:*"):
+        k = key if isinstance(key, str) else key.decode()
+        raw = main.redis_client.get(k)
+        if not raw:
+            continue
+        try:
+            job = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error("Malformed job record for %s", k)
+            continue
+
+        if isinstance(job, dict):
+            job.setdefault("job_code", k.split("job:", 1)[1])
+            job.setdefault("posted_by", None)
+            job.setdefault("assigned_students", [])
+            job.setdefault("placed_students", [])
+            job.setdefault("rejected_students", [])
+            job.setdefault("student_notes", {})
+            jobs.append(job)
+
+    return {"jobs": jobs}
 
 
 @router.put("/{job_code}")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -60,6 +60,47 @@ def login_admin():
     return resp.json()["token"]
 
 
+def test_list_jobs():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    token = login_admin()
+    job = {
+        "job_title": "Test",
+        "job_description": "desc",
+        "desired_skills": [],
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "required_license": "lvn",
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    code = resp.json()["job_code"]
+    resp = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    jobs = resp.json().get("jobs", [])
+    assert any(j["job_code"] == code and j.get("posted_by") == "admin@example.com" for j in jobs)
+
+
+def test_list_jobs_includes_existing_records():
+    """Jobs created before new defaults should still be returned."""
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    # legacy job without defaults or job_code field
+    legacy = {"job_title": "Legacy", "job_description": "desc"}
+    main_app.redis_client.set("job:OLDCODE", json.dumps(legacy))
+
+    token = login_admin()
+    resp = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    jobs = resp.json().get("jobs", [])
+    legacy_job = next(j for j in jobs if j["job_code"] == "OLDCODE")
+    assert legacy_job["job_title"] == "Legacy"
+    assert legacy_job["student_notes"] == {}
+    assert legacy_job["assigned_students"] == []
+
+
 def test_create_job_and_match(monkeypatch):
     token = login_admin()
 


### PR DESCRIPTION
## Summary
- add GET /jobs endpoint
- normalise legacy job entries with default fields
- tests for listing and legacy support

## Testing
- `pytest tests/test_jobs.py::test_list_jobs -q`
- `pytest tests/test_jobs.py::test_list_jobs_includes_existing_records -q`
- `pytest -q` *(fails: multiple tests such as test_recruiter_cannot_modify_unowned_job)*

------
https://chatgpt.com/codex/tasks/task_e_68acc4ed74d08333a85267df764bf143