### PR TITLE
Adjust match table to hide assigned by default

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -761,6 +761,13 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                   Press <strong>Match</strong> to find your candidates.
                 </td>
               </tr>
+            ) : unassignedMatches.length === 0 ? (
+              <tr>
+                <td colSpan="100%" className="match-prompt">
+                  No new matches available. Check the Assigned tab to review previously
+                  matched students.
+                </td>
+              </tr>
             ) : (
               unassignedMatches.map((row) => {
                 const selectedCount = selectedRows[job.job_code]?.length || 0;
@@ -828,9 +835,6 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
             )}
           </tbody>
         </table>
-        {matches[job.job_code] &&
-          matches[job.job_code].some((m) => m.status === 'assigned') &&
-          renderAssigned(job)}
       </>
     );
   };


### PR DESCRIPTION
## Summary
- hide the assigned matches subtable when viewing fresh match results
- show a friendly message when no new/unassigned matches are available

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d4b9867c148333974f594aa4d6b748