### PR TITLE
Format job dates and display job locations

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -103,13 +103,20 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
     if (Number.isNaN(date.getTime())) {
       return '';
     }
-    return date.toLocaleString(undefined, {
+    return date.toLocaleDateString('en-US', {
       year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit'
+      month: '2-digit',
+      day: '2-digit'
     });
+  };
+
+  const formatJobLocation = (job) => {
+    const city = job?.city?.trim();
+    const state = job?.state?.trim();
+    if (city && state) return `${city}, ${state}`;
+    if (city) return city;
+    if (state) return state;
+    return '';
   };
 
   const fetchJobs = async () => {
@@ -1165,6 +1172,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                 <th>Title</th>
                 <th>License</th>
                 <th>Source</th>
+                <th>Location</th>
                 <th>Pay Range</th>
                 <th>Created</th>
                 <th>Assigned</th>
@@ -1201,6 +1209,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                     placeholder="Filter"
                   />
                 </th>
+                <th></th>
                 <th></th>
                 <th>
                   <input
@@ -1259,6 +1268,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                 </td>
                   <td>{licenseLabel(job.required_license)}</td>
                   <td>{job.source}</td>
+                  <td>{formatJobLocation(job)}</td>
                   <td>
                     {job.min_pay !== undefined && job.max_pay !== undefined
                       ? `${job.min_pay} - ${job.max_pay}`


### PR DESCRIPTION
## Summary
- format the job list date column as MM/DD/YYYY
- add a Location column that displays each job's city and state

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d4b12efbe88333aa19e75586356077