### PR TITLE
Surface email send failures and improve candidate notification UX

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -288,10 +288,13 @@ def send_email(
     attachments: list[tuple[str, bytes | str, str]] | None = None,
     track_token: str | None = None,
 ) -> None:
-    """Send an email with optional attachments if SMTP configuration is available."""
+    """Send an email with optional attachments.
+
+    Raises a RuntimeError if SMTP settings are missing or if sending fails so
+    callers can surface the failure to the user."""
     if not SMTP_HOST or not EMAIL_SENDER:
-        logger.warning("[email] Skipping email to %s; SMTP not configured", recipient)
-        return
+        raise RuntimeError("SMTP configuration is missing")
+
     try:
         msg = EmailMessage()
         msg["From"] = EMAIL_SENDER
@@ -332,6 +335,7 @@ def send_email(
         logger.info("[email] Sent notification to %s", recipient)
     except Exception as e:
         logger.error("[email] Failed to send email to %s: %s", recipient, e)
+        raise
 
 async def get_driving_distance_miles(orig_lat: float, orig_lng: float, dest_lat: float, dest_lng: float) -> float:
     """Return driving distance in miles between two coordinates using Google Distance Matrix.
@@ -2536,13 +2540,17 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
         )
     except Exception as e:
         logger.error("Failed to store email open token: %s", e)
-    send_email(
-        student_email,
-        f"Job Match: {job.get('job_title')}",
-        body,
-        html_body=html_body,
-        track_token=token,
-    )
+    try:
+        send_email(
+            student_email,
+            f"Job Match: {job.get('job_title')}",
+            body,
+            html_body=html_body,
+            track_token=token,
+        )
+    except Exception as e:
+        logger.error("Notification email failed: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to send notification email")
 
     return {"message": "Notification sent"}
 

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -328,13 +328,20 @@ if (shouldRedirect) {
             : j
         )
       );
+      return true;
     } catch (err) {
       console.error('Assign failed', err.response?.data || err.message);
+      alert('Failed to assign candidate to job');
+      return false;
     }
   };
 
   const handleNotifyCandidate = async (job, row) => {
-    await handleAssign(job, row);
+    const assigned = await handleAssign(job, row);
+    if (!assigned) {
+      alert('Assignment failed; notification not sent');
+      return;
+    }
     await notifyInterest(job.job_code, row.email);
   };
 
@@ -380,7 +387,9 @@ if (shouldRedirect) {
       );
       alert('Candidate notified of interest');
     } catch (err) {
-      console.error('Notification failed', err);
+      console.error('Notification failed', err.response?.data || err.message);
+      const detail = err.response?.data?.detail || 'Failed to notify candidate';
+      alert(detail);
     }
   };
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -209,7 +209,7 @@ def test_registration_flow():
     assert payload["role"] == "career"
 
 
-def test_register_links_existing_student():
+def test_register_links_existing_student(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()
 
@@ -230,6 +230,7 @@ def test_register_links_existing_student():
         "password": "pw",
         "role": "applicant",
     }
+    monkeypatch.setattr(main_app, "send_email", lambda *a, **k: None)
     resp = client.post("/register", json=user)
     assert resp.status_code == 200
     skey = main_app.resolve_student_key(email)
@@ -533,6 +534,7 @@ def test_create_student_returns_existing_for_same_user(monkeypatch):
         "password": "pw",
         "role": "applicant",
     }
+    monkeypatch.setattr(main_app, "send_email", lambda *a, **k: None)
     client.post("/register", json=user)
 
     key = main_app.user_key(email)
@@ -1529,6 +1531,59 @@ def test_tracking_fields_returned(monkeypatch):
     assert job_entry["email_sent"] is not None
     assert job_entry["first_open"] is not None
     assert job_entry["clicked"] is True
+
+
+def test_notify_interest_missing_smtp(monkeypatch):
+    main_app.redis_client = DummyRedis()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stud",
+        "last_name": "S",
+        "skills": ["python"],
+        "email": "stud@example.com",
+        "institutional_code": "1001",
+        "student_id": "stud_missing",
+    }
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+    main_app.redis_client.set(
+        "job:missing",
+        json.dumps(
+            {
+                "job_code": "missing",
+                "job_title": "Dev",
+                "job_description": "desc",
+                "desired_skills": ["python"],
+                "assigned_students": ["stud@example.com"],
+            }
+        ),
+    )
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "done"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(main_app, "SMTP_HOST", None)
+    monkeypatch.setattr(main_app, "EMAIL_SENDER", None)
+
+    token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    resp = client.post(
+        "/notify-interest",
+        json={"student_email": "stud@example.com", "job_code": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to send notification email"
 
 
 def test_generate_resume_html(monkeypatch):


### PR DESCRIPTION
## Summary
- Raise errors when SMTP config is missing so email send failures reach callers
- Abort candidate notifications when assignment fails and surface API errors to users
- Test notification failure path and patch registration tests for new email behavior

## Testing
- `pytest -q`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c4ad9822208333859cd83e5d7a4aac