### PR TITLE
Remove full job descriptions from AI-generated summaries

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2709,11 +2709,11 @@ You are generating a job description document for internal career services staff
 
 Use the student profile and job information below to:
 
-- Provide an **AI-Generated Job Summary** that paraphrases the job description to avoid copying text verbatim.
+- Provide a **Job Summary** that summarizes the job description to avoid copying it verbatim.
 - Describe **key responsibilities** they might undertake as noted in the job description.
 - List **areas of strength** with plenty of details to reinforce existing experience and how it connects with the job description, and potential **areas for growth** with plenty of insightful and targeted recommendations for training that will improve the probability of success.
 - Mention **school affiliation** and any relevant compliance or readiness info.
-- Offer **Interview Preparation Tips** with real, actionable advice for succeeding in an interview for this role.
+- Offer **Interview Preparation Tips** with real, actionable advice for succeeding in an interview for this role. Include guidance for new graduates on addressing questions when they lack the required experience, such as drawing on academic projects, internships, or other relevant experiences.
 
 Format this as a printable HTML document titled "TalentMatch AI", styled professionally but without producing binary output.
 
@@ -2773,39 +2773,15 @@ Output only valid HTML.
         )
 
     benefits_html = ""
-    description_html = ""
     job_desc = job.get("job_description", "")
     if job_desc:
-        benefits, desc_text = extract_benefits(job_desc)
+        benefits, _ = extract_benefits(job_desc)
         if benefits:
             items = "\n".join(f"<li>{escape(b)}</li>" for b in benefits)
             benefits_html = (
                 "<h2>Benefits</h2>\n"
-                "<p>Pulled from the full job description</p>\n"
                 f"<ul>\n{items}\n</ul>"
             )
-
-        lines = [line.strip() for line in desc_text.splitlines()]
-        formatted: list[str] = []
-        in_list = False
-        for line in lines:
-            if line.startswith(("- ", "* ", "• ")):
-                if not in_list:
-                    formatted.append("<ul>")
-                    in_list = True
-                formatted.append(f"<li>{escape(line[2:].strip())}</li>")
-            elif line:
-                if in_list:
-                    formatted.append("</ul>")
-                    in_list = False
-                formatted.append(f"<p>{escape(line)}</p>")
-            else:
-                if in_list:
-                    formatted.append("</ul>")
-                    in_list = False
-        if in_list:
-            formatted.append("</ul>")
-        description_html = "<h2>Full Job Description</h2>\n" + "\n".join(formatted)
 
     full_html = f"""
 <!DOCTYPE html>
@@ -2834,7 +2810,6 @@ Output only valid HTML.
 {details_html}
 {apply_html}
 {benefits_html}
-{description_html}
 {raw_content}
 </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1030,7 +1030,7 @@ def test_generate_job_description_with_benefits(monkeypatch):
     html = main_app.redis_client.get("jobdesc:code3:stud@example.com")
     assert "<h2>Benefits</h2>" in html
     assert "Referral program" in html
-    assert "<h2>Full Job Description</h2>" in html
+    assert "<h2>Full Job Description</h2>" not in html
 
 
 def test_generate_job_description_external(monkeypatch):


### PR DESCRIPTION
## Summary
- Rename AI-generated summary section to "Job Summary" and tailor interview tips for new graduates
- Drop full job descriptions from generated HTML while preserving benefits list
- Update tests for new job description output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f6ce25288333af140389484de3e4