### PR TITLE
Add refresh token flow and client auto-refresh support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,8 @@ from html import unescape, escape
 import random
 from zoneinfo import ZoneInfo
 from urllib.parse import urlparse
+import secrets
+import hashlib
 from backend.app.schemas.resume import ResumeRequest
 from backend.app.schemas.description import DescriptionRequest
 from backend.app.services.resume import generate_resume_text
@@ -65,6 +67,11 @@ for handler in logging.getLogger().handlers:
 logger = get_logger(__name__)
 
 ADMIN_ROLES = {"admin", "junior_admin"}
+
+REFRESH_TOKEN_TTL_SECONDS = int(os.getenv("REFRESH_TOKEN_TTL_SECONDS", str(60 * 60 * 24 * 7)))
+REFRESH_TOKEN_LOOKUP_PREFIX = "refresh_token_lookup"
+REFRESH_TOKEN_USER_PREFIX = "refresh_token_user"
+ACCESS_TOKEN_TTL = timedelta(hours=1)
 
 
 def init_default_school_codes():
@@ -182,6 +189,54 @@ def normalize_email(email: str | None) -> str:
 def user_key(email: str) -> str:
     """Return the redis key for a user."""
     return f"user:{normalize_email(email)}"
+
+
+def _hash_refresh_token(token: str) -> str:
+    """Return a deterministic hash for a refresh token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _set_with_ttl(key: str, ttl: int, value: str) -> None:
+    """Set a redis key with an optional TTL, falling back to set."""
+    if hasattr(redis_client, "setex"):
+        redis_client.setex(key, ttl, value)
+    else:
+        redis_client.set(key, value)
+
+
+def issue_refresh_token(email: str) -> str:
+    """Generate and persist a refresh token for a user, rotating old values."""
+    normalized = normalize_email(email)
+    raw_token = secrets.token_urlsafe(48)
+    hashed = _hash_refresh_token(raw_token)
+    current = redis_client.get(f"{REFRESH_TOKEN_USER_PREFIX}:{normalized}")
+    if current:
+        redis_client.delete(f"{REFRESH_TOKEN_LOOKUP_PREFIX}:{current}")
+    _set_with_ttl(f"{REFRESH_TOKEN_USER_PREFIX}:{normalized}", REFRESH_TOKEN_TTL_SECONDS, hashed)
+    _set_with_ttl(f"{REFRESH_TOKEN_LOOKUP_PREFIX}:{hashed}", REFRESH_TOKEN_TTL_SECONDS, normalized)
+    return raw_token
+
+
+def revoke_refresh_token(email: str, hashed: str | None = None) -> None:
+    """Remove refresh token mappings for a user."""
+    normalized = normalize_email(email)
+    stored_hash = hashed or redis_client.get(f"{REFRESH_TOKEN_USER_PREFIX}:{normalized}")
+    if stored_hash:
+        redis_client.delete(f"{REFRESH_TOKEN_LOOKUP_PREFIX}:{stored_hash}")
+    redis_client.delete(f"{REFRESH_TOKEN_USER_PREFIX}:{normalized}")
+
+
+def generate_access_token(email: str, role: str) -> str:
+    """Create a signed JWT access token for the given user."""
+    now = datetime.utcnow()
+    payload = {
+        "sub": normalize_email(email),
+        "role": role,
+        "exp": now + ACCESS_TOKEN_TTL,
+        "iat": now,
+        "jti": str(uuid.uuid4()),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=ALGORITHM)
 
 
 def student_key(institution_code: str, student_id: str) -> str:
@@ -706,6 +761,10 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
 class VerifyTokenRequest(BaseModel):
     token: str
 
@@ -921,12 +980,8 @@ def login(req: LoginRequest, request: Request):
         )
         raise HTTPException(status_code=403, detail="User deactivated")
 
-    payload = {
-        "sub": email,
-        "role": user["role"],
-        "exp": datetime.utcnow() + timedelta(hours=1),
-    }
-    token = jwt.encode(payload, JWT_SECRET, algorithm=ALGORITHM)
+    token = generate_access_token(email, user["role"])
+    refresh_token = issue_refresh_token(email)
     logger.info(
         "POST /login success email=%s ip=%s ts=%s request_id=%s",
         email,
@@ -947,7 +1002,46 @@ def login(req: LoginRequest, request: Request):
         )
     except Exception as e:
         logger.error("Failed to store login log for %s: %s", email, e)
-    return {"token": token}
+    return {"token": token, "refresh_token": refresh_token}
+
+
+@app.post("/refresh")
+def refresh(req: RefreshRequest):
+    token_value = (req.refresh_token or "").strip()
+    if not token_value:
+        raise HTTPException(status_code=400, detail="Refresh token required")
+
+    hashed = _hash_refresh_token(token_value)
+    lookup_key = f"{REFRESH_TOKEN_LOOKUP_PREFIX}:{hashed}"
+    email = redis_client.get(lookup_key)
+    if not email:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    stored_hash = redis_client.get(f"{REFRESH_TOKEN_USER_PREFIX}:{normalize_email(email)}")
+    if stored_hash != hashed:
+        revoke_refresh_token(email, hashed)
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    key = find_user_key(email)
+    raw = redis_client.get(key) if key else None
+    if not raw:
+        revoke_refresh_token(email, hashed)
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    try:
+        user = json.loads(raw)
+    except json.JSONDecodeError:
+        revoke_refresh_token(email, hashed)
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    if not user.get("approved") or not user.get("active", True):
+        revoke_refresh_token(email, hashed)
+        raise HTTPException(status_code=403, detail="User not authorized")
+
+    revoke_refresh_token(email, hashed)
+    new_refresh_token = issue_refresh_token(email)
+    access_token = generate_access_token(email, user["role"])
+    return {"token": access_token, "refresh_token": new_refresh_token}
 
 
 @app.post("/verify-token")
@@ -2111,6 +2205,8 @@ def get_metrics(current_user: dict = Depends(get_current_user)):
             or skey.startswith("metrics:")
             or skey.startswith("school_code:")
             or skey.startswith("license:")
+            or skey.startswith(f"{REFRESH_TOKEN_LOOKUP_PREFIX}:")
+            or skey.startswith(f"{REFRESH_TOKEN_USER_PREFIX}:")
         ):
             continue
         if redis_client.get(key):

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import jwt_decode from 'jwt-decode';
+import { clearStoredTokens } from './api';
 import './AdminMenu.css';
 
 function AdminMenu({ children }) {
@@ -12,7 +13,7 @@ function AdminMenu({ children }) {
   const userRole = decoded?.role;
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
+    clearStoredTokens();
     navigate('/login');
   };
 

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -6,7 +6,17 @@ import api from './api';
 import axios from 'axios';
 
 jest.mock('axios', () => {
-  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  const mockAxios = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    create: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() }
+    }
+  };
   mockAxios.create.mockReturnValue(mockAxios);
   return mockAxios;
 });

--- a/frontend/src/LoginForm.js
+++ b/frontend/src/LoginForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api from "./api";
+import api, { storeTokens } from "./api";
 import { Link, useNavigate } from 'react-router-dom';
 import './LoginForm.css';
 import TopMenu from './TopMenu';
@@ -28,8 +28,9 @@ function LoginForm({ infoContent }) {
       console.log('Response data:', resp.data);
 
       const token = resp.data.token || resp.data.access_token;
+      const refreshToken = resp.data.refresh_token || resp.data.refreshToken;
       if (token) {
-        localStorage.setItem('token', token);
+        storeTokens(token, refreshToken);
         console.log('Token stored in localStorage:', token);
 
         // Primary navigation

--- a/frontend/src/NoteEditor.test.js
+++ b/frontend/src/NoteEditor.test.js
@@ -4,7 +4,17 @@ import api from './api';
 import axios from 'axios';
 
 jest.mock('axios', () => {
-  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  const mockAxios = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    create: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() }
+    }
+  };
   mockAxios.create.mockReturnValue(mockAxios);
   return mockAxios;
 });

--- a/frontend/src/NotesHistoryModal.test.js
+++ b/frontend/src/NotesHistoryModal.test.js
@@ -3,7 +3,17 @@ import NotesHistoryModal from './NotesHistoryModal';
 import axios from 'axios';
 
 jest.mock('axios', () => {
-  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  const mockAxios = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    create: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() }
+    }
+  };
   mockAxios.create.mockReturnValue(mockAxios);
   return mockAxios;
 });

--- a/frontend/src/ProtectedRoute.js
+++ b/frontend/src/ProtectedRoute.js
@@ -1,21 +1,27 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import jwtDecode from 'jwt-decode';
+import { getAccessToken, getRefreshToken } from './api';
 
 function ProtectedRoute({ children }) {
-  const token = localStorage.getItem('token');
-  if (!token) {
+  const token = getAccessToken();
+  const refreshToken = getRefreshToken();
+
+  if (!token && !refreshToken) {
     return <Navigate to="/login" replace />;
   }
 
-  try {
-    const { exp } = jwtDecode(token);
-    if (exp && Date.now() >= exp * 1000) {
-      localStorage.removeItem('token');
-      return <Navigate to="/login" replace />;
+  if (token) {
+    try {
+      const { exp } = jwtDecode(token);
+      if (exp && Date.now() >= exp * 1000 && !refreshToken) {
+        return <Navigate to="/login" replace />;
+      }
+    } catch (err) {
+      if (!refreshToken) {
+        return <Navigate to="/login" replace />;
+      }
     }
-  } catch (err) {
-    return <Navigate to="/login" replace />;
   }
 
   return children;

--- a/frontend/src/StudentProfiles.js
+++ b/frontend/src/StudentProfiles.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react';
-import api from './api';
+import api, { getAccessToken, getRefreshToken } from './api';
 import { useNavigate } from 'react-router-dom';
 
 import AdminMenu from './AdminMenu';
@@ -171,7 +171,7 @@ function StudentProfiles() {
   }, [schoolStudents, activeTab]);
 
   const navigate = useNavigate();
-  const token = localStorage.getItem('token');
+  const token = getAccessToken();
   let decoded = {};
   try {
     decoded = token ? jwt_decode(token) : {};
@@ -198,7 +198,6 @@ function StudentProfiles() {
       setNextCursor(resp.data?.next_cursor || null);
     } catch (err) {
       if (err.response && err.response.status === 401) {
-        localStorage.removeItem('token');
         navigate('/login');
       } else {
         console.error('Failed to fetch students:', err);
@@ -213,7 +212,7 @@ function StudentProfiles() {
           const p = api.post(
             '/metrics/student-load-time',
             { role: decoded.role, duration },
-            { headers: { Authorization: `Bearer ${token}` } }
+            { headers: { Authorization: `Bearer ${getAccessToken()}` } }
           );
           if (p && p.catch) p.catch(() => {});
         } catch (e) {
@@ -233,18 +232,8 @@ function StudentProfiles() {
   };
 
   useEffect(() => {
-    if (!token) {
-      navigate('/login');
-      return;
-    }
-    try {
-      const { exp } = jwt_decode(token);
-      if (exp && Date.now() >= exp * 1000) {
-        localStorage.removeItem('token');
-        navigate('/login');
-        return;
-      }
-    } catch (err) {
+    const refreshToken = getRefreshToken();
+    if (!token && !refreshToken) {
       navigate('/login');
       return;
     }

--- a/frontend/src/StudentProfiles.test.js
+++ b/frontend/src/StudentProfiles.test.js
@@ -6,7 +6,17 @@ import api from './api';
 import axios from 'axios';
 
 jest.mock('axios', () => {
-  const mockAxios = { get: jest.fn(), post: jest.fn(), create: jest.fn() };
+  const mockAxios = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    create: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() }
+    }
+  };
   mockAxios.create.mockReturnValue(mockAxios);
   return mockAxios;
 });

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,23 +5,153 @@ const api = axios.create({
   baseURL: process.env.REACT_APP_API_URL || "http://localhost:8000"
 });
 
+const normalizeEmails = (obj) => {
+  if (Array.isArray(obj)) {
+    obj.forEach((item) => normalizeEmails(item));
+    return obj;
+  }
+  if (obj && typeof obj === "object") {
+    for (const key of Object.keys(obj)) {
+      const val = obj[key];
+      if (typeof val === "string" && key.toLowerCase().includes("email")) {
+        obj[key] = val.toLowerCase();
+      } else if (val && typeof val === "object") {
+        normalizeEmails(val);
+      }
+    }
+  }
+  return obj;
+};
+
+const getLocalStorage = () => {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+};
+
+export const getAccessToken = () => {
+  const storage = getLocalStorage();
+  return storage ? storage.getItem("token") : null;
+};
+
+export const getRefreshToken = () => {
+  const storage = getLocalStorage();
+  return storage ? storage.getItem("refreshToken") : null;
+};
+
+export const storeTokens = (accessToken, refreshToken) => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  if (accessToken) {
+    storage.setItem("token", accessToken);
+  }
+  if (refreshToken) {
+    storage.setItem("refreshToken", refreshToken);
+  }
+};
+
+export const clearStoredTokens = () => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.removeItem("token");
+  storage.removeItem("refreshToken");
+};
+
+const subscribers = [];
+let refreshPromise = null;
+
+const addSubscriber = (callback) => {
+  subscribers.push(callback);
+};
+
+const notifySubscribers = (error, accessToken) => {
+  while (subscribers.length) {
+    const subscriber = subscribers.shift();
+    if (subscriber) {
+      subscriber(error, accessToken);
+    }
+  }
+};
+
+const performRefresh = async (refreshToken) => {
+  try {
+    const resp = await api.post(
+      "/refresh",
+      { refresh_token: refreshToken },
+      { skipAuthRefresh: true, _skipAuthToken: true }
+    );
+    const newAccess = resp.data.token || resp.data.access_token;
+    const newRefresh = resp.data.refresh_token || resp.data.refreshToken;
+    storeTokens(newAccess, newRefresh);
+    notifySubscribers(null, newAccess);
+    return newAccess;
+  } catch (err) {
+    clearStoredTokens();
+    notifySubscribers(err, null);
+    throw err;
+  } finally {
+    refreshPromise = null;
+  }
+};
+
 if (api.interceptors?.request) {
   api.interceptors.request.use((config) => {
-    const normalize = (obj) => {
-      if (obj && typeof obj === "object") {
-        for (const key of Object.keys(obj)) {
-          const val = obj[key];
-          if (typeof val === "string" && key.toLowerCase().includes("email")) {
-            obj[key] = val.toLowerCase();
-          }
-        }
+    config.data = normalizeEmails(config.data);
+    config.params = normalizeEmails(config.params);
+
+    if (!config._skipAuthToken) {
+      const accessToken = getAccessToken();
+      if (accessToken) {
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer ${accessToken}`;
       }
-      return obj;
-    };
-    config.data = normalize(config.data);
-    config.params = normalize(config.params);
+    }
+
     return config;
   });
+}
+
+if (api.interceptors?.response) {
+  api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const { response, config } = error;
+      if (!response || response.status !== 401 || config?.skipAuthRefresh || config?._retry) {
+        return Promise.reject(error);
+      }
+
+      const refreshToken = getRefreshToken();
+      if (!refreshToken) {
+        clearStoredTokens();
+        return Promise.reject(error);
+      }
+
+      const retryOriginalRequest = new Promise((resolve, reject) => {
+        addSubscriber((refreshErr, newAccessToken) => {
+          if (refreshErr || !newAccessToken) {
+            reject(refreshErr || error);
+            return;
+          }
+          config._retry = true;
+          config.headers = config.headers || {};
+          config.headers.Authorization = `Bearer ${newAccessToken}`;
+          resolve(api(config));
+        });
+      });
+
+      if (!refreshPromise) {
+        refreshPromise = performRefresh(refreshToken);
+      }
+
+      try {
+        await refreshPromise;
+        return retryOriginalRequest;
+      } catch (refreshErr) {
+        return Promise.reject(refreshErr);
+      }
+    }
+  );
 }
 
 export default api;

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from jose import jwt
 import json
 import app.main as main_app
 from datetime import datetime, timedelta
+import hashlib
 
 
 class DummyRedis:
@@ -18,28 +19,53 @@ class DummyRedis:
         self.hashes = {}
         self.lists = {}
         self.sets = {}
+        self.expirations = {}
+
+    def _expired(self, key):
+        expires = self.expirations.get(key)
+        if expires and expires <= datetime.utcnow():
+            self.store.pop(key, None)
+            self.hashes.pop(key, None)
+            self.lists.pop(key, None)
+            self.sets.pop(key, None)
+            self.expirations.pop(key, None)
+            return True
+        return False
 
     def set(self, key, value):
         self.store[key] = value
+        self.expirations.pop(key, None)
 
     def get(self, key):
+        if self._expired(key):
+            return None
         return self.store.get(key)
 
     def exists(self, key):
+        if self._expired(key):
+            return False
         return key in self.store
 
     def delete(self, key):
         self.store.pop(key, None)
+        self.expirations.pop(key, None)
 
     def scan_iter(self, pattern="*"):
         from fnmatch import fnmatch
         for k in list(self.store.keys()):
+            if self._expired(k):
+                continue
             if fnmatch(k, pattern):
                 yield k
 
     def scan(self, cursor=0, match=None, count=None):
         from fnmatch import fnmatch
-        keys = [k for k in self.store.keys() if not match or fnmatch(k, match)]
+        keys = []
+        for k in list(self.store.keys()):
+            if self._expired(k):
+                continue
+            if not match or fnmatch(k, match):
+                keys.append(k)
         return 0, keys
 
     def incr(self, key, amount=1):
@@ -73,6 +99,7 @@ class DummyRedis:
         self.hashes.clear()
         self.lists.clear()
         self.sets.clear()
+        self.expirations.clear()
 
     def hset(self, name, key, value):
         self.hashes.setdefault(name, {})[key] = value
@@ -90,6 +117,18 @@ class DummyRedis:
         if 0 <= index < len(lst):
             return lst[index]
         return None
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.expirations[key] = datetime.utcnow() + timedelta(seconds=ttl)
+
+    def ttl(self, key):
+        if self._expired(key):
+            return -2
+        expires = self.expirations.get(key)
+        if not expires:
+            return -1
+        return int((expires - datetime.utcnow()).total_seconds())
 
 
 main_app.redis_client = DummyRedis()
@@ -209,6 +248,68 @@ def test_registration_flow():
     assert payload["role"] == "career"
 
 
+def test_login_issues_refresh_token_and_allows_rotation():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post(
+        "/login",
+        json={"email": "admin@example.com", "password": "admin123"},
+    )
+    assert login_resp.status_code == 200
+    data = login_resp.json()
+    access_token = data["token"]
+    refresh_token = data["refresh_token"]
+    assert access_token
+    assert refresh_token
+
+    hashed = hashlib.sha256(refresh_token.encode()).hexdigest()
+    lookup_key = f"refresh_token_lookup:{hashed}"
+    user_key = f"refresh_token_user:admin@example.com"
+    assert main_app.redis_client.get(lookup_key) == "admin@example.com"
+    assert main_app.redis_client.get(user_key) == hashed
+
+    refresh_resp = client.post(
+        "/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert refresh_resp.status_code == 200
+    refreshed = refresh_resp.json()
+    assert refreshed["token"] != access_token
+    assert refreshed["refresh_token"] != refresh_token
+
+    # Old lookup entries should be gone and replaced with the new token
+    assert main_app.redis_client.get(lookup_key) is None
+    new_hashed = hashlib.sha256(refreshed["refresh_token"].encode()).hexdigest()
+    assert main_app.redis_client.get(f"refresh_token_lookup:{new_hashed}") == "admin@example.com"
+    assert main_app.redis_client.get(user_key) == new_hashed
+
+
+def test_refresh_rejects_invalid_or_expired_tokens():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post(
+        "/login",
+        json={"email": "admin@example.com", "password": "admin123"},
+    )
+    refresh_token = login_resp.json()["refresh_token"]
+    hashed = hashlib.sha256(refresh_token.encode()).hexdigest()
+
+    # Simulate expiry by removing lookup entry
+    main_app.redis_client.delete(f"refresh_token_lookup:{hashed}")
+    expired_resp = client.post(
+        "/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert expired_resp.status_code == 401
+
+    # Completely invalid token
+    invalid_resp = client.post(
+        "/refresh",
+        json={"refresh_token": "totally-invalid"},
+    )
+    assert invalid_resp.status_code == 401
 def test_register_links_existing_student(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()


### PR DESCRIPTION
## Summary
- issue and rotate hashed refresh tokens, expose a /refresh endpoint, and adjust metrics counting to ignore refresh token keys
- extend the DummyRedis test double with TTL support and add backend tests covering refresh success and failure cases
- add axios request/response interceptors for automatic token refresh, store both tokens on login, and update UI guards to rely on the centralized helpers

## Testing
- pytest
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ccd13ebf408333be2a436c113e8a77