### PR TITLE
Remove recruiter review reference from interest emails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2390,7 +2390,7 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
     body = (
         f"Hello {first_name},\n\n"
         f"{summary}\n\n"
-        "Your resume has been matched with this job and the recruiter has reviewed your resume.\n\n"
+        "Your resume has been matched with this job.\n\n"
         f"Please review the job description here: {public_url}\n\n"
     )
     if external_url:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -973,6 +973,8 @@ def test_notify_interest_generates_description(monkeypatch):
     assert "Good Luck" in sent.get("body")
     assert "/public/job-description-html/codei/stud@example.com" in sent.get("body")
     assert sent.get("attachments") is None
+    assert "Your resume has been matched with this job." in sent.get("body")
+    assert "recruiter has reviewed your resume" not in sent.get("body").lower()
 
 
 def test_notify_interest_multiple_times(monkeypatch):
@@ -1032,6 +1034,8 @@ def test_notify_interest_multiple_times(monkeypatch):
     assert resp1.status_code == 200
     assert resp2.status_code == 200
     assert len(bodies) == 2 and bodies[0] == bodies[1]
+    assert "Your resume has been matched with this job." in bodies[0]
+    assert "recruiter has reviewed your resume" not in bodies[0].lower()
     stored = main_app.redis_client.get("job_description:codei:stud@example.com")
     assert stored is not None and "done" in stored
 


### PR DESCRIPTION
## Summary
- simplify recruiter interest emails to only state the job match and share the description link
- adjust tests to check for the new phrasing

## Testing
- `pytest tests/test_main.py::test_notify_interest_generates_description tests/test_main.py::test_notify_interest_multiple_times -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d08b0388333870fdf5f904749ee