### PR TITLE
Fix popover handling in StudentProfiles

### DIFF
--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -100,16 +100,17 @@ function StudentProfiles() {
     return Array.from(map.values());
   };
 
-  const showTrackingPopover = (job, event) => {
-    const rect = event.currentTarget.getBoundingClientRect();
+  const showTrackingPopover = (job, targetEl) => {
+    const rect = targetEl.getBoundingClientRect();
     setHoveredJob({ job, position: { top: rect.bottom, left: rect.left } });
   };
 
   const handleJobEnter = (job, event) => {
     if ('ontouchstart' in window) return;
+    const targetEl = event.currentTarget;
     clearTimeout(hoverTimer.current);
     hoverTimer.current = setTimeout(
-      () => showTrackingPopover(job, event),
+      () => showTrackingPopover(job, targetEl),
       3000
     );
   };
@@ -125,7 +126,7 @@ function StudentProfiles() {
     if (hoveredJob && hoveredJob.job.job_code === job.job_code) {
       setHoveredJob(null);
     } else {
-      showTrackingPopover(job, event);
+      showTrackingPopover(job, event.currentTarget);
     }
   };
 


### PR DESCRIPTION
## Summary
- Accept DOM element in `showTrackingPopover` instead of event
- Store `event.currentTarget` before timeout in `handleJobEnter`
- Pass `event.currentTarget` to `showTrackingPopover` in `handleJobClick`

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc5422727883338154770898549a29