### PR TITLE
Track student profile load times

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -273,6 +273,8 @@ def rebuild_vector_index() -> None:
 ACTIVITY_LOG_KEY = "activity_logs"
 # Mapping of email tracking tokens to metadata
 EMAIL_OPEN_TOKENS_KEY = "email_open_tokens"
+# List key for student load time metrics
+STUDENT_LOAD_TIME_KEY = "metrics:student_load_time"
 # 1x1 transparent PNG
 TRANSPARENT_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAc8o/QkAAAAASUVORK5CYII="
@@ -1913,6 +1915,27 @@ def delete_job(job_code: str, token_data: dict = Depends(get_current_user)):
     redis_client.delete(match_key)
 
     return {"message": f"Job {job_code} deleted successfully"}
+
+
+class StudentLoadTimeMetric(BaseModel):
+    role: str
+    duration: float
+
+
+@app.post("/metrics/student-load-time")
+def record_student_load_time(
+    metric: StudentLoadTimeMetric, current_user: dict = Depends(get_current_user)
+):
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "role": metric.role,
+        "duration": metric.duration,
+    }
+    try:
+        redis_client.rpush(STUDENT_LOAD_TIME_KEY, json.dumps(entry))
+    except Exception as e:
+        logger.error("Failed to record student load time metric: %s", e)
+    return {"status": "ok"}
 
 
 @app.get("/metrics")

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -183,8 +183,12 @@ function StudentProfiles() {
 
   const fetchStudents = async () => {
     setIsLoading(true);
+    const start = performance.now();
     try {
-      const endpoint = userRole === 'admin' || userRole === 'junior_admin' ? '/students/all' : '/students/by-school';
+      const endpoint =
+        userRole === 'admin' || userRole === 'junior_admin'
+          ? '/students/all'
+          : '/students/by-school';
       const resp = await api.get(endpoint, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -200,6 +204,16 @@ function StudentProfiles() {
         setTimeout(() => setToast(''), 3000);
       }
     } finally {
+      const duration = performance.now() - start;
+      try {
+        await api.post(
+          '/metrics/student-load-time',
+          { role: decoded.role, duration },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+      } catch (e) {
+        console.error('Failed to record student load time', e);
+      }
       setIsLoading(false);
     }
   };

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -618,6 +618,32 @@ def test_metrics_endpoint():
     assert data["rematch_rate"] == 0.5
 
 
+def test_student_load_time_metric():
+    main_app.redis_client = DummyRedis()
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    )
+    token = login_resp.json()["token"]
+
+    resp = client.post(
+        "/metrics/student-load-time",
+        json={"role": "admin", "duration": 123.4},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    if hasattr(main_app.redis_client, "lrange"):
+        entries = main_app.redis_client.lrange("metrics:student_load_time", 0, -1) or []
+    else:
+        entries = main_app.redis_client.lists.get("metrics:student_load_time", [])
+    assert len(entries) == 1
+    record = json.loads(entries[0])
+    assert record["role"] == "admin"
+    assert record["duration"] == 123.4
+
+
 def test_admin_reset_jobs():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- measure time to load students in frontend and send to backend metrics endpoint
- add POST `/metrics/student-load-time` to log duration with user role
- persist metrics in Redis and add regression test

## Testing
- `npm install`
- `CI=true npm test`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02e2bddd08333a138659d33a649bc