### PR TITLE
Parse benefits section from job descriptions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2644,6 +2644,46 @@ def generate_description(req: DescriptionRequest, current_user: dict = Depends(g
     return {"status": "success", "description": generated_desc}
 
 
+def extract_benefits(job_desc: str) -> tuple[list[str], str]:
+    """Split an Indeed-style description into benefits and the remaining text.
+
+    Returns a tuple of (benefits_list, remaining_description).
+    If no benefits section is detected, the first element is an empty list and
+    the original description is returned unchanged.
+    """
+
+    lines = [line.strip() for line in job_desc.splitlines()]
+    if not lines:
+        return [], ""
+
+    idx = 0
+    # Look for the "Benefits" heading at the very start
+    if lines[idx].lower() != "benefits":
+        return [], job_desc.strip()
+
+    idx += 1
+    if idx < len(lines) and lines[idx].lower().startswith("pulled from"):
+        idx += 1
+
+    benefits: list[str] = []
+    while idx < len(lines):
+        line = lines[idx].strip()
+        low = line.lower()
+        if not line or low.startswith("full job description"):
+            break
+        benefits.append(line)
+        idx += 1
+
+    # Skip to the actual description after the "Full job description" marker
+    while idx < len(lines) and not lines[idx].strip():
+        idx += 1
+    if idx < len(lines) and lines[idx].lower().startswith("full job description"):
+        idx += 1
+
+    remaining = "\n".join(lines[idx:]).strip()
+    return benefits, remaining
+
+
 def generate_job_description_html(job_code: str, student_email: str) -> tuple[str, bool]:
     """Create or fetch an HTML job description for a student."""
     student_email = normalize_email(student_email)
@@ -2732,10 +2772,20 @@ Output only valid HTML.
             f"<a href='{job['external_apply_url']}' target='_blank' rel='noopener noreferrer'>Apply Here</a></p>"
         )
 
+    benefits_html = ""
     description_html = ""
     job_desc = job.get("job_description", "")
     if job_desc:
-        lines = [line.strip() for line in job_desc.splitlines()]
+        benefits, desc_text = extract_benefits(job_desc)
+        if benefits:
+            items = "\n".join(f"<li>{escape(b)}</li>" for b in benefits)
+            benefits_html = (
+                "<h2>Benefits</h2>\n"
+                "<p>Pulled from the full job description</p>\n"
+                f"<ul>\n{items}\n</ul>"
+            )
+
+        lines = [line.strip() for line in desc_text.splitlines()]
         formatted: list[str] = []
         in_list = False
         for line in lines:
@@ -2783,6 +2833,7 @@ Output only valid HTML.
 <h1>TalentMatch-AI</h1>
 {details_html}
 {apply_html}
+{benefits_html}
 {description_html}
 {raw_content}
 </body>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -956,6 +956,83 @@ def test_generate_job_description(monkeypatch):
     assert "<h1>TalentMatch-AI</h1>" in html_content
 
 
+def test_generate_job_description_with_benefits(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stud",
+        "last_name": "S",
+        "skills": ["python"],
+        "email": "stud@example.com",
+        "institutional_code": "1001",
+        "student_id": "stud4",
+    }
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+
+    job_desc = (
+        "Benefits\nPulled from the full job description\nReferral program\n403(b)\n\n"
+        "Full job description\nHIRING NOW!"
+    )
+    main_app.redis_client.set(
+        "job:code3",
+        json.dumps(
+            {
+                "job_code": "code3",
+                "job_title": "Dev",
+                "job_description": job_desc,
+                "desired_skills": ["python"],
+                "min_pay": 5.0,
+                "max_pay": 10.0,
+                "city": "Austin",
+                "state": "TX",
+                "source": "Indeed",
+            }
+        ),
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [
+                type(
+                    "obj",
+                    (),
+                    {
+                        "message": type(
+                            "obj",
+                            (),
+                            {
+                                "content": "<h2>Job Summary</h2><p>done</p><h2>Interview Preparation Tips</h2><p>tips</p>",
+                            },
+                        )
+                    },
+                )
+            ]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+
+    login_resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
+    token = login_resp.json()["token"]
+
+    resp = client.post(
+        "/generate-job-description",
+        json={"student_email": "stud@example.com", "job_code": "code3"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    html = main_app.redis_client.get("jobdesc:code3:stud@example.com")
+    assert "<h2>Benefits</h2>" in html
+    assert "Referral program" in html
+    assert "<h2>Full Job Description</h2>" in html
+
+
 def test_generate_job_description_external(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- extract and split Benefits from Indeed-style job descriptions
- render Benefits section in generated job description HTML output
- add regression test ensuring benefits are included in rendered HTML

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c034187f148333b17b80296682bb5a