### PR TITLE
Add jobs listing API with matches

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -38,6 +38,10 @@ def create_job(job: dict, user: dict = Depends(get_current_user)) -> dict:
     data["job_code"] = code
     data.setdefault("assigned_students", [])
     data.setdefault("placed_students", [])
+    data.setdefault("rejected_students", [])
+    data.setdefault("uninterested_students", [])
+    data.setdefault("student_notes", {})
+    data["posted_by"] = user.get("email")
     rl = data.get("required_license")
     if isinstance(rl, str):
         rl_clean = rl.strip()
@@ -55,6 +59,48 @@ def create_job(job: dict, user: dict = Depends(get_current_user)) -> dict:
     main.redis_client.set(f"job:{code}", json.dumps(data))
     logger.info("Job %s created", code)
     return {"message": "Job stored", "job_code": code}
+
+
+@router.get("")
+def list_jobs(_: dict = Depends(get_current_user)) -> dict:
+    """Return all stored jobs with sensible defaults.
+
+    Older job records may pre-date some of the fields added by the POST
+    handler (e.g. ``posted_by`` or ``student_notes``).  The front-end expects
+    these keys to exist, so we normalise each job before returning it.  Missing
+    ``job_code`` values are derived from the redis key.
+    """
+
+    jobs = []
+    for key in main.redis_client.scan_iter("job:*"):
+        k = key if isinstance(key, str) else key.decode()
+        raw = main.redis_client.get(k)
+        if not raw:
+            continue
+        try:
+            job = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error("Malformed job record for %s", k)
+            continue
+
+        if isinstance(job, dict):
+            job.setdefault("job_code", k.split("job:", 1)[1])
+            job.setdefault("posted_by", None)
+            job.setdefault("assigned_students", [])
+            job.setdefault("placed_students", [])
+            job.setdefault("rejected_students", [])
+            job.setdefault("uninterested_students", [])
+            job.setdefault("student_notes", {})
+            code = job.get("job_code")
+            m_raw = main.redis_client.get(f"match_results:{code}")
+            try:
+                job["matches"] = json.loads(m_raw) if m_raw else []
+            except json.JSONDecodeError:
+                logger.error("Malformed match results for %s", code)
+                job["matches"] = []
+            jobs.append(job)
+
+    return {"jobs": jobs}
 
 
 @router.put("/{job_code}")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -60,6 +60,107 @@ def login_admin():
     return resp.json()["token"]
 
 
+def test_list_jobs():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    token = login_admin()
+    job = {
+        "job_title": "Test",
+        "job_description": "desc",
+        "desired_skills": [],
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "required_license": "lvn",
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    code = resp.json()["job_code"]
+    resp = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    jobs = resp.json().get("jobs", [])
+    assert any(j["job_code"] == code and j.get("posted_by") == "admin@example.com" for j in jobs)
+
+
+def test_list_jobs_includes_existing_records():
+    """Jobs created before new defaults should still be returned."""
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    # legacy job without defaults or job_code field
+    legacy = {"job_title": "Legacy", "job_description": "desc"}
+    main_app.redis_client.set("job:OLDCODE", json.dumps(legacy))
+
+    token = login_admin()
+    resp = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    jobs = resp.json().get("jobs", [])
+    legacy_job = next(j for j in jobs if j["job_code"] == "OLDCODE")
+    assert legacy_job["job_title"] == "Legacy"
+    assert legacy_job["student_notes"] == {}
+    assert legacy_job["assigned_students"] == []
+
+
+def test_list_jobs_includes_matches_and_assignments(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+    token = login_admin()
+
+    class FakeResp:
+        def __init__(self, emb):
+            self.data = [type("obj", (), {"embedding": emb})]
+
+    def fake_create(input, model):
+        if "python" in input:
+            return FakeResp([1.0, 0.0])
+        return FakeResp([0.0, 1.0])
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+    monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 0.0)
+
+    student = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john@example.com",
+        "phone": "123",
+        "license": "lvn",
+        "skills": ["python"],
+        "experience_summary": "sum",
+        "interests": "",
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 100.0,
+    }
+    client.post("/students", json=student, headers={"Authorization": f"Bearer {token}"})
+
+    job = {
+        "job_title": "Dev",
+        "job_description": "Need python",
+        "desired_skills": ["python"],
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "required_license": "lvn",
+    }
+    resp = client.post("/jobs", json=job, headers={"Authorization": f"Bearer {token}"})
+    code = resp.json()["job_code"]
+
+    client.post("/match", json={"job_code": code}, headers={"Authorization": f"Bearer {token}"})
+    client.post(
+        "/assign",
+        json={"job_code": code, "student_email": student["email"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    resp = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    job_entry = next(j for j in resp.json()["jobs"] if j["job_code"] == code)
+    assert student["email"] in job_entry["assigned_students"]
+    assert any(m["email"] == student["email"] for m in job_entry.get("matches", []))
+
+
 def test_create_job_and_match(monkeypatch):
     token = login_admin()
 


### PR DESCRIPTION
## Summary
- add GET /jobs endpoint
- normalise legacy job entries with default fields
- include match results and uninterested student lists in job listings
- tests for listing, legacy support, and match/assignment visibility

## Testing
- `pytest tests/test_jobs.py::test_list_jobs -q`
- `pytest tests/test_jobs.py::test_list_jobs_includes_existing_records -q`
- `pytest tests/test_jobs.py::test_list_jobs_includes_matches_and_assignments -q`
- `pytest tests/test_jobs.py::test_create_job_and_match -q`
- `pytest -q` *(fails: tests/test_jobs.py::test_match_filters_by_license, tests/test_jobs.py::test_recruiter_cannot_modify_unowned_job, tests/test_main.py::test_upload_students, tests/test_main.py::test_student_creation_records_metadata, tests/test_main.py::test_metrics_endpoint, tests/test_main.py::test_update_student, tests/test_main.py::test_generate_description, tests/test_main.py::test_notify_interest_generates_description, tests/test_main.py::test_notify_interest_multiple_times, tests/test_main.py::test_admin_weekly_summary, tests/test_main.py::test_match_metrics_increment, tests/test_main.py::test_student_endpoints_handle_string_notes, tests/test_main.py::test_malformed_user_skipped_in_listings)`


------
https://chatgpt.com/codex/tasks/task_e_68acc4ed74d08333a85267df764bf143