### PR TITLE
feat: support external job links

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator, HttpUrl
 from jose import jwt, JWTError
 import bcrypt
 for _p in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
@@ -39,6 +39,7 @@ from rq import Queue
 from html import unescape
 import random
 from zoneinfo import ZoneInfo
+from urllib.parse import urlparse
 from backend.app.schemas.resume import ResumeRequest
 from backend.app.schemas.description import DescriptionRequest
 from backend.app.services.resume import generate_resume_text
@@ -569,6 +570,7 @@ class JobRequest(BaseModel):
     desired_skills: list[str]
     job_code: Optional[str] = None
     source: str | None = None
+    external_apply_url: HttpUrl | None = None
     required_license: str | None = None
     min_pay: float
     max_pay: float
@@ -1381,6 +1383,9 @@ def create_job(job: JobRequest, current_user: dict = Depends(get_current_user)):
         if label:
             data["source"] = label.split("-", 1)[-1] if "-" in label else label
 
+    if data.get("external_apply_url") and not data.get("source"):
+        raise HTTPException(status_code=400, detail="Source required when external apply URL is provided")
+
     data["job_code"] = generated_code
     data["posted_by"] = user_email
     data["timestamp"] = datetime.now().isoformat()
@@ -1417,6 +1422,12 @@ def update_job(job_code: str, updated: dict, token_data: dict = Depends(get_curr
             raise HTTPException(status_code=400, detail="Invalid pay range")
     if "required_license" in updated:
         updated["required_license"] = license_to_code(updated["required_license"])
+    if "external_apply_url" in updated:
+        parsed = urlparse(updated["external_apply_url"])
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise HTTPException(status_code=400, detail="Invalid external_apply_url")
+        if not (updated.get("source") or job.get("source")):
+            raise HTTPException(status_code=400, detail="Source required when external_apply_url is provided")
     job.update(updated)
     redis_client.set(key, json.dumps(job))
     logger.info("✏️ Updated job %s", job_code)
@@ -2339,15 +2350,19 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
         if SITE_BASE_URL
         else f"/public/job-description-html/{job_code}/{student_email}"
     )
+    summary = (
+        f"Job: {job.get('job_title')} at {job.get('source', '')} in {job.get('city', '')}, {job.get('state', '')}"
+    )
+    external_url = job.get("external_apply_url")
     body = (
         f"Hello {first_name},\n\n"
-        "Your resume has been matched with a job and the recruiter has reviewed your resume.\n\n"
-        "You are receiving this email because the Recruiter would like to notify you that you are a match "
-        "and will be contacting you to discuss your resume.\n\n"
+        f"{summary}\n\n"
+        "Your resume has been matched with this job and the recruiter has reviewed your resume.\n\n"
         f"Please review the job description here: {public_url}\n\n"
-        "Good Luck!\n\n"
-        "Support Team @ TalentMatch-AI"
     )
+    if external_url:
+        body += f"You must apply using the following link: {external_url}\n\n"
+    body += "Good Luck!\n\nSupport Team @ TalentMatch-AI"
 
     send_email(
         student_email,
@@ -2532,7 +2547,14 @@ Output only valid HTML.
     if raw_content.endswith("```"):
         raw_content = raw_content.rsplit("```", 1)[0].strip()
 
-    details_html = """
+    link_html = ""
+    if job.get("external_apply_url"):
+        link_html = (
+            f"<p><strong>Click this link to apply on the employer's site:</strong> "
+            f"<a href='{job['external_apply_url']}' target='_blank' rel='noopener noreferrer'>Apply Here</a></p>"
+        )
+    details_html = (
+        """{link}
     <h2>Job Details</h2>
     <ul>
       <li><strong>Source:</strong> {source}</li>
@@ -2540,11 +2562,13 @@ Output only valid HTML.
       <li><strong>Location:</strong> {city}, {state}</li>
     </ul>
     """.format(
-        source=job.get("source", ""),
-        pay_min=job.get("min_pay", ""),
-        pay_max=job.get("max_pay", ""),
-        city=job.get("city", ""),
-        state=job.get("state", ""),
+            link=link_html,
+            source=job.get("source", ""),
+            pay_min=job.get("min_pay", ""),
+            pay_max=job.get("max_pay", ""),
+            city=job.get("city", ""),
+            state=job.get("state", ""),
+        )
     )
 
     full_html = f"""

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -14,6 +14,7 @@ function JobPosting() {
     desired_skills: '',
     required_license: '',
     source: '',
+    external_apply_url: '',
     min_pay: '',
     max_pay: '',
     city: '',
@@ -182,12 +183,19 @@ if (shouldRedirect) {
       if (!isRecruiter) {
         payload.source = formData.source;
       }
+      if (formData.external_apply_url) {
+        payload.external_apply_url = formData.external_apply_url;
+        if (!payload.source) {
+          setMessage('Source is required when providing an external apply URL');
+          return;
+        }
+      }
       const resp = await api.post('/jobs', payload, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setMessage(`Job posted successfully! Job code: ${resp.data.job_code}`);
       setFormData({
-        job_title: '', job_description: '', desired_skills: '', required_license: '', source: '', min_pay: '', max_pay: '', city: '', state: '', lat: '', lng: ''
+        job_title: '', job_description: '', desired_skills: '', required_license: '', source: '', external_apply_url: '', min_pay: '', max_pay: '', city: '', state: '', lat: '', lng: ''
       });
       fetchJobs();
     } catch (err) {
@@ -881,6 +889,18 @@ if (shouldRedirect) {
                   />
                 </div>
               )}
+              {!isRecruiter && (
+                <div className="form-field">
+                  <label htmlFor="external_apply_url">External Apply URL</label>
+                  <input
+                    id="external_apply_url"
+                    name="external_apply_url"
+                    type="text"
+                    value={formData.external_apply_url}
+                    onChange={handleChange}
+                  />
+                </div>
+              )}
               <div className="form-field">
                 <label htmlFor="min_pay">Minimum Pay</label>
                 <input
@@ -1152,6 +1172,28 @@ if (shouldRedirect) {
                                   }
                                 />
                               </div>
+                              {userRole === 'admin' && (
+                                <div className="form-row">
+                                  <label>External Apply URL</label>
+                                  <input
+                                    type="text"
+                                    value={
+                                      editedJobs[job.job_code]?.external_apply_url ||
+                                      job.external_apply_url ||
+                                      ''
+                                    }
+                                    onChange={(e) =>
+                                      setEditedJobs((prev) => ({
+                                        ...prev,
+                                        [job.job_code]: {
+                                          ...prev[job.job_code],
+                                          external_apply_url: e.target.value,
+                                        },
+                                      }))
+                                    }
+                                  />
+                                </div>
+                              )}
                               <div className="form-row">
                                 <label>Minimum Pay</label>
                                 <input
@@ -1201,6 +1243,11 @@ if (shouldRedirect) {
                                 <p>License: {licenseLabel(job.required_license)}</p>
                               )}
                               <p>Source: {job.source}</p>
+                              {job.external_apply_url && (
+                                <p>
+                                  External Apply: <a href={job.external_apply_url} target="_blank" rel="noopener noreferrer">Apply Here</a>
+                                </p>
+                              )}
                               <p>
                                 Pay Range: {job.min_pay} - {job.max_pay}
                               </p>


### PR DESCRIPTION
## Summary
- allow jobs to include an external apply URL and require a source
- expose external links in job notification emails and description pages
- add admin UI fields for external apply links when posting or editing jobs

## Testing
- `pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5655c348333958d729afd4ea93f