### PR TITLE
Serialize HttpUrl fields before storing jobs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1234,7 +1234,7 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
 
     student_id = generate_student_id()
 
-    data = student_data.model_dump()
+    data = student_data.model_dump(mode="json")
     data["embedding"] = embedding
     data["institution_code"] = institution_code
     data["institutional_code"] = institution_code
@@ -1291,7 +1291,7 @@ def update_student(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Embedding failed: {str(e)}")
 
-    data = updated.model_dump()
+    data = updated.model_dump(mode="json")
     data["email"] = email
     data["embedding"] = embedding
     inst_code = existing.get("institution_code") or existing.get("institutional_code") or existing.get("school_code")
@@ -1373,7 +1373,7 @@ def upload_students(file: UploadFile = File(...), current_user: dict = Depends(g
             continue
 
         student_id = generate_student_id()
-        data = student.model_dump()
+        data = student.model_dump(mode="json")
         data["embedding"] = embedding
         data["created_by"] = current_user.get("sub")
         data["created_at"] = datetime.now(timezone.utc).isoformat()
@@ -1399,7 +1399,7 @@ def create_job(job: JobRequest, current_user: dict = Depends(get_current_user)):
         generated_code = str(uuid.uuid4())[:8]
         key = f"job:{generated_code}"
 
-    data = job.model_dump()
+    data = job.model_dump(mode="json")
     data["required_license"] = license_to_code(data.get("required_license"))
     user_email = current_user.get("sub")
     user_role = current_user.get("role")

--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -41,6 +41,10 @@ function ApplicantProfile() {
       const ac = new window.google.maps.places.Autocomplete(cityRef.current, { types: ['(cities)'] });
       ac.addListener('place_changed', () => {
         const place = ac.getPlace();
+        if (!place.geometry || !place.geometry.location) {
+          console.warn('No geometry for selected place', place);
+          return;
+        }
         const comps = place.address_components || [];
         const city = comps.find(c => c.types.includes('locality'))?.long_name || '';
         const state = comps.find(c => c.types.includes('administrative_area_level_1'))?.short_name || '';

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -55,6 +55,10 @@ function JobPosting() {
       const ac = new window.google.maps.places.Autocomplete(locationRef.current, { types: ['(cities)'] });
       ac.addListener('place_changed', () => {
         const place = ac.getPlace();
+        if (!place.geometry || !place.geometry.location) {
+          console.warn('No geometry for selected place', place);
+          return;
+        }
         const comps = place.address_components || [];
         const city = comps.find(c => c.types.includes('locality'))?.long_name || '';
         const state = comps.find(c => c.types.includes('administrative_area_level_1'))?.short_name || '';

--- a/frontend/src/StudentForm.js
+++ b/frontend/src/StudentForm.js
@@ -35,6 +35,10 @@ function StudentForm({ title, initialData, licenses = [], onSubmit, onCancel, is
         const ac = new window.google.maps.places.Autocomplete(cityRef.current, { types: ['(cities)'] });
         ac.addListener('place_changed', () => {
           const place = ac.getPlace();
+          if (!place.geometry || !place.geometry.location) {
+            console.warn('No geometry for selected place', place);
+            return;
+          }
           const comps = place.address_components || [];
           const city = comps.find(c => c.types.includes('locality'))?.long_name || '';
           const state = comps.find(c => c.types.includes('administrative_area_level_1'))?.short_name || '';


### PR DESCRIPTION
## Summary
- ensure all Pydantic models are dumped in JSON mode before saving to Redis
- prevents `HttpUrl` serialization errors when creating jobs or students

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba73f172088333876a193aecda4b3a