### PR TITLE
Add resend job description option for recruiters

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -734,10 +734,16 @@ if (shouldRedirect) {
                 <span className="badge assigned inline">Assigned</span>
               </td>
               <td>
-                {isRecruiter && (
-                  <button onClick={() => notifyInterest(job.job_code, row.email)}>Notify Candidate</button>
-                )}
-                {!isRecruiter && (
+                {isRecruiter ? (
+                  <>
+                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                      Notify Candidate
+                    </button>
+                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                      Resend Job Description
+                    </button>
+                  </>
+                ) : (
                   <button onClick={() => handlePlace(job, row)}>Place</button>
                 )}
                 <button onClick={() => rejectAssigned(job.job_code, row.email)}>


### PR DESCRIPTION
## Summary
- Add "Resend Job Description" button for assigned candidates so recruiters can resend emails
- Confirm `/notify-interest` endpoint already sends email on each call without restrictions

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bfab11c0688333828eb61f2499b2bb