### PR TITLE
Fix View Matches tab selection

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1410,13 +1410,9 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                                 loadMatchResults(job.job_code);
                               }
                               setExpandedJob(job.job_code);
-                              const nextTab =
-                                hasMatchInRedis || matchListLength > 0
-                                  ? 'matches'
-                                  : 'assigned';
                               setActiveSubtab((prev) => ({
                                 ...prev,
-                                [job.job_code]: nextTab,
+                                [job.job_code]: 'matches',
                               }));
                             }}
                           >


### PR DESCRIPTION
## Summary
- ensure the View Matches action always opens the unassigned matches tab
- prevent automatic switching to the assigned tab when no unassigned matches are available

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d4be0b2e088333b41132ab9ed1f783