### PR TITLE
Disable automatic match emails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1478,13 +1478,13 @@ def match_job(
         get_queue().enqueue(
             match_worker,
             req.job_code,
-            True,
+            False,
             enq_time,
             meta={"request_id": request.state.request_id},
         )
         return {"message": "Match job queued"}
     else:
-        matches = match_worker(req.job_code, True, enq_time)
+        matches = match_worker(req.job_code, False, enq_time)
         return {"matches": matches}
 
 
@@ -1510,13 +1510,14 @@ def rematch_job(
         return {"matches": matches}
 
 
-async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time: float | None = None):
+async def _perform_match_async(job_code: str, send_emails: bool = False, enq_time: float | None = None):
     key = f"job:{job_code}"
     raw = redis_client.get(key)
     if not raw:
         raise HTTPException(status_code=404, detail="Job not found")
     job = json.loads(raw)
     job.setdefault("uninterested_students", [])
+    was_matched_before = bool(redis_client.exists(f"match_results:{job_code}"))
 
     required_license = license_to_code(job.get("required_license"))
 
@@ -1709,10 +1710,10 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
             if matches
             else 0.0
         )
-        if send_emails:
-            redis_client.incr("metrics:total_matches")
-        else:
+        if was_matched_before:
             redis_client.incr("metrics:total_rematches")
+        else:
+            redis_client.incr("metrics:total_matches")
         redis_client.incrbyfloat("metrics:total_match_score", avg_score)
         redis_client.set(
             "metrics:last_match_timestamp", datetime.now().isoformat()
@@ -1723,12 +1724,12 @@ async def _perform_match_async(job_code: str, send_emails: bool = True, enq_time
     return top_matches
 
 
-def _perform_match(job_code: str, send_emails: bool = True, enq_time: float | None = None):
+def _perform_match(job_code: str, send_emails: bool = False, enq_time: float | None = None):
     """Synchronous wrapper for background execution."""
     return asyncio.run(_perform_match_async(job_code, send_emails, enq_time))
 
 
-def match_worker(job_code: str, send_emails: bool = True, enq_time: float | None = None):
+def match_worker(job_code: str, send_emails: bool = False, enq_time: float | None = None):
     start = datetime.now()
     if enq_time is not None:
         queue_time = start - datetime.fromtimestamp(enq_time)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2113,7 +2113,15 @@ def test_match_metrics_increment(monkeypatch):
     monkeypatch.setattr(main_app.client.embeddings, "create", lambda *a, **k: FakeResp())
     monkeypatch.setattr(main_app, "get_driving_distance_miles", lambda *a, **k: 1.0)
 
-    main_app.match_worker("abc", send_emails=False, enq_time=datetime.now().timestamp())
+    called = {}
+
+    def fake_send_email(*args, **kwargs):
+        called["count"] = called.get("count", 0) + 1
+
+    monkeypatch.setattr(main_app, "send_email", fake_send_email)
+
+    main_app.match_worker("abc", enq_time=datetime.now().timestamp())
+    assert called == {}
     process = float(main_app.redis_client.get("metrics:match_process_time") or 0)
     queue = float(main_app.redis_client.get("metrics:match_queue_time") or 0)
     assert process > 0


### PR DESCRIPTION
## Summary
- avoid sending emails during job matching by default
- gate candidate email notifications behind explicit flag
- track match vs rematch metrics independent of email sending

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb68e0604c8333885664748ed5d33c