### PR TITLE
Remove assigned jobs from student profile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3387,42 +3387,15 @@ def student_me(current_user: dict = Depends(get_current_user)):
     if claimed_by and claimed_by != current_sub:
         raise HTTPException(status_code=403, detail="Profile not claimed by current user")
 
-    # gather related job info
-    assigned_jobs = []
+    # Summaries of job status are stored in Redis sets keyed by status
+    assigned_job_code = None
     placed = 0
-    for job_key in redis_client.scan_iter("job:*"):
-        job_raw = redis_client.get(job_key)
-        if not job_raw:
-            continue
-        try:
-            job = json.loads(job_raw)
-        except Exception:
-            continue
-        status = None
-        notes_raw = job.get("student_notes", {}).get(email, [])
-        notes, latest_note = _normalize_notes(notes_raw)
-        if email in job.get("placed_students", []):
-            placed += 1
-            status = "placed"
-        elif email in job.get("assigned_students", []):
-            status = "assigned"
-        elif email in job.get("rejected_students", []):
-            status = "rejected"
-        elif email in job.get("uninterested_students", []):
-            status = "uninterested"
-        if status:
-            assigned_jobs.append({
-                "job_code": job.get("job_code"),
-                "job_title": job.get("job_title"),
-                "source": job.get("source"),
-                "min_pay": job.get("min_pay"),
-                "max_pay": job.get("max_pay"),
-                "job_description": job.get("job_description"),
-                "status": status,
-                "posted_by": job.get("posted_by"),
-                "notes": notes,
-                **({"note": latest_note} if latest_note is not None else {}),
-            })
+    if email:
+        assigned = redis_client.smembers(f"student_jobs:{email}:assigned") or []
+        assigned_job_code = next(iter(assigned), None)
+        if isinstance(assigned_job_code, bytes):
+            assigned_job_code = assigned_job_code.decode("utf-8")
+        placed = len(redis_client.smembers(f"student_jobs:{email}:placed") or [])
 
     info = {
         "first_name": student.get("first_name"),
@@ -3436,9 +3409,8 @@ def student_me(current_user: dict = Depends(get_current_user)):
         "experience_summary": student.get("experience_summary"),
         "interests": student.get("interests"),
         "institutional_code": student.get("institutional_code"),
-        "assigned_jobs": assigned_jobs,
         "placed_jobs": placed,
-        "assigned_job_code": next((j["job_code"] for j in assigned_jobs if j["status"] == "assigned"), None),
+        "assigned_job_code": assigned_job_code,
     }
     return info
 

--- a/frontend/src/ApplicantProfile.js
+++ b/frontend/src/ApplicantProfile.js
@@ -79,6 +79,18 @@ function ApplicantProfile() {
     loadLicenses();
   }, []);
 
+  const fetchAssignedJobs = async () => {
+    try {
+      const resp = await api.get(`/students/${email}/jobs`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setAssignedJobs(resp.data.jobs || []);
+    } catch (err) {
+      console.error('Failed to fetch assigned jobs', err);
+      setAssignedJobs([]);
+    }
+  };
+
   const fetchProfile = async () => {
     try {
       const resp = await api.get('/students/me', { headers: { Authorization: `Bearer ${token}` } });
@@ -98,7 +110,7 @@ function ApplicantProfile() {
         lng: data.lng || '',
         max_travel: data.max_travel || ''
       });
-      setAssignedJobs(data.assigned_jobs || []);
+      await fetchAssignedJobs();
       setIsEditing(true);
     } catch (err) {
       // no profile yet

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2722,6 +2722,10 @@ def test_student_endpoints_handle_string_notes():
     assert entry["note"] == "legacy"
     assert "posted_by" in entry
 
+    main_app.redis_client.set(
+        "user:student@example.com",
+        json.dumps({"role": "applicant", "institutional_code": "001"}),
+    )
     token_student = jwt.encode(
         {
             "sub": "student@example.com",
@@ -2737,7 +2741,12 @@ def test_student_endpoints_handle_string_notes():
     me_entry = resp_me.json()
     assert me_entry["city"] == "City"
     assert me_entry["state"] == "ST"
-    entry = me_entry["assigned_jobs"][0]
+    assert "assigned_jobs" not in me_entry
+    jobs_self = client.get(
+        f"/students/{student['email']}/jobs",
+        headers={"Authorization": f"Bearer {token_student}"},
+    )
+    entry = jobs_self.json()["jobs"][0]
     assert entry["notes"] == [{"text": "legacy"}]
     assert entry["note"] == "legacy"
     assert "posted_by" in entry


### PR DESCRIPTION
## Summary
- stop scanning job data when loading a student's profile and drop `assigned_jobs` field
- fetch assigned jobs via `/students/{email}/jobs` in `ApplicantProfile`
- adjust tests for new behavior

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c464cf693883338f7d127defe5cbec