### PR TITLE
Stop match polling once results are available

### DIFF
--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -295,6 +295,19 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
   }, [stopPollingJob]);
 
   useEffect(() => {
+    Object.entries(pollingMetadataRef.current).forEach(([jobKey, metadata]) => {
+      const jobCode = metadata?.jobCode || jobKey;
+      const isLoading = Boolean(loadingMatches[jobCode]);
+      const hasLoaded = Boolean(matchLoaded[jobCode]);
+      const hasResults = Array.isArray(matches[jobCode]) && matches[jobCode].length > 0;
+
+      if (!isLoading && (hasLoaded || hasResults)) {
+        stopPollingJob(jobKey);
+      }
+    });
+  }, [matches, matchLoaded, loadingMatches, stopPollingJob]);
+
+  useEffect(() => {
     const activeIdentifiers = new Set(
       jobs.map((job) => String(job.job_id ?? job.id ?? job.job_code ?? ''))
     );


### PR DESCRIPTION
## Summary
- add a guard effect that checks loaded match state and cancels active polling intervals once results have reached the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5523c24688333a03a5fcaaee30274