### PR TITLE
Skip AI summary for external job posts and add branding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2536,8 +2536,9 @@ def generate_job_description_html(job_code: str, student_email: str) -> tuple[st
 
     job = json.loads(job_raw)
     student = json.loads(student_raw)
-
-    prompt = f"""
+    raw_content = ""
+    if not job.get("external_apply_url"):
+        prompt = f"""
 You are generating a job description document for internal career services staff. The document should first summarize the position itself, then connect it with the student's background.
 
 Use the student profile and job information below to:
@@ -2567,18 +2568,18 @@ Pay Range: {job.get('min_pay', '')} - {job.get('max_pay', '')}
 Output only valid HTML.
 """
 
-    resp = client.chat.completions.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.5,
-    )
+        resp = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.5,
+        )
 
-    raw_content = resp.choices[0].message.content.strip()
+        raw_content = resp.choices[0].message.content.strip()
 
-    if raw_content.startswith("```html"):
-        raw_content = raw_content.replace("```html", "", 1).strip()
-    if raw_content.endswith("```"):
-        raw_content = raw_content.rsplit("```", 1)[0].strip()
+        if raw_content.startswith("```html"):
+            raw_content = raw_content.replace("```html", "", 1).strip()
+        if raw_content.endswith("```"):
+            raw_content = raw_content.rsplit("```", 1)[0].strip()
 
     details_html = (
         """
@@ -2652,6 +2653,7 @@ Output only valid HTML.
   </style>
 </head>
 <body>
+<h1>TalentMatch-AI</h1>
 {details_html}
 {apply_html}
 {description_html}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -877,6 +877,67 @@ def test_generate_job_description(monkeypatch):
     assert "Source:" in html_content
     assert "Pay Range:" in html_content
     assert "Location:" in html_content
+    assert "<h1>TalentMatch-AI</h1>" in html_content
+
+
+def test_generate_job_description_external(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stud",
+        "last_name": "S",
+        "skills": ["python"],
+        "email": "stud@example.com",
+        "institutional_code": "1001",
+        "student_id": "studext",
+    }
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+    main_app.redis_client.set(
+        "job:code_ext",
+        json.dumps(
+            {
+                "job_code": "code_ext",
+                "job_title": "Dev",
+                "job_description": "desc",
+                "desired_skills": ["python"],
+                "min_pay": 5.0,
+                "max_pay": 10.0,
+                "city": "Austin",
+                "state": "TX",
+                "source": "Indeed",
+                "external_apply_url": "https://example.com/apply",
+            }
+        ),
+    )
+
+    def fake_create(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("OpenAI should not be called for external jobs")
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+
+    login_resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
+    token = login_resp.json()["token"]
+
+    resp = client.post(
+        "/generate-job-description",
+        json={"student_email": "stud@example.com", "job_code": "code_ext"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    get_resp = client.get(
+        "/job-description/code_ext/stud@example.com",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert get_resp.status_code == 200
+    html_content = get_resp.json()["description"]
+    assert "<h1>TalentMatch-AI</h1>" in html_content
+    assert "Job Summary" not in html_content
+    assert "Apply Here" in html_content
 
 
 def test_job_description_html_route():


### PR DESCRIPTION
## Summary
- Skip OpenAI summary generation when a job includes an external apply URL
- Always add `<h1>TalentMatch-AI</h1>` to generated job descriptions
- Test coverage for external job descriptions without AI summary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e1738dc8333b0425f0ea09d81d4