### PR TITLE
feat: expose student job stats on demand

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3298,17 +3298,6 @@ def students_by_school(
             st_license = student.get("license") or student.get("education_level")
             if license and (st_license or "").lower() != license.lower():
                 continue
-            assigned_codes = redis_client.smembers(
-                _student_job_key(email, "assigned")
-            )
-            placed_count = redis_client.scard(_student_job_key(email, "placed"))
-            rejected_count = redis_client.scard(
-                _student_job_key(email, "rejected")
-            )
-            uninterested_count = redis_client.scard(
-                _student_job_key(email, "uninterested")
-            )
-
             info = {
                 "first_name": student.get("first_name"),
                 "last_name": student.get("last_name"),
@@ -3320,12 +3309,8 @@ def students_by_school(
                 "skills": student.get("skills"),
                 "experience_summary": student.get("experience_summary"),
                 "interests": student.get("interests"),
-                "assigned_job_count": len(assigned_codes)
-                + placed_count
-                + rejected_count
-                + uninterested_count,
-                "placed_jobs": placed_count,
-                "assigned_job_code": next(iter(assigned_codes), None),
+                "institutional_code": student.get("institutional_code")
+                or student.get("school_code"),
             }
             students.append(info)
             if len(students) >= limit:
@@ -3335,6 +3320,39 @@ def students_by_school(
 
     next_cursor = None if cur == 0 else str(cur)
     return {"students": students, "next_cursor": next_cursor}
+
+
+@app.get("/students/{email}/job-stats")
+def student_job_stats(email: str, current_user: dict = Depends(get_current_user)):
+    """Return job status sets for a given student."""
+    norm = normalize_email(email)
+    key = resolve_student_key(norm)
+    raw = redis_client.get(key) if key else None
+    if not raw:
+        raise HTTPException(status_code=404, detail="Student not found")
+
+    if current_user.get("role") not in ADMIN_ROLES:
+        try:
+            student = json.loads(raw)
+        except Exception:
+            raise HTTPException(status_code=500, detail="Corrupted profile data")
+        user_raw = redis_client.get(user_key(current_user.get("sub")))
+        user = json.loads(user_raw) if user_raw else {}
+        st_code = student.get("institutional_code") or student.get("school_code")
+        u_code = user.get("institutional_code") or user.get("school_code")
+        if st_code != u_code:
+            raise HTTPException(status_code=403, detail="Not authorized")
+        if current_user.get("role") == "career" and student.get("created_by") != current_user.get("sub"):
+            raise HTTPException(status_code=403, detail="Not authorized")
+
+    return {
+        "assigned": list(redis_client.smembers(_student_job_key(norm, "assigned"))),
+        "placed": list(redis_client.smembers(_student_job_key(norm, "placed"))),
+        "rejected": list(redis_client.smembers(_student_job_key(norm, "rejected"))),
+        "uninterested": list(
+            redis_client.smembers(_student_job_key(norm, "uninterested"))
+        ),
+    }
 
 
 @app.get("/students/{email}/jobs")

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -93,6 +93,7 @@ function StudentProfiles() {
   const hoverTimer = useRef(null);
   const [jobsByEmail, setJobsByEmail] = useState({});
   const [loadingJobs, setLoadingJobs] = useState({});
+  const [jobStatsByEmail, setJobStatsByEmail] = useState({});
 
   const mergeStudents = (list) => {
     const map = new Map();
@@ -278,6 +279,16 @@ function StudentProfiles() {
       const state = prev[email];
       const isOpen = state === 'open' || state === 'opening';
       if (!isOpen) {
+        if (!jobStatsByEmail[email]) {
+          api
+            .get(`/students/${email}/job-stats`, {
+              headers: { Authorization: `Bearer ${token}` },
+            })
+            .then((resp) =>
+              setJobStatsByEmail((p) => ({ ...p, [email]: resp.data || {} }))
+            )
+            .catch((err) => console.error('Failed to fetch job stats', err));
+        }
         if (!jobsByEmail[email]) {
           setLoadingJobs((l) => ({ ...l, [email]: true }));
           api
@@ -512,12 +523,20 @@ function StudentProfiles() {
               .includes(codeFilter.toLowerCase());
       const licenseMatch =
         !licenseFilter || (s.license || '').toLowerCase() === licenseFilter.toLowerCase();
-      const assignedCount = s.assigned_job_count || 0;
+      const stats = jobStatsByEmail[s.email];
+      const assignedCount = stats
+        ? (stats.assigned?.length || 0) +
+          (stats.placed?.length || 0) +
+          (stats.rejected?.length || 0) +
+          (stats.uninterested?.length || 0)
+        : s.assigned_job_count || 0;
       const assignedMatch =
         assignedFilter === ''
           ? true
           : assignedCount.toString().includes(assignedFilter.toString());
-      const placed = Array.isArray(s.placed_jobs)
+      const placed = stats
+        ? stats.placed?.length || 0
+        : Array.isArray(s.placed_jobs)
         ? s.placed_jobs.length
         : s.placed_jobs || 0;
       let placementMatch = true;
@@ -545,6 +564,7 @@ function StudentProfiles() {
     assignedFilter,
     placementFilter,
     userRole,
+    jobStatsByEmail,
   ]);
 
   return (
@@ -756,8 +776,18 @@ function StudentProfiles() {
                 </thead>
                 <tbody>
                   {filteredStudents.map((s) => {
-                    const assigned = s.assigned_job_count || 0;
-                    const placed = Array.isArray(s.placed_jobs) ? s.placed_jobs.length : s.placed_jobs || 0;
+                    const stats = jobStatsByEmail[s.email];
+                    const assigned = stats
+                      ? (stats.assigned?.length || 0) +
+                        (stats.placed?.length || 0) +
+                        (stats.rejected?.length || 0) +
+                        (stats.uninterested?.length || 0)
+                      : s.assigned_job_count || 0;
+                    const placed = stats
+                      ? stats.placed?.length || 0
+                      : Array.isArray(s.placed_jobs)
+                      ? s.placed_jobs.length
+                      : s.placed_jobs || 0;
                     return (
                       <React.Fragment key={s.email}>
                         <tr>

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -19,6 +19,11 @@ beforeEach(() => {
     if (url === '/licenses') {
       return Promise.resolve({ data: { licenses: [] } });
     }
+    if (url.includes('/job-stats')) {
+      return Promise.resolve({
+        data: { assigned: [], placed: [], rejected: [], uninterested: [] }
+      });
+    }
     return Promise.resolve({ data: { students: [] } });
   });
 });
@@ -50,9 +55,7 @@ test('displays student count in tab bar', async () => {
             city: 'City',
             state: 'ST',
             institutional_code: 'ABC',
-            license: '',
-            assigned_job_count: 0,
-            placed_jobs: 0
+            license: ''
           },
           {
             first_name: 'C',
@@ -61,9 +64,7 @@ test('displays student count in tab bar', async () => {
             city: 'City',
             state: 'ST',
             institutional_code: 'ABC',
-            license: '',
-            assigned_job_count: 0,
-            placed_jobs: 0
+            license: ''
           }
         ]
       }
@@ -99,6 +100,11 @@ test('opens notes history modal when View Notes clicked', async () => {
         }
       });
     }
+    if (url === '/students/s@example.com/job-stats') {
+      return Promise.resolve({
+        data: { assigned: ['J1'], placed: [], rejected: [], uninterested: [] }
+      });
+    }
     return Promise.resolve({
       data: {
         students: [
@@ -108,10 +114,7 @@ test('opens notes history modal when View Notes clicked', async () => {
             email: 's@example.com',
             city: 'City',
             state: 'ST',
-            institutional_code: 'ABC',
-            assigned_job_count: 1,
-            placed_jobs: 0,
-            assigned_job_code: 'J1'
+            institutional_code: 'ABC'
           }
         ]
       }
@@ -149,6 +152,11 @@ test('loads jobs on demand when expanding a student', async () => {
         data: { jobs: [{ job_code: 'J1', job_title: 'Job 1', status: 'open' }] }
       });
     }
+    if (url === '/students/s@example.com/job-stats') {
+      return Promise.resolve({
+        data: { assigned: ['J1'], placed: [], rejected: [], uninterested: [] }
+      });
+    }
     return Promise.resolve({
       data: {
         students: [
@@ -158,10 +166,7 @@ test('loads jobs on demand when expanding a student', async () => {
             email: 's@example.com',
             city: 'City',
             state: 'ST',
-            institutional_code: 'ABC',
-            assigned_job_count: 1,
-            placed_jobs: 0,
-            assigned_job_code: 'J1'
+            institutional_code: 'ABC'
           }
         ]
       }
@@ -193,14 +198,17 @@ test('deduplicates students from multiple payloads', async () => {
     city: 'City',
     state: 'ST',
     institutional_code: 'ABC',
-    license: '',
-    assigned_job_count: 0,
-    placed_jobs: 0
+    license: ''
   };
 
   api.get.mockImplementation((url) => {
     if (url === '/licenses') {
       return Promise.resolve({ data: { licenses: [] } });
+    }
+    if (url.includes('/job-stats')) {
+      return Promise.resolve({
+        data: { assigned: [], placed: [], rejected: [], uninterested: [] }
+      });
     }
     return Promise.resolve({ data: { students: [student] } });
   });

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1101,8 +1101,13 @@ def test_reject_assigned(monkeypatch):
 
     resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
     data = resp.json()["students"][0]
-    assert data["assigned_job_count"] == 1
-    assert "assigned_jobs" not in data
+    assert "assigned_job_count" not in data
+    stats = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert stats["assigned"] == []
+    assert set(stats["rejected"]) == {job_code}
     jobs_resp = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token}"},
@@ -1198,8 +1203,12 @@ def test_student_note_school_code_fallback():
     assert resp.status_code == 200
     data = resp.json()["students"]
     stu = next(s for s in data if s["email"] == student["email"])
-    assert stu["assigned_job_count"] == 1
-    assert "assigned_jobs" not in stu
+    assert "assigned_job_count" not in stu
+    stats = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert set(stats["assigned"]) == {job_code}
     jobs_resp = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token}"},
@@ -1266,8 +1275,12 @@ def test_assign_note_persists_on_reject(monkeypatch):
 
     resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
     data = resp.json()["students"][0]
-    assert data["assigned_job_count"] == 1
-    assert "assigned_jobs" not in data
+    assert "assigned_job_count" not in data
+    stats = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert set(stats["assigned"]) == {job_code}
     jobs_resp = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token}"},
@@ -1404,8 +1417,12 @@ def test_student_note_assigned(monkeypatch):
 
     resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
     data = resp.json()["students"][0]
-    assert data["assigned_job_count"] == 1
-    assert "assigned_jobs" not in data
+    assert "assigned_job_count" not in data
+    stats = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert set(stats["assigned"]) == {job_code}
     jobs_resp = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token}"},
@@ -1428,8 +1445,13 @@ def test_student_note_assigned(monkeypatch):
 
     resp = client.get("/students/by-school", headers={"Authorization": f"Bearer {token}"})
     data = resp.json()["students"][0]
-    assert data["assigned_job_count"] == 1
-    assert "assigned_jobs" not in data
+    assert "assigned_job_count" not in data
+    stats = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert stats["assigned"] == []
+    assert set(stats["rejected"]) == {job_code}
     jobs_resp = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token}"},

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2704,8 +2704,16 @@ def test_student_endpoints_handle_string_notes():
     school_entry = resp_school.json()["students"][0]
     assert school_entry["city"] == "City"
     assert school_entry["state"] == "ST"
-    assert school_entry["assigned_job_count"] == 1
-    assert "assigned_jobs" not in school_entry
+    assert "assigned_job_count" not in school_entry
+    stats_resp = client.get(
+        f"/students/{student['email']}/job-stats",
+        headers={"Authorization": f"Bearer {token_counselor}"},
+    )
+    stats = stats_resp.json()
+    assert set(stats["assigned"]) == {"J1"}
+    assert stats["placed"] == []
+    assert stats["rejected"] == []
+    assert stats["uninterested"] == []
     jobs_school = client.get(
         f"/students/{student['email']}/jobs",
         headers={"Authorization": f"Bearer {token_counselor}"},


### PR DESCRIPTION
## Summary
- streamline `/students/by-school` to return only profile fields
- add `/students/{email}/job-stats` endpoint with assigned/placed/rejected/uninterested sets
- load and cache student job stats in frontend when rows expand

## Testing
- `pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4596fae148333936092f5822d6d08