### PR TITLE
Add admin endpoint to clear student claims

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2700,6 +2700,32 @@ def reset_jobs(current_user: dict = Depends(get_current_user)):
     return {"message": f"Deleted {deleted} jobs and match data"}
 
 
+@app.delete("/admin/student-claims/{email}")
+def clear_student_claim(email: str, current_user: dict = Depends(get_current_user)):
+    """Clear the claimed_by field and related claim tokens for a student."""
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    email = normalize_email(email)
+    key = resolve_student_key(email)
+    if not key or not redis_client.exists(key):
+        raise HTTPException(status_code=404, detail="Student not found")
+
+    raw = redis_client.get(key)
+    student = json.loads(raw) if raw else {}
+    student.pop("claimed_by", None)
+    payload = json.dumps(student)
+    redis_client.set(key, payload)
+    redis_client.set(f"student:{email}", payload)
+
+    for token_key in redis_client.scan_iter("student_claim:*"):
+        k = token_key if isinstance(token_key, str) else token_key.decode()
+        val = redis_client.get(k)
+        if email in k or (isinstance(val, str) and normalize_email(val) == email):
+            redis_client.delete(k)
+
+    return {"message": f"Cleared claim for {email}"}
+
+
 @app.delete("/admin/delete-student/{email}")
 def delete_student(email: str, current_user: dict = Depends(get_current_user)):
     """Remove a student profile and any associated user record."""

--- a/tests/test_admin_student_claims.py
+++ b/tests/test_admin_student_claims.py
@@ -1,0 +1,87 @@
+import os
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("GOOGLE_KEY", "test")
+
+import json
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+from jose import jwt
+import app.main as main_app
+from app.main import app, JWT_SECRET, ALGORITHM
+
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def exists(self, key):
+        return key in self.store
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    def scan_iter(self, pattern="*"):
+        from fnmatch import fnmatch
+        for k in list(self.store.keys()):
+            if fnmatch(k, pattern):
+                yield k
+
+    def incr(self, key, amount=1):
+        val = int(self.store.get(key, 0)) + amount
+        self.store[key] = val
+        return val
+
+    def incrbyfloat(self, key, amount=1.0):
+        val = float(self.store.get(key, 0.0)) + amount
+        self.store[key] = val
+        return val
+
+    def mget(self, keys):
+        return [self.store.get(k) for k in keys]
+
+    def flushdb(self):
+        self.store.clear()
+
+
+main_app.redis_client = DummyRedis()
+client = TestClient(app)
+
+
+def _admin_header(email: str = "admin@example.com") -> dict:
+    token = jwt.encode(
+        {"sub": email, "role": "admin", "exp": datetime.utcnow() + timedelta(hours=1)},
+        JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_clear_student_claim():
+    main_app.redis_client.flushdb()
+    student = {
+        "email": "stu@example.com",
+        "student_id": "1",
+        "institutional_code": "1001",
+        "claimed_by": "claimer@example.com",
+    }
+    main_app.persist_student_record(student["email"], student, "1001", "1")
+    main_app.redis_client.set("student_claim:token1:stu@example.com", "stu@example.com")
+    main_app.redis_client.set("student_claim:token2:other@example.com", "other@example.com")
+
+    resp = client.delete("/admin/student-claims/stu@example.com", headers=_admin_header())
+    assert resp.status_code == 200
+
+    key = main_app.resolve_student_key("stu@example.com")
+    raw = main_app.redis_client.get(key)
+    data = json.loads(raw)
+    assert "claimed_by" not in data
+
+    assert not main_app.redis_client.exists("student_claim:token1:stu@example.com")
+    assert main_app.redis_client.exists("student_claim:token2:other@example.com")


### PR DESCRIPTION
## Summary
- allow admins to clear a student's `claimed_by` field and purge related `student_claim:*` tokens
- add regression test for clearing student claim

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1d4aa3e8833398d69241ad9d20ca