### PR TITLE
Add click tracking for notify-interest emails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from fastapi import (
     UploadFile,
     File,
 )
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, Response, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator, HttpUrl
 from jose import jwt, JWTError
@@ -491,6 +491,32 @@ def track_open(token: str):
     except Exception as e:
         logger.error("Failed to log email open: %s", e)
     return Response(content=TRANSPARENT_PNG, media_type="image/png")
+
+
+@app.get("/track/click/{token}")
+def track_click(token: str):
+    """Redirect to the external URL while logging an email click event."""
+    info_raw = redis_client.hget(EMAIL_OPEN_TOKENS_KEY, token)
+    info: dict[str, str] = {}
+    if info_raw:
+        try:
+            info = json.loads(info_raw)
+        except Exception:
+            info = {}
+    external_url = info.get("external_url")
+    if not external_url:
+        raise HTTPException(status_code=404, detail="Unknown token")
+    log_entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": "email_click",
+        "token": token,
+        **info,
+    }
+    try:
+        redis_client.rpush(ACTIVITY_LOG_KEY, json.dumps(log_entry))
+    except Exception as e:
+        logger.error("Failed to log email click: %s", e)
+    return RedirectResponse(url=external_url)
 
 @app.get("/school-codes")
 def school_codes():
@@ -2429,6 +2455,7 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
     summary = (
         f"Job: {job.get('job_title')} at {job.get('source', '')} in {job.get('city', '')}, {job.get('state', '')}"
     )
+    token = str(uuid.uuid4())
     external_url = job.get("external_apply_url")
     body = (
         f"Hello {first_name},\n\n"
@@ -2437,14 +2464,24 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
         f"Please review the job description here: {public_url}\n\n"
     )
     if external_url:
-        body += f"You must apply using the following link: {external_url}\n\n"
+        click_url = (
+            f"{SITE_BASE_URL}/track/click/{token}"
+            if SITE_BASE_URL
+            else f"/track/click/{token}"
+        )
+        body += f"You must apply using the following link: {click_url}\n\n"
     body += "Good Luck!\n\nSupport Team @ TalentMatch-AI"
-    token = str(uuid.uuid4())
     try:
         redis_client.hset(
             EMAIL_OPEN_TOKENS_KEY,
             token,
-            json.dumps({"student_email": student_email, "job_code": job_code}),
+            json.dumps(
+                {
+                    "student_email": student_email,
+                    "job_code": job_code,
+                    "external_url": external_url,
+                }
+            ),
         )
     except Exception as e:
         logger.error("Failed to store email open token: %s", e)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1022,6 +1022,7 @@ def test_notify_interest_generates_description(monkeypatch):
             "job_description": "desc",
             "desired_skills": ["python"],
             "assigned_students": ["stud@example.com"],
+            "external_apply_url": "https://example.com/apply",
         })
     )
 
@@ -1057,18 +1058,36 @@ def test_notify_interest_generates_description(monkeypatch):
     )
     assert resp.status_code == 200
     stored = main_app.redis_client.get("job_description:codei:stud@example.com")
-    assert stored is not None and "done" in stored
+    assert stored is not None
+    assert "Apply Here" in stored
     assert main_app.redis_client.get("jobdesc:codei:stud@example.com") == stored
     token_val = sent.get("token")
     assert token_val
-    mapping = main_app.redis_client.hget(main_app.EMAIL_OPEN_TOKENS_KEY, token_val)
-    assert mapping is not None
+    mapping_raw = main_app.redis_client.hget(main_app.EMAIL_OPEN_TOKENS_KEY, token_val)
+    assert mapping_raw is not None
+    mapping = json.loads(mapping_raw)
+    assert mapping.get("external_url") == "https://example.com/apply"
+    click_url = f"/track/click/{token_val}"
+    if main_app.SITE_BASE_URL:
+        click_url = f"{main_app.SITE_BASE_URL}{click_url}"
+    assert click_url in sent.get("body")
+    assert "https://example.com/apply" not in sent.get("body")
     assert f"/track/open/{token_val}.png" in sent.get("final_body")
     assert "Good Luck" in sent.get("body")
     assert "/public/job-description-html/codei/stud@example.com" in sent.get("body")
     assert sent.get("attachments") is None
     assert "Your resume has been matched with this job." in sent.get("body")
     assert "recruiter has reviewed your resume" not in sent.get("body").lower()
+
+    # Verify click tracking redirects and logs
+    resp_click = client.get(f"/track/click/{token_val}", follow_redirects=False)
+    assert resp_click.status_code in (302, 307)
+    assert resp_click.headers.get("location") == "https://example.com/apply"
+    log_raw = main_app.redis_client.lindex(main_app.ACTIVITY_LOG_KEY, -2)
+    assert log_raw is not None
+    log = json.loads(log_raw)
+    assert log.get("event") == "email_click"
+    assert log.get("token") == token_val
 
 
 def test_notify_interest_multiple_times(monkeypatch):


### PR DESCRIPTION
## Summary
- Add `/track/click/{token}` endpoint that redirects to external job link and logs `email_click`
- Replace external apply URLs in notify-interest emails with tracked links and store mapping
- Extend tests to cover click tracking redirect and logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8f1aa19c8333ad642de6da379cd5