### PR TITLE
Remove assigned job statistics from student listings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3214,13 +3214,6 @@ def get_all_students(
             assigned_codes = redis_client.smembers(
                 _student_job_key(email, "assigned")
             )
-            placed_count = redis_client.scard(_student_job_key(email, "placed"))
-            rejected_count = redis_client.scard(
-                _student_job_key(email, "rejected")
-            )
-            uninterested_count = redis_client.scard(
-                _student_job_key(email, "uninterested")
-            )
 
             info = {
                 "first_name": student.get("first_name"),
@@ -3235,11 +3228,6 @@ def get_all_students(
                 "interests": student.get("interests"),
                 "institutional_code": student.get("institutional_code")
                 or student.get("school_code"),
-                "assigned_job_count": len(assigned_codes)
-                + placed_count
-                + rejected_count
-                + uninterested_count,
-                "placed_jobs": placed_count,
                 "assigned_job_code": next(iter(assigned_codes), None),
             }
             students.append(info)

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -529,7 +529,7 @@ function StudentProfiles() {
           (stats.placed?.length || 0) +
           (stats.rejected?.length || 0) +
           (stats.uninterested?.length || 0)
-        : s.assigned_job_count || 0;
+        : 0;
       const assignedMatch =
         assignedFilter === ''
           ? true
@@ -782,7 +782,7 @@ function StudentProfiles() {
                         (stats.placed?.length || 0) +
                         (stats.rejected?.length || 0) +
                         (stats.uninterested?.length || 0)
-                      : s.assigned_job_count || 0;
+                      : 0;
                     const placed = stats
                       ? stats.placed?.length || 0
                       : Array.isArray(s.placed_jobs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1521,7 +1521,6 @@ def test_tracking_fields_returned(monkeypatch):
     )
     assert resp2.status_code == 200
     student_email = resp2.json()["students"][0]["email"]
-    assert resp2.json()["students"][0]["assigned_job_count"] == 1
     jobs_resp = client.get(
         f"/students/{student_email}/jobs",
         headers={"Authorization": f"Bearer {token}"},
@@ -2675,7 +2674,7 @@ def test_student_endpoints_handle_string_notes():
     student_entry = resp_all.json()["students"][0]
     assert student_entry["city"] == "City"
     assert student_entry["state"] == "ST"
-    assert student_entry["assigned_job_count"] == 1
+    assert "assigned_job_count" not in student_entry
     assert "assigned_jobs" not in student_entry
     jobs_admin = client.get(
         f"/students/{student['email']}/jobs",
@@ -2808,7 +2807,7 @@ def test_student_job_sets_and_pagination():
     )
     data = resp.json()
     assert len(data["students"]) == 1
-    assert data["students"][0]["assigned_job_count"] == 1
+    assert "assigned_job_count" not in data["students"][0]
     assert "assigned_jobs" not in data["students"][0]
     jobs_resp = client.get(
         "/students/stud@example.com/jobs",


### PR DESCRIPTION
## Summary
- simplify `get_all_students` by eliminating assigned job count and related Redis lookups
- default job stats to zero in StudentProfiles when absent
- adjust tests to stop expecting `assigned_job_count`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c461beaa6c83338de72f5690f7707a