### PR TITLE
Allow admins to resend job descriptions

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -744,7 +744,12 @@ if (shouldRedirect) {
                     </button>
                   </>
                 ) : (
-                  <button onClick={() => handlePlace(job, row)}>Place</button>
+                  <>
+                    <button onClick={() => handlePlace(job, row)}>Place</button>
+                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                      Resend Job Description
+                    </button>
+                  </>
                 )}
                 <button onClick={() => rejectAssigned(job.job_code, row.email)}>
                   Not Interested


### PR DESCRIPTION
## Summary
- Let admins resend job descriptions from the assigned candidates list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb767803c8333bfcd3458a2a1e0ed