### PR TITLE
Ensure job matches reload previous results

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -191,6 +191,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
         }));
       } catch (err) {
         console.error(`Error loading stored matches for ${jobCode}:`, err);
+        setMatchLoaded((prev) => ({ ...prev, [jobCode]: true }));
       }
     },
     [jobs, token]
@@ -225,15 +226,17 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
   }, [jobs]);
 
   useEffect(() => {
-    const shouldLoad =
-      expandedJob &&
-      matchPresence[expandedJob] === true &&
-      !matches[expandedJob];
+    if (!expandedJob) {
+      return;
+    }
 
-    if (shouldLoad) {
+    const alreadyLoaded = matchLoaded[expandedJob];
+    const currentlyLoading = loadingMatches[expandedJob];
+
+    if (!alreadyLoaded && !currentlyLoading) {
       loadMatchResults(expandedJob);
     }
-  }, [expandedJob, matchPresence, matches, loadMatchResults]);
+  }, [expandedJob, matchLoaded, loadingMatches, loadMatchResults]);
 
   useEffect(() => {
     if (!activeJobId || !activeJobCode) {


### PR DESCRIPTION
## Summary
- automatically reload stored matches when expanding a job panel even if the has-match flag is false
- prevent repeated failing fetch attempts by marking match load attempts as completed on error

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d4ae968eb48333ab03d4b34979681e