### PR TITLE
fix: shrink job row font and allow wrapping

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -258,6 +258,15 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  table-layout: fixed;
+}
+
+.job-subtable th:first-child,
+.job-subtable td:first-child {
+  max-width: 220px;
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
 }
 
 /* Smooth slide animation for job rows */
@@ -350,6 +359,7 @@
   background-color: white;
   color: black;
   text-align: center;
+  font-size: 0.9rem;
 }
 
 .no-jobs-row td {


### PR DESCRIPTION
## Summary
- keep job subtable layout fixed for uniform columns
- allow wrapping job titles and break long words
- shrink job row font size for tighter layout

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c107677b4883338cac0b7c4f89f56e