### PR TITLE
Link registrations to existing student profiles

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -613,7 +613,7 @@ def register(req: RegisterRequest):
     existing = find_user_key(email)
     if existing:
         raise HTTPException(status_code=400, detail="User already exists")
-
+    student_key_existing = resolve_student_key(email)
     key = user_key(email)
 
     if req.role in {"career", "recruiter"} and not req.institutional_code:
@@ -645,6 +645,31 @@ def register(req: RegisterRequest):
             }
         ),
     )
+    if student_key_existing:
+        raw = redis_client.get(student_key_existing)
+        try:
+            student = json.loads(raw) if raw else {}
+        except Exception:
+            student = {}
+        student["registered_by"] = key
+        redis_client.set(student_key_existing, json.dumps(student))
+        send_email(
+            email,
+            "Student profile claimed",
+            "Your account has been linked to an existing student profile.",
+        )
+        creator = student.get("created_by")
+        if creator and creator != email:
+            send_email(
+                creator,
+                "Student profile claimed",
+                f"{email} has claimed the student profile you created.",
+            )
+        logger.info(
+            "Linked user %s to existing student profile %s",
+            email,
+            student_key_existing,
+        )
     logger.info("POST /register success email=%s", email)
     return {"message": "Registration submitted. Awaiting admin approval"}
 
@@ -1045,7 +1070,17 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
 
     existing_key = resolve_student_key(student_data.email)
     if existing_key:
-        created_by_in_db = json.loads(redis_client.get(existing_key)).get("created_by")
+        stored = json.loads(redis_client.get(existing_key))
+        created_by_in_db = stored.get("created_by")
+        registered_by_in_db = stored.get("registered_by")
+        owner_key = user_key(owner) if owner else None
+        if owner in {created_by_in_db} or owner_key == registered_by_in_db:
+            logger.info(
+                "POST /students duplicate/self email=%s owner=%s",
+                student_data.email,
+                owner,
+            )
+            return {"message": "Student already exists", "student": stored}
         logger.warning(
             "POST /students duplicate/conflict email=%s owner=%s created_by_in_db=%s",
             student_data.email,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -153,6 +153,34 @@ def test_registration_flow():
     assert payload["role"] == "career"
 
 
+def test_register_links_existing_student():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    email = "stud@example.com"
+    profile = {
+        "email": email,
+        "student_id": "1",
+        "institution_code": "1001",
+        "created_by": "career@example.com",
+    }
+    main_app.persist_student_record(email, profile, "1001", "1")
+
+    user = {
+        "email": email,
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "school_code": "1001",
+        "password": "pw",
+        "role": "applicant",
+    }
+    resp = client.post("/register", json=user)
+    assert resp.status_code == 200
+    skey = main_app.resolve_student_key(email)
+    stored = json.loads(main_app.redis_client.get(skey))
+    assert stored.get("registered_by") == main_app.user_key(email)
+
+
 def test_non_admin_cannot_approve():
     main_app.redis_client.flushdb()
 
@@ -427,6 +455,72 @@ def test_student_creation_records_metadata(monkeypatch):
     assert stored2["city"] == "NewCity"
     assert stored2["created_by"] == "admin@example.com"
     assert stored2["created_at"] == stored["created_at"]
+
+
+def test_create_student_returns_existing_for_same_user(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    email = "stud@example.com"
+    profile = {
+        "email": email,
+        "student_id": "1",
+        "institution_code": "1001",
+        "created_by": "career@example.com",
+    }
+    main_app.persist_student_record(email, profile, "1001", "1")
+
+    user = {
+        "email": email,
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "password": "pw",
+        "role": "applicant",
+    }
+    client.post("/register", json=user)
+
+    key = main_app.user_key(email)
+    udata = json.loads(main_app.redis_client.get(key))
+    udata["approved"] = True
+    main_app.redis_client.set(key, json.dumps(udata))
+    login = client.post("/login", json={"email": email, "password": "pw"})
+    token = login.json()["token"]
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.0, 0.1]})]
+
+    def fake_create(input, model):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+    monkeypatch.setattr(main_app, "ensure_index", lambda dim: None)
+    monkeypatch.setattr(main_app, "rebuild_vector_index", lambda: None)
+    main_app.vector_index = None
+
+    body = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": email,
+        "phone": "123",
+        "license": "lvn",
+        "skills": [],
+        "experience_summary": "",
+        "interests": "",
+        "city": "Town",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10,
+    }
+    resp = client.post(
+        "/students",
+        json=body,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    returned = resp.json()["student"]
+    assert returned["email"] == email
 
 
 def test_metrics_endpoint():


### PR DESCRIPTION
## Summary
- Link new user registrations to pre-existing student profiles via `registered_by`
- Return existing student record when a registered user attempts to create a duplicate profile
- Add regression tests for profile linking and duplicate handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba0df0832483339ed216efeca44982