### PR TITLE
Log start of match worker

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1926,6 +1926,7 @@ def _perform_match(
 
 
 def match_worker(job_code: str, send_emails: bool = False, enq_time: float | None = None):
+    logger.info(f"🔎 Match worker started for job {job_code}")
     start = datetime.now()
 
     def progress_callback(event: str, payload: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- log a message when the match worker begins processing a job so startup is visible in logs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc18a2045c8333895260c6c191ec80