### PR TITLE
Optimize match fallback lookups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2305,6 +2305,22 @@ async def _perform_match_async(
         len(matches),
     )
 
+    assigned = set(job.get("assigned_students", []))
+    placed = set(job.get("placed_students", []))
+    rejected = set(job.get("rejected_students", []))
+    uninterested_students = set(job.get("uninterested_students", []))
+
+    existing_emails = {m["email"] for m in matches}
+    viable_matches = [
+        m
+        for m in matches
+        if m["email"] not in assigned
+        and m["email"] not in placed
+        and m["email"] not in rejected
+    ]
+    max_results = 10
+    remaining_slots = max(max_results - len(viable_matches), 0)
+
     raw_matches = list(matches)
     logger.info(
         "⚙️ Starting candidate filtering for job %s with %d raw matches",
@@ -2314,46 +2330,49 @@ async def _perform_match_async(
     filter_start = time.time()
     # Include applicant user records with a matching institutional code when no
     # student profile exists for them
-    fallback_emails: set[str] = set()
     normalized_poster_code = _normalize_institution_code(poster_code)
-    if normalized_poster_code:
-        index_key = user_index_key(normalized_poster_code)
+    index_key = user_index_key(normalized_poster_code) if normalized_poster_code else None
+
+    fallback_emails: set[str] = set()
+    fallback_list: list[str] = []
+    raw_users: list[str | None] = []
+
+    if remaining_slots > 0 and index_key:
         try:
             emails = redis_client.smembers(index_key)
         except Exception:
             emails = set()
         fallback_emails = set(emails or [])
-    else:
-        index_key = None
+        fallback_emails.difference_update(existing_emails)
+        fallback_emails.difference_update(uninterested_students)
+        fallback_list = list(fallback_emails)[:remaining_slots]
 
-    fallback_list = list(fallback_emails)
-    fallback_keys = [user_key(email) for email in fallback_list]
-    raw_users: list[str | None]
-    try:
-        if fallback_keys and hasattr(redis_client, "mget"):
-            raw_users = list(redis_client.mget(fallback_keys))  # type: ignore[arg-type]
-        elif fallback_keys and hasattr(redis_client, "pipeline"):
-            pipe = redis_client.pipeline()
-            for key in fallback_keys:
-                pipe.get(key)
-            raw_users = list(pipe.execute())
-        else:
+        fallback_keys = [user_key(email) for email in fallback_list]
+        try:
+            if fallback_keys and hasattr(redis_client, "mget"):
+                raw_users = list(redis_client.mget(fallback_keys))  # type: ignore[arg-type]
+            elif fallback_keys and hasattr(redis_client, "pipeline"):
+                pipe = redis_client.pipeline()
+                for key in fallback_keys:
+                    pipe.get(key)
+                raw_users = list(pipe.execute())
+            else:
+                raw_users = []
+        except Exception:
             raw_users = []
-    except Exception:
-        raw_users = []
 
-    if raw_users and len(raw_users) != len(fallback_list):
-        # When batched retrieval fails to return results for all keys fall back to individual lookups
-        raw_users = []
+        if raw_users and len(raw_users) != len(fallback_list):
+            # When batched retrieval fails to return results for all keys fall back to individual lookups
+            raw_users = []
 
-    if not raw_users and fallback_list:
-        # Either there is no efficient batch retrieval available or it failed. Fetch sequentially
-        raw_users = []
-        for email in fallback_list:
-            try:
-                raw_users.append(redis_client.get(user_key(email)))
-            except Exception:
-                raw_users.append(None)
+        if not raw_users and fallback_list:
+            # Either there is no efficient batch retrieval available or it failed. Fetch sequentially
+            raw_users = []
+            for email in fallback_list:
+                try:
+                    raw_users.append(redis_client.get(user_key(email)))
+                except Exception:
+                    raw_users.append(None)
 
     student_index_keys = [student_email_key(email) for email in fallback_list]
     email_has_student: dict[str, bool] = {}
@@ -2461,9 +2480,6 @@ async def _perform_match_async(
     # students have been assigned.
     filtered_matches = [m for m in matches if m["email"] not in assigned]
     top_matches = filtered_matches[:10]
-
-    placed = set(job.get("placed_students", []))
-    rejected = set(job.get("rejected_students", []))
 
     # Only store unassigned/unplaced/unrejected matches and keep
     # the list length at a maximum of 10. Assigned candidates will be

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2879,6 +2879,16 @@ def test_match_worker_includes_fallback_applicants(monkeypatch):
     }
     main_app.redis_client.set(f"user:{fallback_email}", json.dumps(applicant))
 
+    smembers_calls = {"count": 0}
+
+    original_smembers = main_app.redis_client.smembers
+
+    def tracking_smembers(key):
+        smembers_calls["count"] += 1
+        return original_smembers(key)
+
+    monkeypatch.setattr(main_app.redis_client, "smembers", tracking_smembers)
+
     class FakeEmbeddingsResp:
         def __init__(self):
             self.data = [type("obj", (), {"embedding": [0.1, 0.2, 0.3]})]
@@ -2916,11 +2926,94 @@ def test_match_worker_includes_fallback_applicants(monkeypatch):
         ("exists", legacy_key) in commands
         for commands in main_app.redis_client.pipeline_history
     )
+    assert smembers_calls["count"] > 0
 
     main_app.vector_index = None
     main_app.vector_emails = []
     main_app.EMBEDDING_DIM = None
 
+
+def test_match_worker_skips_fallback_when_quota_met(monkeypatch):
+    main_app.redis_client.flushdb()
+    job_code = "job-no-fallback"
+    poster_email = "poster@example.com"
+
+    job = {
+        "job_title": "Test",
+        "job_description": "desc",
+        "desired_skills": [],
+        "lat": 0.0,
+        "lng": 0.0,
+        "posted_by": poster_email,
+        "uninterested_students": [],
+    }
+    main_app.redis_client.set(f"job:{job_code}", json.dumps(job))
+
+    poster = {"role": "recruiter", "institutional_code": "1001"}
+    main_app.redis_client.set(f"user:{poster_email}", json.dumps(poster))
+
+    index_key = main_app.user_index_key("1001")
+    main_app.redis_client.sadd(index_key, "fallback@example.com")
+
+    smembers_calls = {"count": 0}
+    original_smembers = main_app.redis_client.smembers
+
+    def tracking_smembers(key):
+        smembers_calls["count"] += 1
+        return original_smembers(key)
+
+    monkeypatch.setattr(main_app.redis_client, "smembers", tracking_smembers)
+
+    class FakeEmbeddingsResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.1, 0.2, 0.3]})]
+
+    monkeypatch.setattr(
+        main_app.client.embeddings, "create", lambda *a, **k: FakeEmbeddingsResp()
+    )
+
+    class DummyIndex:
+        def __init__(self):
+            self.ntotal = 0
+
+    def fake_ensure_index(dim):
+        main_app.EMBEDDING_DIM = dim
+        main_app.vector_index = DummyIndex()
+        main_app.vector_emails = []
+
+    def fake_rebuild():
+        main_app.vector_emails = []
+
+    async def fake_filter_candidates(*args, **kwargs):
+        matches = [
+            {
+                "name": f"Candidate {i}",
+                "first_name": "Candidate",
+                "last_name": str(i),
+                "email": f"student{i}@example.com",
+                "score": 1.0,
+                "distance_miles": 1.0,
+            }
+            for i in range(10)
+        ]
+        return matches, 0.0
+
+    main_app.vector_index = None
+    main_app.vector_emails = []
+    main_app.EMBEDDING_DIM = None
+
+    monkeypatch.setattr(main_app, "ensure_index", fake_ensure_index)
+    monkeypatch.setattr(main_app, "rebuild_vector_index", fake_rebuild)
+    monkeypatch.setattr(main_app, "filter_candidates", fake_filter_candidates)
+
+    matches = main_app._perform_match(job_code, False)
+
+    assert len(matches) == 10
+    assert smembers_calls["count"] == 0
+
+    main_app.vector_index = None
+    main_app.vector_emails = []
+    main_app.EMBEDDING_DIM = None
 
 def test_students_by_school_fallback():
     main_app.redis_client.flushdb()


### PR DESCRIPTION
## Summary
- avoid loading fallback applicants when the initial match set already fills the 10-result quota
- limit fallback redis lookups to only the remaining open slots when additional candidates are required
- add coverage to ensure fallback queries are skipped with ample matches and still executed when needed

## Testing
- pytest tests/test_main.py -k match_worker

------
https://chatgpt.com/codex/tasks/task_e_68d30a0bb5f48333bd4b0cd4dc6f2842