### PR TITLE
Add email analytics to weekly summary

### DIFF
--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -13,6 +13,7 @@ from openai import OpenAI
 from backend.app.logging_utils import get_logger
 
 ACTIVITY_LOG_KEY = "activity_logs"
+EMAIL_OPEN_TOKENS_KEY = "email_open_tokens"
 redis_client = None
 send_email = None
 
@@ -122,13 +123,16 @@ def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
             created_emails.add(email)
 
     # From activity logs (POST/PUT /students*) to catch any creations not captured above
-    logs = redis_client.lrange(ACTIVITY_LOG_KEY, 0, -1) or []
-    for raw in logs:
-        raw = _decode(raw)
+    raw_logs = redis_client.lrange(ACTIVITY_LOG_KEY, 0, -1) or []
+    activity_entries: List[Dict[str, Any]] = []
+    for raw in raw_logs:
+        decoded = _decode(raw)
         try:
-            entry = json.loads(raw)
+            entry = json.loads(decoded)
         except Exception:
             continue
+
+        activity_entries.append(entry)
 
         if (entry.get("user") or "").strip().lower() != user_lc:
             continue
@@ -226,13 +230,89 @@ def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
                 ):
                     stats_per_student[email]["note_in_window"] = True
 
+    # ---- Email analytics for the week ----
+    email_tokens: Dict[str, Dict[str, Any]] = {}
+    per_student_email: Dict[str, Dict[str, Any]] = {
+        email: {"sent": 0, "opened": False, "clicked": False}
+        for email in user_students
+    }
+    sent_count = 0
+    opened_students: set[str] = set()
+    clicked_students: set[str] = set()
+
+    try:
+        if hasattr(redis_client, "hscan_iter"):
+            iterator = redis_client.hscan_iter(EMAIL_OPEN_TOKENS_KEY)
+        else:
+            iterator = redis_client.hashes.get(EMAIL_OPEN_TOKENS_KEY, {}).items()  # type: ignore[attr-defined]
+    except Exception:
+        iterator = []
+
+    for token, raw in iterator:
+        decoded = _decode(raw)
+        try:
+            info = json.loads(decoded)
+        except Exception:
+            continue
+
+        email = (info.get("student_email") or "").strip()
+        if not email:
+            continue
+        if email not in user_students:
+            user_students.add(email)
+            stats_per_student.setdefault(
+                email,
+                {
+                    "assigned_jobs": 0,
+                    "placed_jobs": 0,
+                    "latest_note": None,
+                    "notes": [],
+                    "note_in_window": False,
+                },
+            )
+            per_student_email[email] = {"sent": 0, "opened": False, "clicked": False}
+
+        email_tokens[token] = {
+            "student_email": email,
+            "sent": info.get("sent"),
+            "job_code": info.get("job_code"),
+        }
+
+        if _in_window(info.get("sent"), window_start, window_end):
+            sent_count += 1
+            per_student_email[email]["sent"] += 1
+
+    for entry in activity_entries:
+        token = entry.get("token")
+        if not token or token not in email_tokens:
+            continue
+
+        timestamp = entry.get("timestamp")
+        if not _in_window(timestamp, window_start, window_end):
+            continue
+
+        email = email_tokens[token]["student_email"]
+        per_student_email.setdefault(email, {"sent": 0, "opened": False, "clicked": False})
+
+        event = entry.get("event")
+        if event == "email_open":
+            per_student_email[email]["opened"] = True
+            opened_students.add(email)
+        elif event == "email_click":
+            per_student_email[email]["clicked"] = True
+            clicked_students.add(email)
+
+    for email in stats_per_student.keys():
+        per_student_email.setdefault(email, {"sent": 0, "opened": False, "clicked": False})
+
     stats_students: List[Dict[str, Any]] = []
     engaged_count = 0
     assignment_count = 0
     placement_count = 0
     notes_count = 0
 
-    for email, data in stats_per_student.items():
+    for email in sorted(stats_per_student.keys()):
+        data = stats_per_student[email]
         assigned = data["assigned_jobs"]
         placed = data["placed_jobs"]
         all_notes = data["notes"]
@@ -251,6 +331,7 @@ def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
             or datetime.min.replace(tzinfo=timezone.utc)
         )
 
+        email_metrics = per_student_email.get(email, {"sent": 0, "opened": False, "clicked": False})
         stats_students.append(
             {
                 "email": email,
@@ -258,8 +339,26 @@ def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
                 "placed_jobs": placed,
                 "latest_note": latest_note,
                 "notes": all_notes,
+                "email_metrics": email_metrics,
             }
         )
+
+    email_analytics = {
+        "sent_count": sent_count,
+        "unique_open_count": len(opened_students),
+        "unique_click_count": len(clicked_students),
+        "click_students": sorted(clicked_students),
+        "open_students": sorted(opened_students),
+        "per_student": [
+            {
+                "email": student["email"],
+                "sent": student["email_metrics"]["sent"],
+                "opened": student["email_metrics"]["opened"],
+                "clicked": student["email_metrics"]["clicked"],
+            }
+            for student in stats_students
+        ],
+    }
 
     return {
         "created_count": len(created_emails),
@@ -271,6 +370,7 @@ def compile_weekly_stats(user_email: str, now: datetime) -> Dict[str, Any]:
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
         "user_email": user_email,
+        "email_analytics": email_analytics,
     }
 
 
@@ -278,6 +378,13 @@ def compile_all_weekly_stats(now: datetime) -> Dict[str, Any]:
     """Aggregate weekly stats for all career staff (for admin summaries)."""
     _ensure_dependencies()
     users: Dict[str, Any] = {}
+    agg_email = {
+        "sent_count": 0,
+        "unique_open_count": 0,
+        "unique_click_count": 0,
+        "click_students": set(),
+        "open_students": set(),
+    }
     for key in redis_client.scan_iter("user:*"):
         raw = _decode(redis_client.get(key))
         if not raw:
@@ -289,8 +396,27 @@ def compile_all_weekly_stats(now: datetime) -> Dict[str, Any]:
         if user.get("role") != "career":
             continue
         email = key.split("user:", 1)[1]
-        users[email] = compile_weekly_stats(email, now)
-    return {"users": users, "window_end": now.isoformat()}
+        stats = compile_weekly_stats(email, now)
+        users[email] = stats
+        email_stats = stats.get("email_analytics", {})
+        agg_email["sent_count"] += email_stats.get("sent_count", 0)
+        agg_email["unique_open_count"] += email_stats.get("unique_open_count", 0)
+        agg_email["unique_click_count"] += email_stats.get("unique_click_count", 0)
+        agg_email["click_students"].update(email_stats.get("click_students", []))
+        agg_email["open_students"].update(email_stats.get("open_students", []))
+
+    agg_email_summary = {
+        "sent_count": agg_email["sent_count"],
+        "unique_open_count": agg_email["unique_open_count"],
+        "unique_click_count": agg_email["unique_click_count"],
+        "click_students": sorted(agg_email["click_students"]),
+        "open_students": sorted(agg_email["open_students"]),
+    }
+    return {
+        "users": users,
+        "window_end": now.isoformat(),
+        "email_analytics": agg_email_summary,
+    }
 
 
 def build_summary_narrative(stats: Dict[str, Any], user_name: str) -> str:
@@ -306,6 +432,17 @@ def build_summary_narrative(stats: Dict[str, Any], user_name: str) -> str:
     assignment_count = stats.get("assignment_count", 0)
     placement_count = stats.get("placement_count", 0)
     notes_count = stats.get("notes_count", 0)
+
+    email_stats = stats.get("email_analytics", {}) or {}
+    sent_count = email_stats.get("sent_count", 0)
+    open_count = email_stats.get("unique_open_count", 0)
+    click_count = email_stats.get("unique_click_count", 0)
+    click_students = email_stats.get("click_students") or []
+    click_line = (
+        f"• Apply link clicks: {click_count} ({', '.join(click_students)})"
+        if click_students
+        else f"• Apply link clicks: {click_count}"
+    )
 
     prompt = f"""
 You are generating a concise, upbeat weekly activity summary email for {user_name}.
@@ -324,6 +461,11 @@ Key Numbers
 • {assignment_count} job assignments
 • {placement_count} job placements
 • Notes recorded for {notes_count} students this week
+
+Email Analytics
+• {sent_count} outreach emails sent
+• {open_count} unique opens
+{click_line}
 
 Short Insights
 • 1–3 short bullet points highlighting notable trends or outcomes based on the Stats JSON.

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,5 +1,8 @@
 import json
+import os
 from datetime import datetime, timezone, timedelta
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 from backend.app.services import summary
 
@@ -9,6 +12,7 @@ class DummyRedis:
         self.store = {}
         self.lists = {}
         self.sets = {}
+        self.hashes = {}
 
     def set(self, key, value):
         self.store[key] = value
@@ -28,7 +32,7 @@ class DummyRedis:
     def scan_iter(self, pattern="*"):
         from fnmatch import fnmatch
 
-        for k in list(self.store.keys()) + list(self.lists.keys()):
+        for k in list(self.store.keys()) + list(self.lists.keys()) + list(self.hashes.keys()):
             if fnmatch(k, pattern):
                 yield k
 
@@ -50,6 +54,16 @@ class DummyRedis:
         if key in self.sets:
             self.sets[key].discard(value)
 
+    def hset(self, key, field, value):
+        self.hashes.setdefault(key, {})[field] = value
+
+    def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
+    def hscan_iter(self, key):
+        for field, value in self.hashes.get(key, {}).items():
+            yield field, value
+
 
 
 def test_admin_weekly_summary():
@@ -60,15 +74,34 @@ def test_admin_weekly_summary():
     summary.redis_client.set("user:career@example.com", json.dumps({"role": "career"}))
     summary.redis_client.set("user:admin@example.com", json.dumps({"role": "admin"}))
 
+    token = "tok-1"
+    sent_ts = now.isoformat()
+    summary.redis_client.hset(
+        summary.EMAIL_OPEN_TOKENS_KEY,
+        token,
+        json.dumps(
+            {
+                "student_email": "stu@example.com",
+                "job_code": "1",
+                "sent": sent_ts,
+            }
+        ),
+    )
+
     # Activity log for career user
-    log = {
+    creation_log = {
         "user": "career@example.com",
         "method": "POST",
         "path": "/students",
         "timestamp": now.isoformat(),
         "student_email": "stu@example.com",
     }
-    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(log))
+    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(creation_log))
+
+    open_log = {"event": "email_open", "token": token, "timestamp": sent_ts}
+    click_log = {"event": "email_click", "token": token, "timestamp": sent_ts}
+    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(open_log))
+    summary.redis_client.lpush(summary.ACTIVITY_LOG_KEY, json.dumps(click_log))
 
     # Job record
     job = {
@@ -112,6 +145,10 @@ def test_admin_weekly_summary():
     assert (
         captured_stats["stats"]["users"]["career@example.com"]["created_count"] == 1
     )
+    email_stats = captured_stats["stats"]["email_analytics"]
+    assert email_stats["sent_count"] == 1
+    assert email_stats["unique_click_count"] == 1
+    assert email_stats["click_students"] == ["stu@example.com"]
 
 
 def test_compile_weekly_stats_handles_naive_timestamp():
@@ -140,6 +177,7 @@ def test_compile_weekly_stats_handles_naive_timestamp():
     stats = summary.compile_weekly_stats("career@example.com", now)
     assert stats["created_count"] == 1
     assert stats["students"][0]["latest_note"]["text"] == "note"
+    assert stats["email_analytics"]["sent_count"] == 0
 
 
 def test_compile_weekly_stats_includes_all_notes():
@@ -172,6 +210,7 @@ def test_compile_weekly_stats_includes_all_notes():
     notes = stats["students"][0]["notes"]
     assert [n["text"] for n in notes] == ["old", "new"]
     assert stats["notes_count"] == 1
+    assert stats["email_analytics"]["unique_open_count"] == 0
 
 
 def test_preexisting_student_assignments_counted():
@@ -198,6 +237,7 @@ def test_preexisting_student_assignments_counted():
     stats = summary.compile_weekly_stats("career@example.com", now)
     assert stats["created_count"] == 0
     assert stats["assignment_count"] == 1
+    assert stats["email_analytics"]["unique_click_count"] == 0
     assert stats["placement_count"] == 1
     assert stats["engaged_count"] == 1
     assert any(


### PR DESCRIPTION
## Summary
- augment weekly stats to gather email send, open, and click metrics per student and expose them in the summary payload
- roll up the new analytics for admin summaries and surface the numbers in the generated Email Analytics section
- extend summary tests with hash support, seed tracking data, and assert the new metrics

## Testing
- pytest tests/test_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68d02d6b113c8333ac76d579a9d7c76e