### PR TITLE
Implement email open tracking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from fastapi import (
     UploadFile,
     File,
 )
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator, HttpUrl
 from jose import jwt, JWTError
@@ -31,6 +31,7 @@ for _p in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
 import httpx
 from openai import OpenAI
 import redis
+import base64
 import asyncio
 import re
 import numpy as np
@@ -270,12 +271,19 @@ def rebuild_vector_index() -> None:
 
 # Key used to store activity log entries
 ACTIVITY_LOG_KEY = "activity_logs"
+# Mapping of email tracking tokens to metadata
+EMAIL_OPEN_TOKENS_KEY = "email_open_tokens"
+# 1x1 transparent PNG
+TRANSPARENT_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAc8o/QkAAAAASUVORK5CYII="
+)
 
 def send_email(
     recipient: str,
     subject: str,
     body: str,
     attachments: list[tuple[str, bytes | str, str]] | None = None,
+    track_token: str | None = None,
 ) -> None:
     """Send an email with optional attachments if SMTP configuration is available."""
     if not SMTP_HOST or not EMAIL_SENDER:
@@ -286,7 +294,19 @@ def send_email(
         msg["From"] = EMAIL_SENDER
         msg["To"] = recipient
         msg["Subject"] = subject
+
+        html_body = body
+        if track_token:
+            pixel_url = (
+                f"{SITE_BASE_URL}/track/open/{track_token}.png"
+                if SITE_BASE_URL
+                else f"/track/open/{track_token}.png"
+            )
+            html_body += f"\n<img src=\"{pixel_url}\" width=\"1\" height=\"1\" />"
+
         msg.set_content(body)
+        if html_body != body:
+            msg.add_alternative(html_body, subtype="html")
 
         if attachments:
             for filename, content, mime in attachments:
@@ -449,6 +469,28 @@ app.add_middleware(
 @app.options("/{rest_of_path:path}")
 async def preflight_handler(rest_of_path: str):
     return {}
+
+@app.get("/track/open/{token}.png")
+def track_open(token: str):
+    """Log an email open event and return a 1x1 transparent PNG."""
+    info_raw = redis_client.hget(EMAIL_OPEN_TOKENS_KEY, token)
+    info: dict[str, str] = {}
+    if info_raw:
+        try:
+            info = json.loads(info_raw)
+        except Exception:
+            info = {}
+    log_entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": "email_open",
+        "token": token,
+        **info,
+    }
+    try:
+        redis_client.rpush(ACTIVITY_LOG_KEY, json.dumps(log_entry))
+    except Exception as e:
+        logger.error("Failed to log email open: %s", e)
+    return Response(content=TRANSPARENT_PNG, media_type="image/png")
 
 @app.get("/school-codes")
 def school_codes():
@@ -2397,11 +2439,20 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
     if external_url:
         body += f"You must apply using the following link: {external_url}\n\n"
     body += "Good Luck!\n\nSupport Team @ TalentMatch-AI"
-
+    token = str(uuid.uuid4())
+    try:
+        redis_client.hset(
+            EMAIL_OPEN_TOKENS_KEY,
+            token,
+            json.dumps({"student_email": student_email, "job_code": job_code}),
+        )
+    except Exception as e:
+        logger.error("Failed to store email open token: %s", e)
     send_email(
         student_email,
         f"Recruiter Interest: {job.get('job_title')}",
         body,
+        track_token=token,
     )
 
     return {"message": "Notification sent"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta
 class DummyRedis:
     def __init__(self):
         self.store = {}
+        self.hashes = {}
+        self.lists = {}
 
     def set(self, key, value):
         self.store[key] = value
@@ -49,6 +51,25 @@ class DummyRedis:
 
     def flushdb(self):
         self.store.clear()
+        self.hashes.clear()
+        self.lists.clear()
+
+    def hset(self, name, key, value):
+        self.hashes.setdefault(name, {})[key] = value
+
+    def hget(self, name, key):
+        return self.hashes.get(name, {}).get(key)
+
+    def rpush(self, name, value):
+        self.lists.setdefault(name, []).append(value)
+
+    def lindex(self, name, index):
+        lst = self.lists.get(name, [])
+        if index < 0:
+            index += len(lst)
+        if 0 <= index < len(lst):
+            return lst[index]
+        return None
 
 
 main_app.redis_client = DummyRedis()
@@ -979,7 +1000,7 @@ def test_public_job_description_html_route():
 
 
 def test_notify_interest_generates_description(monkeypatch):
-    main_app.redis_client.flushdb()
+    main_app.redis_client = DummyRedis()
     init_default_admin()
 
     student = {
@@ -1013,9 +1034,16 @@ def test_notify_interest_generates_description(monkeypatch):
 
     sent = {}
 
-    def fake_send(recipient, subject, body, attachments=None):
+    def fake_send(recipient, subject, body, attachments=None, track_token=None):
         sent['body'] = body
         sent['attachments'] = attachments
+        sent['token'] = track_token
+        pixel_url = (
+            f"{main_app.SITE_BASE_URL}/track/open/{track_token}.png"
+            if main_app.SITE_BASE_URL
+            else f"/track/open/{track_token}.png"
+        )
+        sent['final_body'] = body + (f'<img src="{pixel_url}" width="1" height="1" />' if track_token else '')
 
     monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
     monkeypatch.setattr(main_app, "send_email", fake_send)
@@ -1031,6 +1059,11 @@ def test_notify_interest_generates_description(monkeypatch):
     stored = main_app.redis_client.get("job_description:codei:stud@example.com")
     assert stored is not None and "done" in stored
     assert main_app.redis_client.get("jobdesc:codei:stud@example.com") == stored
+    token_val = sent.get("token")
+    assert token_val
+    mapping = main_app.redis_client.hget(main_app.EMAIL_OPEN_TOKENS_KEY, token_val)
+    assert mapping is not None
+    assert f"/track/open/{token_val}.png" in sent.get("final_body")
     assert "Good Luck" in sent.get("body")
     assert "/public/job-description-html/codei/stud@example.com" in sent.get("body")
     assert sent.get("attachments") is None
@@ -1039,7 +1072,7 @@ def test_notify_interest_generates_description(monkeypatch):
 
 
 def test_notify_interest_multiple_times(monkeypatch):
-    main_app.redis_client.flushdb()
+    main_app.redis_client = DummyRedis()
     init_default_admin()
 
     student = {
@@ -1073,8 +1106,8 @@ def test_notify_interest_multiple_times(monkeypatch):
 
     bodies = []
 
-    def fake_send(recipient, subject, body, attachments=None):
-        bodies.append(body)
+    def fake_send(recipient, subject, body, attachments=None, track_token=None):
+        bodies.append((body, track_token))
 
     monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
     monkeypatch.setattr(main_app, "send_email", fake_send)
@@ -1094,11 +1127,75 @@ def test_notify_interest_multiple_times(monkeypatch):
 
     assert resp1.status_code == 200
     assert resp2.status_code == 200
-    assert len(bodies) == 2 and bodies[0] == bodies[1]
-    assert "Your resume has been matched with this job." in bodies[0]
-    assert "recruiter has reviewed your resume" not in bodies[0].lower()
+    assert len(bodies) == 2
+    assert bodies[0][0] == bodies[1][0]
+    assert bodies[0][1] != bodies[1][1]
+    assert "Your resume has been matched with this job." in bodies[0][0]
+    assert "recruiter has reviewed your resume" not in bodies[0][0].lower()
     stored = main_app.redis_client.get("job_description:codei:stud@example.com")
     assert stored is not None and "done" in stored
+
+
+def test_track_open_logs_event(monkeypatch):
+    main_app.redis_client = DummyRedis()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stud",
+        "last_name": "S",
+        "skills": ["python"],
+        "email": "stud@example.com",
+        "institutional_code": "1001",
+        "student_id": "stud7",
+    }
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+    main_app.redis_client.set(
+        "job:codei",
+        json.dumps({
+            "job_code": "codei",
+            "job_title": "Dev",
+            "job_description": "desc",
+            "desired_skills": ["python"],
+            "assigned_students": ["stud@example.com"],
+        }),
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "done"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    sent = {}
+
+    def fake_send(recipient, subject, body, attachments=None, track_token=None):
+        sent["token"] = track_token
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(main_app, "send_email", fake_send)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/notify-interest",
+        json={"student_email": "stud@example.com", "job_code": "codei"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    tok = sent["token"]
+    resp2 = client.get(f"/track/open/{tok}.png")
+    assert resp2.status_code == 200
+    assert resp2.headers["content-type"] == "image/png"
+    assert resp2.content == main_app.TRANSPARENT_PNG
+    entry_raw = main_app.redis_client.lindex(main_app.ACTIVITY_LOG_KEY, -2)
+    entry = json.loads(entry_raw)
+    assert entry["event"] == "email_open"
+    assert entry["token"] == tok
+    assert entry["student_email"] == "stud@example.com"
+    assert entry["job_code"] == "codei"
 
 
 def test_generate_resume_html(monkeypatch):
@@ -1975,7 +2072,7 @@ def test_admin_test_notification(monkeypatch):
 
     sent = {}
 
-    def fake_send_email(recipient, subject, body):
+    def fake_send_email(recipient, subject, body, attachments=None, track_token=None):
         sent["recipient"] = recipient
         sent["subject"] = subject
         sent["body"] = body

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -63,7 +63,7 @@ def test_admin_weekly_summary():
 
     sent = {}
 
-    def fake_send_email(to, subject, body):
+    def fake_send_email(to, subject, body, attachments=None, track_token=None):
         sent["to"] = to
         sent["subject"] = subject
         sent["body"] = body


### PR DESCRIPTION
## Summary
- add `/track/open/{token}.png` endpoint logging `email_open` events
- generate tracking tokens for `/notify-interest` emails and store metadata
- embed tracking pixel in emails via updated `send_email`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a3e07cc833397822c7d9adefaaf