### PR TITLE
Align match polling storage with job IDs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1731,24 +1731,23 @@ def match_job(
     """Launch a background matching job and return immediately."""
 
     job_id = str(uuid.uuid4())
-    result_key = f"match_job:{job_id}"
 
-    def _run_match_job(job_code: str, redis_key: str, enqueued_at: float) -> None:
+    def _run_match_job(job_code: str, job_id: str, enqueued_at: float) -> None:
+        redis_key = f"match_job:{job_id}"
         try:
             logger.info("🚀 Starting background match job %s", job_code)
-            matches = match_worker(job_code, False, enqueued_at)
-            payload: dict[str, Any] = {"status": "complete", "results": matches}
+            match_worker(job_code, False, enqueued_at, job_id=job_id)
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("❌ Match job %s failed", job_code)
-            payload = {"status": "failed", "error": str(exc)}
-        redis_client.set(redis_key, json.dumps(payload))
+            payload = {"status": "failed", "results": [], "error": str(exc)}
+            redis_client.set(redis_key, json.dumps(payload))
 
     enqueue_time = datetime.now().timestamp()
     if hasattr(redis_client, "pipeline"):
         background_tasks.add_task(
             _run_match_job,
             req.job_code,
-            result_key,
+            job_id,
             enqueue_time,
         )
         logger.info(
@@ -1762,11 +1761,7 @@ def match_job(
     logger.info(
         "⚙️ Executing match synchronously for job %s (test mode)", req.job_code
     )
-    matches = match_worker(req.job_code, False, enqueue_time)
-    redis_client.set(
-        result_key,
-        json.dumps({"status": "complete", "results": matches}),
-    )
+    matches = match_worker(req.job_code, False, enqueue_time, job_id=job_id)
     return {"job_id": job_id, "matches": matches}
 
 
@@ -1798,6 +1793,7 @@ async def _perform_match_async(
     send_emails: bool = False,
     enq_time: float | None = None,
     progress_callback: Callable[[str, dict[str, Any]], None] | None = None,
+    job_id: str | None = None,
 ):
     key = f"job:{job_code}"
     raw = redis_client.get(key)
@@ -2039,8 +2035,18 @@ async def _perform_match_async(
 
 
 
+    payload = {"status": "complete", "results": top_matches}
+    if job_id:
+        redis_client.set(
+            f"match_job:{job_id}", json.dumps(payload)
+        )
+        logger.info(
+            "✅ Marked job %s as complete in Redis with %s results",
+            job_id,
+            len(top_matches),
+        )
     redis_client.set(
-        f"match_results:{job_code}", json.dumps(top_matches)
+        f"match_results:{job_code}", json.dumps(payload)
     )
     if progress_callback:
         try:
@@ -2089,14 +2095,26 @@ def _perform_match(
     send_emails: bool = False,
     enq_time: float | None = None,
     progress_callback: Callable[[str, dict[str, Any]], None] | None = None,
+    job_id: str | None = None,
 ):
     """Synchronous wrapper for background execution."""
     return asyncio.run(
-        _perform_match_async(job_code, send_emails, enq_time, progress_callback)
+        _perform_match_async(
+            job_code,
+            send_emails,
+            enq_time,
+            progress_callback,
+            job_id=job_id,
+        )
     )
 
 
-def match_worker(job_code: str, send_emails: bool = False, enq_time: float | None = None):
+def match_worker(
+    job_code: str,
+    send_emails: bool = False,
+    enq_time: float | None = None,
+    job_id: str | None = None,
+):
     logger.info(f"🔎 Match worker started for job {job_code}")
     start = datetime.now()
     timings: dict[str, float] = {}
@@ -2152,7 +2170,13 @@ def match_worker(job_code: str, send_emails: bool = False, enq_time: float | Non
     if enq_time is not None:
         queue_time = start - datetime.fromtimestamp(enq_time)
         redis_client.incrbyfloat("metrics:match_queue_time", queue_time.total_seconds())
-    result = _perform_match(job_code, send_emails, enq_time, progress_callback)
+    result = _perform_match(
+        job_code,
+        send_emails,
+        enq_time,
+        progress_callback,
+        job_id=job_id,
+    )
     process_time = datetime.now() - start
     redis_client.incrbyfloat("metrics:match_process_time", process_time.total_seconds())
     breakdown_parts = []
@@ -2183,7 +2207,20 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         return {"matches": []}
 
     try:
-        matches = {m["email"]: m for m in json.loads(results_json)}
+        parsed = json.loads(results_json)
+    except json.JSONDecodeError:
+        logger.warning("⚠️ Stored match payload for job %s was not JSON", job_code)
+        return {"matches": []}
+
+    if isinstance(parsed, dict):
+        stored_matches = parsed.get("results", [])
+    elif isinstance(parsed, list):
+        stored_matches = parsed
+    else:
+        stored_matches = []
+
+    try:
+        matches = {m["email"]: m for m in stored_matches}
         logger.info("📦 Returning %s stored matches for job %s", len(matches), job_code)
 
         # Ensure each match has first and last name fields
@@ -2251,12 +2288,20 @@ def has_match_data(job_id: str):
         payload = json.loads(results_json)
     except json.JSONDecodeError:
         logger.warning("⚠️ Match payload for job %s was not JSON", job_id)
-        return results_json
+        return {"has_match": True, "results": []}
 
-    if isinstance(payload, dict) and "results" in payload:
-        return payload["results"]
+    results: list[Any]
+    if isinstance(payload, dict):
+        results = payload.get("results", [])
+    elif isinstance(payload, list):
+        results = payload
+    else:
+        results = []
 
-    return payload
+    logger.info(
+        "📬 Returning %s results for match job %s", len(results), job_id
+    )
+    return {"has_match": True, "results": results}
 
 @app.get("/jobs")
 def list_jobs(current_user: dict = Depends(get_current_user)):
@@ -3417,12 +3462,23 @@ def delete_student(email: str, current_user: dict = Depends(get_current_user)):
         if not raw:
             continue
         try:
-            matches = json.loads(raw)
-            new_matches = [m for m in matches if m.get("email") != email]
-            if len(new_matches) != len(matches):
-                redis_client.set(match_key, json.dumps(new_matches))
+            data = json.loads(raw)
         except Exception:
             continue
+
+        if isinstance(data, dict):
+            matches = data.get("results", [])
+            status = data.get("status", "complete")
+        elif isinstance(data, list):
+            matches = data
+            status = "complete"
+        else:
+            continue
+
+        new_matches = [m for m in matches if m.get("email") != email]
+        if len(new_matches) != len(matches):
+            updated_payload = {"status": status, "results": new_matches}
+            redis_client.set(match_key, json.dumps(updated_payload))
 
     return {"message": f"Student {email} and related data deleted successfully"}
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -208,9 +208,9 @@ def test_get_match_results_status(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
 
     job_code = "XYZ"
-    store[f"match_results:{job_code}"] = json.dumps([
-        {"email": "a@example.com", "score": 1.0}
-    ])
+    store[f"match_results:{job_code}"] = json.dumps(
+        {"status": "complete", "results": [{"email": "a@example.com", "score": 1.0}]}
+    )
     store[f"job:{job_code}"] = json.dumps({
         "job_code": job_code,
         "assigned_students": ["a@example.com"],
@@ -238,9 +238,9 @@ def test_get_match_results_status_placed(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
 
     job_code = "XYZ2"
-    store[f"match_results:{job_code}"] = json.dumps([
-        {"email": "b@example.com", "score": 1.0}
-    ])
+    store[f"match_results:{job_code}"] = json.dumps(
+        {"status": "complete", "results": [{"email": "b@example.com", "score": 1.0}]}
+    )
     store[f"job:{job_code}"] = json.dumps({
         "job_code": job_code,
         "assigned_students": [],
@@ -268,7 +268,9 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
 
     job_code = "XYZ3"
-    store[f"match_results:{job_code}"] = json.dumps([])
+    store[f"match_results:{job_code}"] = json.dumps(
+        {"status": "complete", "results": []}
+    )
     store[f"job:{job_code}"] = json.dumps({
         "job_code": job_code,
         "assigned_students": ["a@example.com", "b@example.com"],
@@ -304,9 +306,9 @@ def test_get_match_results_includes_notes(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
 
     job_code = "XYZ4"
-    store[f"match_results:{job_code}"] = json.dumps([
-        {"email": "a@example.com", "score": 1.0}
-    ])
+    store[f"match_results:{job_code}"] = json.dumps(
+        {"status": "complete", "results": [{"email": "a@example.com", "score": 1.0}]}
+    )
     store[f"job:{job_code}"] = json.dumps({
         "job_code": job_code,
         "assigned_students": [],
@@ -337,10 +339,15 @@ def test_get_match_results_no_duplicate_emails(monkeypatch):
     monkeypatch.setattr(main_app.redis_client, "set", fake_set)
 
     job_code = "XYZ5"
-    store[f"match_results:{job_code}"] = json.dumps([
-        {"email": "dup@example.com", "score": 1.0},
-        {"email": "dup@example.com", "score": 2.0},
-    ])
+    store[f"match_results:{job_code}"] = json.dumps(
+        {
+            "status": "complete",
+            "results": [
+                {"email": "dup@example.com", "score": 1.0},
+                {"email": "dup@example.com", "score": 2.0},
+            ],
+        },
+    )
     store[f"job:{job_code}"] = json.dumps({
         "job_code": job_code,
         "assigned_students": [],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -773,7 +773,10 @@ def test_admin_reset_jobs():
 
     # Seed some job and match data
     main_app.redis_client.set("job:one", json.dumps({"job_code": "one"}))
-    main_app.redis_client.set("match_results:one", json.dumps([]))
+    main_app.redis_client.set(
+        "match_results:one",
+        json.dumps({"status": "complete", "results": []}),
+    )
 
     login_resp = client.post(
         "/login", json={"email": "admin@example.com", "password": "admin123"}
@@ -2173,7 +2176,10 @@ def test_admin_delete_student_cleans_up():
     )
     main_app.redis_client.set("resume:j1:del@example.com", "resume")
     main_app.redis_client.set("job_description:j1:del@example.com", "desc")
-    main_app.redis_client.set("match_results:j1", json.dumps([{"email": "del@example.com"}]))
+    main_app.redis_client.set(
+        "match_results:j1",
+        json.dumps({"status": "complete", "results": [{"email": "del@example.com"}]}),
+    )
 
     login_resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
     token = login_resp.json()["token"]
@@ -2192,7 +2198,9 @@ def test_admin_delete_student_cleans_up():
     assert "del@example.com" not in job.get("placed_students", [])
     assert main_app.redis_client.get("resume:j1:del@example.com") is None
     assert main_app.redis_client.get("job_description:j1:del@example.com") is None
-    assert main_app.redis_client.get("match_results:j1") == "[]"
+    stored_match = main_app.redis_client.get("match_results:j1")
+    assert stored_match is not None
+    assert json.loads(stored_match)["results"] == []
 
 
 def test_delete_student_not_found():


### PR DESCRIPTION
## Summary
- unify background match job storage under the `match_job:{job_id}` namespace and update `/has-match` polling responses
- persist match results with a consistent `{status, results}` structure and update cleanup logic accordingly
- refresh unit tests to reflect the new Redis payload format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06879e1d083338cd0109aa69c00e4