### PR TITLE
Refresh analytics after resending notifications

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3089,10 +3089,16 @@ def _tracking_stats(student_email: str, job_code: str) -> dict:
     if not tokens:
         return {"email_sent": None, "first_open": None, "clicked": False}
 
-    email_sent_values = [t.get("sent") for t in tokens if t.get("sent")]
-    email_sent = min(email_sent_values) if email_sent_values else None
+    latest_token: dict | None = None
+    latest_sent: str | None = None
+    for t in tokens:
+        sent = t.get("sent")
+        if sent and (latest_sent is None or sent > latest_sent):
+            latest_sent = sent
+            latest_token = t
 
-    token_set = {t["token"] for t in tokens}
+    token_set = {latest_token["token"]} if latest_token else set()
+    email_sent = latest_sent
     first_open = None
     clicked = False
     try:

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -447,6 +447,18 @@ function StudentProfiles() {
         { headers: { Authorization: `Bearer ${token}` } }
       );
       alert('Job description resent');
+      const [jobsResp, statsResp] = await Promise.all([
+        api.get(`/students/${studentEmail}/jobs`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        api.get(`/students/${studentEmail}/job-stats`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const jobs = jobsResp.data?.jobs || [];
+      setJobsByEmail((p) => ({ ...p, [studentEmail]: jobs }));
+      setJobStatsByEmail((p) => ({ ...p, [studentEmail]: statsResp.data || {} }));
+      await fetchJobDescriptionStatus(studentEmail, jobCode);
     } catch (err) {
       console.error('Notification failed', err);
     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1533,6 +1533,101 @@ def test_tracking_fields_returned(monkeypatch):
     assert job_entry["clicked"] is True
 
 
+def test_resend_updates_tracking(monkeypatch):
+    main_app.redis_client = DummyRedis()
+    init_default_admin()
+
+    student = {
+        "first_name": "Stud",
+        "last_name": "S",
+        "skills": ["python"],
+        "email": "stud@example.com",
+        "institutional_code": "1001",
+        "student_id": "stud8",
+    }
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+    main_app.redis_client.set(
+        "job:codei",
+        json.dumps(
+            {
+                "job_code": "codei",
+                "job_title": "Dev",
+                "job_description": "desc",
+                "desired_skills": ["python"],
+                "assigned_students": ["stud@example.com"],
+                "external_apply_url": "https://example.com/apply",
+            }
+        ),
+    )
+    main_app.redis_client.sadd("student_jobs:stud@example.com:assigned", "codei")
+
+    class FakeResp:
+        def __init__(self):
+            self.choices = [type("obj", (), {"message": type("obj", (), {"content": "done"})})]
+
+    def fake_create(model, messages, temperature):
+        return FakeResp()
+
+    sent = []
+
+    def fake_send(recipient, subject, body, html_body=None, attachments=None, track_token=None):
+        sent.append(track_token)
+
+    monkeypatch.setattr(main_app.client.chat.completions, "create", fake_create)
+    monkeypatch.setattr(main_app, "send_email", fake_send)
+
+    token = client.post("/login", json={"email": "admin@example.com", "password": "admin123"}).json()["token"]
+
+    resp = client.post(
+        "/notify-interest",
+        json={"student_email": "stud@example.com", "job_code": "codei"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    first_token = sent[-1]
+    client.get(f"/track/open/{first_token}.png")
+    client.get(f"/track/click/{first_token}")
+
+    jobs_resp = client.get(
+        "/students/stud@example.com/jobs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    job_entry = jobs_resp.json()["jobs"][0]
+    first_sent = job_entry["email_sent"]
+    assert job_entry["first_open"] is not None
+    assert job_entry["clicked"] is True
+
+    resp = client.post(
+        "/notify-interest",
+        json={"student_email": "stud@example.com", "job_code": "codei"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    second_token = sent[-1]
+    jobs_resp = client.get(
+        "/students/stud@example.com/jobs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    job_entry = jobs_resp.json()["jobs"][0]
+    assert job_entry["email_sent"] != first_sent
+    assert job_entry["first_open"] is None
+    assert job_entry["clicked"] is False
+
+    client.get(f"/track/open/{second_token}.png")
+    client.get(f"/track/click/{second_token}")
+
+    jobs_resp = client.get(
+        "/students/stud@example.com/jobs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    job_entry = jobs_resp.json()["jobs"][0]
+    assert job_entry["email_sent"] != first_sent
+    assert job_entry["first_open"] is not None
+    assert job_entry["clicked"] is True
+
+
 def test_notify_interest_missing_smtp(monkeypatch):
     main_app.redis_client = DummyRedis()
     init_default_admin()


### PR DESCRIPTION
## Summary
- Track email analytics using only the most recently sent notification
- Refresh job and stats data on the student profile after resending a job description
- Add regression test verifying resend resets analytics until new email activity occurs

## Testing
- `pytest`
- `cd frontend && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c503734e4083338f588cb22b29c639