### PR TITLE
fix: prevent job row text wrapping

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -258,6 +258,28 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5rem;
+  table-layout: fixed;
+}
+
+.job-subtable th:first-child,
+.job-subtable td:first-child {
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.job-subtable th:nth-child(2),
+.job-subtable td:nth-child(2) {
+  width: 100px;
+  white-space: nowrap;
+}
+
+.job-subtable th:nth-child(5),
+.job-subtable td:nth-child(5) {
+  width: 100px;
+  white-space: nowrap;
 }
 
 /* Smooth slide animation for job rows */
@@ -284,7 +306,7 @@
 }
 
 .job-subrow.open .job-subrow-content {
-  max-height: 500px;
+  max-height: none;
   opacity: 1;
 }
 
@@ -350,6 +372,25 @@
   background-color: white;
   color: black;
   text-align: center;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.job-action-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+  width: 160px;
+  box-sizing: border-box;
+}
+
+.job-action-btn + .job-action-btn {
+  margin-left: 0.5rem;
 }
 
 .no-jobs-row td {
@@ -371,16 +412,6 @@
 .desc-button:hover {
   background-color: #005fa3;
 }
-
-.view-btn {
-  background: white;
-  border: 1px solid #ccc;
-  padding: 6px 10px;
-  cursor: pointer;
-  border-radius: 4px;
-  font-size: 0.85rem;
-}
-
 
 /* Ensure the students table sits directly under the tab bar */
 .students-panel {

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -817,52 +817,29 @@ function StudentProfiles() {
                                             : 'N/A'}
                                         </td>
                                         <td>{job.source || 'N/A'}</td>
-                                        <td style={{ textAlign: 'center' }}>
+                                        <td>
                                           {loadingJobDescriptions[job.job_code] ? (
                                             <span>Generating...</span>
                                           ) : (
                                             <>
                                               {jobDescriptionStatus[job.job_code] === 'ready' ? (
                                                 <button
-                                                  style={{
-                                                    padding: '4px 10px',
-                                                    fontSize: '14px',
-                                                    border: '1px solid #ccc',
-                                                    borderRadius: '4px',
-                                                    backgroundColor: '#f5f5f5',
-                                                    cursor: 'pointer'
-                                                  }}
                                                   onClick={() => viewJobDescription(job.job_code, s.email)}
-                                                  className="view-btn"
+                                                  className="job-action-btn"
                                                 >
                                                   View Job Description
                                                 </button>
                                               ) : (
                                                 <button
-                                                  style={{
-                                                    padding: '4px 10px',
-                                                    fontSize: '14px',
-                                                    border: '1px solid #ccc',
-                                                    borderRadius: '4px',
-                                                    backgroundColor: '#f5f5f5',
-                                                    cursor: 'pointer'
-                                                  }}
                                                   onClick={() => handleGenerateJobDescription(job.job_code, s.email)}
+                                                  className="job-action-btn"
                                                 >
                                                   Load Job Description
                                                 </button>
                                               )}
                                               <button
-                                                style={{
-                                                  padding: '4px 10px',
-                                                  fontSize: '14px',
-                                                  border: '1px solid #ccc',
-                                                  borderRadius: '4px',
-                                                  backgroundColor: '#f5f5f5',
-                                                  cursor: 'pointer',
-                                                  marginLeft: '8px'
-                                                }}
                                                 onClick={() => resendJobDescription(job.job_code, s.email)}
+                                                className="job-action-btn"
                                               >
                                                 Resend Job Description
                                               </button>


### PR DESCRIPTION
## Summary
- keep job subtable layout fixed for uniform columns
- truncate long job titles with ellipsis to avoid wrapping
- shrink job row font size for tighter layout
- narrow rate/status columns and standardize action button sizes
- remove cutoff limiting assigned jobs shown

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c107677b4883338cac0b7c4f89f56e