### PR TITLE
Show assigned students beneath matches

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -760,79 +760,164 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
             )}
           </tbody>
         </table>
+        {matches[job.job_code] && matches[job.job_code].some((m) => m.status === 'assigned') && (
+          <div className="assigned-subtable">
+            <h4>Assigned Students</h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {matches[job.job_code]
+                  .filter((m) => m.status === 'assigned')
+                  .map((m) => (
+                    <tr key={m.email}>
+                      <td>
+                        {m.first_name} {m.last_name}
+                      </td>
+                      <td>{m.email}</td>
+                      <td>
+                        <span className="badge assigned">Assigned</span>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </>
-      );
+    );
   };
 
   const renderAssigned = (job) => {
     const matchList = matches[job.job_code] || [];
     const assignedMatches = matchList.filter((m) => m.status === 'assigned');
+    console.log('📌 Assigned subtable for', job.job_code, matches[job.job_code]);
+
+    if (assignedMatches.length > 0) {
+      return (
+        <div className="assigned-subtable">
+          <h4>Assigned Students</h4>
+          <table className="matches-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Score</th>
+                <th>Resume</th>
+                <th>Note</th>
+                <th>Status</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assignedMatches.map((row) => (
+                <tr key={row.email}>
+                  <td>
+                    {row.first_name || row.name?.split(' ')[0]}{' '}
+                    {row.last_name || row.name?.split(' ')[1]}
+                  </td>
+                  <td>{row.email}</td>
+                  <td>{formatScore(row.score)}</td>
+                  <td>
+                    {generatingResumes[`${job.job_code}:${row.email}`] ? (
+                      <span className="spinner">⏳</span>
+                    ) : generatedResumes[`${job.job_code}:${row.email}`] ? (
+                      <button
+                        className="resume-icon-button"
+                        onClick={() => viewResume(row.email, job.job_code)}
+                      >
+                        📥
+                      </button>
+                    ) : (
+                      <button onClick={() => generateResume(row.email, job.job_code)}>
+                        Generate Resume
+                      </button>
+                    )}
+                  </td>
+                  <td>
+                    <button onClick={() => openNotes(job, row)}>
+                      View Notes{row.notes && ` (${row.notes.length})`}
+                    </button>
+                  </td>
+                  <td className="status-cell">
+                    <span className="badge assigned inline">Assigned</span>
+                  </td>
+                  <td>
+                    {isRecruiter ? (
+                      <>
+                        <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                          Notify Candidate
+                        </button>
+                        <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                          Resend Job Description
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button onClick={() => handlePlace(job, row)}>Place</button>
+                        <button onClick={() => notifyInterest(job.job_code, row.email)}>
+                          Resend Job Description
+                        </button>
+                      </>
+                    )}
+                    <button onClick={() => rejectAssigned(job.job_code, row.email)}>
+                      Not Interested
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    if (job.assigned_students?.length) {
+      return (
+        <div className="assigned-subtable">
+          <h4>Assigned Students</h4>
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {job.assigned_students.map((email) => {
+                const match = matchList.find((m) => m.email === email);
+                const displayName = match
+                  ? `${match.first_name || match.name?.split(' ')[0] || ''} ${
+                      match.last_name || match.name?.split(' ')[1] || ''
+                    }`.trim()
+                  : '';
+                return (
+                  <tr key={email}>
+                    <td>{displayName || email}</td>
+                    <td>{email}</td>
+                    <td>
+                      <span className="badge assigned">Assigned</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
     return (
-      <table className="matches-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Score</th>
-            <th>Resume</th>
-            <th>Note</th>
-            <th>Status</th>
-            <th>Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {assignedMatches.map((row) => (
-            <tr key={row.email}>
-              <td>{row.first_name || row.name?.split(' ')[0]} {row.last_name || row.name?.split(' ')[1]}</td>
-              <td>{row.email}</td>
-              <td>{formatScore(row.score)}</td>
-              <td>
-                {generatingResumes[`${job.job_code}:${row.email}`] ? (
-                  <span className="spinner">⏳</span>
-                ) : generatedResumes[`${job.job_code}:${row.email}`] ? (
-                  <button className="resume-icon-button" onClick={() => viewResume(row.email, job.job_code)}>
-                    📥
-                  </button>
-                ) : (
-                  <button onClick={() => generateResume(row.email, job.job_code)}>
-                    Generate Resume
-                  </button>
-                )}
-              </td>
-              <td>
-                <button onClick={() => openNotes(job, row)}>
-                  View Notes{row.notes && ` (${row.notes.length})`}
-                </button>
-              </td>
-              <td className="status-cell">
-                <span className="badge assigned inline">Assigned</span>
-              </td>
-              <td>
-                {isRecruiter ? (
-                  <>
-                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
-                      Notify Candidate
-                    </button>
-                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
-                      Resend Job Description
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => handlePlace(job, row)}>Place</button>
-                    <button onClick={() => notifyInterest(job.job_code, row.email)}>
-                      Resend Job Description
-                    </button>
-                  </>
-                )}
-                <button onClick={() => rejectAssigned(job.job_code, row.email)}>
-                  Not Interested
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="assigned-subtable">
+        <h4>Assigned Students</h4>
+        <p>No assigned students yet.</p>
+      </div>
     );
   };
 


### PR DESCRIPTION
## Summary
- render an Assigned Students subtable directly beneath match results so newly assigned candidates appear immediately
- update the assigned tab renderer to log its data and fallback to job-level assigned students when match data is unavailable

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d22f3d21ec8333bbae1417f24e7b60