### PR TITLE
Optimize student/job retrieval with batched Redis calls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3126,26 +3126,79 @@ def _tracking_stats(student_email: str, job_code: str) -> dict:
 
     return {"email_sent": email_sent, "first_open": first_open, "clicked": clicked}
 
+
+def _scan_mget(pattern: str, batch_size: int = 500):
+    """Yield (key, value) pairs for keys matching pattern using batched mget."""
+    buf: list[str] = []
+    for key in redis_client.scan_iter(pattern):
+        if isinstance(key, bytes):
+            key = key.decode()
+        buf.append(key)
+        if len(buf) >= batch_size:
+            values = redis_client.mget(buf)
+            for k, v in zip(buf, values):
+                yield k, v
+            buf = []
+    if buf:
+        values = redis_client.mget(buf)
+        for k, v in zip(buf, values):
+            yield k, v
+
 @app.get("/students/all")
 def get_all_students(current_user: dict = Depends(get_current_user)):
     if current_user.get("role") not in ADMIN_ROLES:
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
-    # Gather all job data once
-    all_jobs = []
-    for job_key in redis_client.scan_iter("job:*"):
-        job_raw = redis_client.get(job_key)
-        if not job_raw:
+    jobs_by_student: dict[str, list[dict]] = {}
+    for _, raw in _scan_mget("job:*"):
+        if not raw:
             continue
         try:
-            job = json.loads(job_raw)
+            job = json.loads(raw)
         except Exception:
             continue
-        all_jobs.append(job)
+        job_code = job.get("job_code")
+        emails = set(
+            job.get("placed_students", [])
+            + job.get("assigned_students", [])
+            + job.get("rejected_students", [])
+            + job.get("uninterested_students", [])
+        )
+        for email in emails:
+            status = None
+            if email in job.get("placed_students", []):
+                status = "placed"
+            elif email in job.get("assigned_students", []):
+                status = "assigned"
+            elif email in job.get("rejected_students", []):
+                status = "rejected"
+            elif email in job.get("uninterested_students", []):
+                status = "uninterested"
+            if not status:
+                continue
+            notes_raw = job.get("student_notes", {}).get(email, [])
+            notes, latest_note = _normalize_notes(notes_raw)
+            track = _tracking_stats(email, job_code)
+            jobs_by_student.setdefault(email, []).append(
+                {
+                    "job_code": job_code,
+                    "job_title": job.get("job_title"),
+                    "source": job.get("source"),
+                    "min_pay": job.get("min_pay"),
+                    "max_pay": job.get("max_pay"),
+                    "job_description": job.get("job_description"),
+                    "status": status,
+                    "posted_by": job.get("posted_by"),
+                    "notes": notes,
+                    **({"note": latest_note} if latest_note is not None else {}),
+                    "email_sent": track["email_sent"],
+                    "first_open": track["first_open"],
+                    "clicked": track["clicked"],
+                }
+            )
 
-    students = []
-    for key in redis_client.scan_iter("student:*"):
-        raw = redis_client.get(key)
+    students: list[dict] = []
+    for _, raw in _scan_mget("student:*"):
         if not raw:
             continue
         try:
@@ -3154,6 +3207,7 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
             continue
 
         email = student.get("email")
+        jobs_list = jobs_by_student.get(email, [])
         info = {
             "first_name": student.get("first_name"),
             "last_name": student.get("last_name"),
@@ -3167,46 +3221,13 @@ def get_all_students(current_user: dict = Depends(get_current_user)):
             "interests": student.get("interests"),
             "institutional_code": student.get("institutional_code")
             or student.get("school_code"),
-            "assigned_jobs": [],
-            "placed_jobs": 0,
-            "assigned_job_code": None,
+            "assigned_jobs": jobs_list,
+            "placed_jobs": sum(1 for j in jobs_list if j["status"] == "placed"),
+            "assigned_job_code": next(
+                (j["job_code"] for j in jobs_list if j["status"] == "assigned"),
+                None,
+            ),
         }
-
-        # Add optional match data
-        jobs_list = []
-        for job in all_jobs:
-            status = None
-            notes_raw = job.get("student_notes", {}).get(email, [])
-            notes, latest_note = _normalize_notes(notes_raw)
-            if email in job.get("placed_students", []):
-                status = "placed"
-            elif email in job.get("assigned_students", []):
-                status = "assigned"
-            elif email in job.get("rejected_students", []):
-                status = "rejected"
-            elif email in job.get("uninterested_students", []):
-                status = "uninterested"
-            if status:
-                track = _tracking_stats(email, job.get("job_code"))
-                jobs_list.append({
-                    "job_code": job.get("job_code"),
-                    "job_title": job.get("job_title"),
-                    "source": job.get("source"),
-                    "min_pay": job.get("min_pay"),
-                    "max_pay": job.get("max_pay"),
-                    "job_description": job.get("job_description"),
-                    "status": status,
-                    "posted_by": job.get("posted_by"),
-                    "notes": notes,
-                    **({"note": latest_note} if latest_note is not None else {}),
-                    "email_sent": track["email_sent"],
-                    "first_open": track["first_open"],
-                    "clicked": track["clicked"],
-                })
-
-        info["assigned_jobs"] = jobs_list
-        info["placed_jobs"] = sum(1 for j in jobs_list if j["status"] == "placed")
-        info["assigned_job_code"] = next((j["job_code"] for j in jobs_list if j["status"] == "assigned"), None)
 
         students.append(info)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -715,6 +715,68 @@ def test_students_all_admin_access():
     assert student_map["two@example.com"]["state"] == "ST"
 
 
+def test_students_all_job_statuses_batched():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    # Seed students
+    s1 = {
+        "first_name": "One",
+        "last_name": "A",
+        "email": "one@example.com",
+        "license": "lvn",
+        "city": "City1",
+        "state": "ST",
+        "institutional_code": "1001",
+        "student_id": "one",
+    }
+    s2 = {
+        "first_name": "Two",
+        "last_name": "B",
+        "email": "two@example.com",
+        "license": "ma",
+        "city": "City2",
+        "state": "ST",
+        "institutional_code": "1001",
+        "student_id": "two",
+    }
+    main_app.persist_student_record(
+        s1["email"], s1, s1["institutional_code"], s1["student_id"]
+    )
+    main_app.persist_student_record(
+        s2["email"], s2, s2["institutional_code"], s2["student_id"]
+    )
+
+    # Seed jobs with student associations
+    job1 = {
+        "job_code": "J1",
+        "job_title": "Job 1",
+        "assigned_students": [s1["email"]],
+    }
+    job2 = {
+        "job_code": "J2",
+        "job_title": "Job 2",
+        "placed_students": [s2["email"]],
+    }
+    main_app.redis_client.set("job:J1", json.dumps(job1))
+    main_app.redis_client.set("job:J2", json.dumps(job2))
+
+    login_resp = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    )
+    token = login_resp.json()["token"]
+
+    resp = client.get("/students/all", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = {s["email"]: s for s in resp.json()["students"]}
+
+    jobs_one = data[s1["email"]]["assigned_jobs"]
+    assert any(j["job_code"] == "J1" and j["status"] == "assigned" for j in jobs_one)
+
+    jobs_two = data[s2["email"]]["assigned_jobs"]
+    assert any(j["job_code"] == "J2" and j["status"] == "placed" for j in jobs_two)
+
+
 def test_students_all_forbidden_for_non_admin():
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- Batch fetch job and student records from Redis using `mget`
- Build job mappings per student to avoid per-key lookups
- Add regression test for batched retrieval ensuring job status integrity
- Chunk Redis scans into manageable batches to prevent large `mget` calls

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c3ac40c9ec8333b476ff8ae773f044