### PR TITLE
Handle legacy match lookup in has_match_data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2588,8 +2588,17 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
 
 @app.get("/has-match/{job_id}")
 def has_match_data(job_id: str):
-    key = f"match_job:{job_id}"
+    storage_id = job_id
+    key = f"match_job:{storage_id}"
     results_json = redis_client.get(key)
+
+    if results_json is None:
+        lookup_key = f"match_job_lookup:{job_id}"
+        lookup_id = redis_client.get(lookup_key)
+        if lookup_id:
+            storage_id = lookup_id
+            key = f"match_job:{storage_id}"
+            results_json = redis_client.get(key)
 
     if results_json is None:
         return {"status": "pending"}
@@ -2611,10 +2620,11 @@ def has_match_data(job_id: str):
         results = []
 
     logger.info(
-        "✅ Returning %s results with status %s for job %s",
+        "✅ Returning %s results with status %s for job %s (storage id %s)",
         len(results),
         status,
         job_id,
+        storage_id,
     )
     return {"status": status, "results": results}
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3124,3 +3124,20 @@ def test_students_pagination():
         )
         assert len(resp2.json()["students"]) == 1
 
+
+def test_has_match_uses_lookup_for_uuid_results():
+    main_app.redis_client.flushdb()
+
+    job_code = "legacy-job"
+    storage_id = "123e4567-e89b-12d3-a456-426614174000"
+    match_results = {"status": "complete", "results": [{"email": "stud@example.com"}]}
+
+    main_app.redis_client.set(f"match_job:{storage_id}", json.dumps(match_results))
+    main_app.redis_client.set(f"match_job_lookup:{job_code}", storage_id)
+
+    resp = client.get(f"/has-match/{job_code}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "complete"
+    assert data["results"] == match_results["results"]
+


### PR DESCRIPTION
## Summary
- fall back to the `match_job_lookup:{job_code}` entry when checking match status so legacy job codes resolve to the UUID-backed payload
- include the resolved storage identifier in the match status log for easier tracing
- add a FastAPI test covering the case where `/has-match/{job_code}` reads a UUID-backed match payload

## Testing
- pytest tests/test_main.py::test_has_match_uses_lookup_for_uuid_results


------
https://chatgpt.com/codex/tasks/task_e_68d21ffcc9008333adf0a154d963814b