### PR TITLE
Refactor student job gathering with lookup map

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3102,8 +3102,8 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
     if current_user.get("role") not in ADMIN_ROLES:
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
-    # Gather all job data once
-    all_jobs = []
+    # Gather job data, mapping each student email to the jobs that reference them
+    jobs_by_student: dict[str, dict[str, dict]] = {}
     for job_key in redis_client.scan_iter("job:*"):
         job_raw = redis_client.get(job_key)
         if not job_raw:
@@ -3112,7 +3112,17 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
             job = json.loads(job_raw)
         except Exception:
             continue
-        all_jobs.append(job)
+        job_code = job.get("job_code")
+        if not job_code:
+            continue
+        for field in (
+            "assigned_students",
+            "placed_students",
+            "rejected_students",
+            "uninterested_students",
+        ):
+            for email in job.get(field, []):
+                jobs_by_student.setdefault(email, {})[job_code] = job
 
     students = []
     for key in redis_client.scan_iter("student:*"):
@@ -3145,7 +3155,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
 
         # Add optional match data
         jobs_list = []
-        for job in all_jobs:
+        for job in jobs_by_student.get(email, {}).values():
             status = None
             notes_raw = job.get("student_notes", {}).get(email, [])
             notes, latest_note = _normalize_notes(notes_raw)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -739,6 +739,66 @@ def test_students_all_forbidden_for_non_admin():
     assert resp.status_code == 403
 
 
+def test_students_all_job_mapping(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    # Seed students
+    s1 = {
+        "first_name": "Alpha",
+        "last_name": "A",
+        "email": "a@example.com",
+        "institutional_code": "1001",
+        "student_id": "a1",
+    }
+    s2 = {
+        "first_name": "Beta",
+        "last_name": "B",
+        "email": "b@example.com",
+        "institutional_code": "1001",
+        "student_id": "b1",
+    }
+    main_app.persist_student_record(
+        s1["email"], s1, s1["institutional_code"], s1["student_id"]
+    )
+    main_app.persist_student_record(
+        s2["email"], s2, s2["institutional_code"], s2["student_id"]
+    )
+
+    # Seed jobs referencing students
+    jobs = [
+        {"job_code": "J1", "assigned_students": [s1["email"]]},
+        {"job_code": "J2", "assigned_students": [s2["email"]]},
+        {"job_code": "J3", "assigned_students": [s1["email"], s2["email"]]},
+        {"job_code": "J4"},  # unrelated job
+    ]
+    for job in jobs:
+        main_app.redis_client.set(f"job:{job['job_code']}", json.dumps(job))
+
+    calls = []
+
+    def fake_track(email, code):
+        calls.append((email, code))
+        return {"email_sent": None, "first_open": None, "clicked": False}
+
+    monkeypatch.setattr(main_app, "_tracking_stats", fake_track)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.get("/students/all", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = {s["email"]: s for s in resp.json()["students"]}
+    assert {"J1", "J3"} == {j["job_code"] for j in data[s1["email"]]["assigned_jobs"]}
+    assert {"J2", "J3"} == {j["job_code"] for j in data[s2["email"]]["assigned_jobs"]}
+    # Ensure tracking stats were only computed for relevant pairs
+    assert set(calls) == {
+        (s1["email"], "J1"),
+        (s1["email"], "J3"),
+        (s2["email"], "J2"),
+        (s2["email"], "J3"),
+    }
+
+
 def test_update_student(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- Build a student-to-job map when scanning Redis `job:*` keys
- Iterate through this map in `get_all_students` for faster lookups and track stats only for relevant jobs
- Add tests for new mapping logic and tracking stats

## Testing
- `pytest tests/test_main.py::test_students_all_admin_access tests/test_main.py::test_students_all_forbidden_for_non_admin tests/test_main.py::test_students_all_job_mapping -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3a3068a908333912090516acc4731