### PR TITLE
Stop returning assigned students in match results

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2705,21 +2705,6 @@ def get_match_results(job_code: str, current_user: dict = Depends(get_current_us
         placed = set(job.get("placed_students", []))
         rejected = set(job.get("rejected_students", []))
 
-        existing = set(matches)
-        for email in assigned | placed | rejected:
-            if email not in existing:
-                udata = json.loads(redis_client.get(f"user:{email}") or "{}")
-                first = udata.get("first_name", "")
-                last = udata.get("last_name", "")
-                name = f"{first} {last}".strip()
-                matches[email] = {
-                    "name": name,
-                    "first_name": first,
-                    "last_name": last,
-                    "email": email,
-                    "score": None,
-                }
-
         for email, m in matches.items():
             if email in placed:
                 m["status"] = "placed"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -283,12 +283,7 @@ def test_get_match_results_includes_missing_assigned(monkeypatch):
     resp = client.get(f"/match/{job_code}", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     data = resp.json()["matches"]
-    emails = {m["email"] for m in data}
-    assert emails == {"a@example.com", "b@example.com"}
-    assert all(m["status"] == "assigned" for m in data)
-    names = {m["email"]: (m.get("first_name"), m.get("last_name")) for m in data}
-    assert names["a@example.com"] == ("A", "One")
-    assert names["b@example.com"] == ("B", "Two")
+    assert data == []
 
 
 def test_get_match_results_includes_notes(monkeypatch):


### PR DESCRIPTION
## Summary
- stop rehydrating assigned, placed, and rejected students when reading stored match results so the API only returns candidates that were matched
- update the regression test to expect that assigned students are not injected into the response payload

## Testing
- pytest tests/test_jobs.py::test_get_match_results_includes_missing_assigned tests/test_jobs.py::test_get_match_results_status tests/test_jobs.py::test_get_match_results_status_placed


------
https://chatgpt.com/codex/tasks/task_e_68d543c1ecc88333aac1cc92b0d2f747