### PR TITLE
Set job timeout on match queue tasks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1556,6 +1556,7 @@ def match_job(
             req.job_code,
             False,
             enq_time,
+            job_timeout=600,
             meta={"request_id": request.state.request_id},
         )
         return {"message": "Match job queued"}
@@ -1578,6 +1579,7 @@ def rematch_job(
             job_code,
             False,
             enq_time,
+            job_timeout=600,
             meta={"request_id": request.state.request_id},
         )
         return {"message": "Rematch queued"}


### PR DESCRIPTION
## Summary
- add a 10-minute job timeout to the `/match` and `/rematches/{job_code}` queue submissions so background jobs cannot run indefinitely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb813eb8f88333982945839abff2d2