### PR TITLE
fix: wrap and align job titles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -258,6 +258,15 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  table-layout: fixed;
+}
+
+.job-subtable th:first-child,
+.job-subtable td:first-child {
+  max-width: 220px;
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
 }
 
 /* Smooth slide animation for job rows */


### PR DESCRIPTION
## Summary
- prevent overflow by fixing job subtable layout and wrapping long job titles
- left-align job titles for easier reading

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c107677b4883338cac0b7c4f89f56e