### PR TITLE
fix: keep table width stable when expanding profiles

### DIFF
--- a/frontend/src/StudentProfiles.css
+++ b/frontend/src/StudentProfiles.css
@@ -167,6 +167,7 @@
 .table-wrapper {
   max-height: 80vh;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   transition: box-shadow 0.3s;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
## Summary
- prevent student table columns from shifting when expanding profile rows by stabilizing scrollbar spacing

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c46b39659c8333978dceac5fc05f95