### PR TITLE
Add admin email blast workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1048,6 +1048,60 @@ class JobRequest(BaseModel):
 class JobCodeRequest(BaseModel):
     job_code: str
 
+
+class EmailBlastRequest(BaseModel):
+    subject: str = Field(..., min_length=1, max_length=200)
+    body: str = Field(..., min_length=1)
+    institutional_codes: list[str] = Field(default_factory=list)
+    license: str | None = None
+    source: str | None = None
+
+    @field_validator("subject", "body", mode="before")
+    @classmethod
+    def _strip_text(cls, value: str | None) -> str | None:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("institutional_codes", mode="before")
+    @classmethod
+    def _normalize_codes(cls, value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if isinstance(value, (list, tuple, set)):
+            normalized: list[str] = []
+            for item in value:
+                if not isinstance(item, str):
+                    continue
+                stripped = item.strip()
+                if stripped:
+                    normalized.append(stripped)
+            return normalized
+        raise TypeError("institutional_codes must be a string or list of strings")
+
+    @field_validator("license", "source", mode="before")
+    @classmethod
+    def _normalize_optional(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        raise TypeError("license/source must be strings")
+
+    @model_validator(mode="after")
+    def _ensure_filters(self):
+        if (
+            not self.institutional_codes
+            and not self.license
+            and not self.source
+        ):
+            raise ValueError("At least one recipient filter must be provided")
+        return self
+
+
 # -------- Auth -------- #
 def get_current_user(authorization: str = Header(..., alias="Authorization")):
     if not authorization.startswith("Bearer "):
@@ -4335,6 +4389,114 @@ def get_all_students(
             break
     next_cursor = None if cur == 0 else str(cur)
     return {"students": students, "next_cursor": next_cursor}
+
+
+@app.post("/email-blast")
+def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_current_user)):
+    """Dispatch a bulk email to students matching the provided filters."""
+
+    if current_user.get("role") not in ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    normalized_codes = {code.lower() for code in req.institutional_codes}
+    license_filter = license_to_code(req.license)
+    license_filter = license_filter.lower() if license_filter else None
+    source_filter = req.source.lower() if req.source else None
+
+    recipients: list[str] = []
+    seen: set[str] = set()
+    skipped_missing_email = 0
+    skipped_filtered = 0
+
+    cursor = 0
+    while True:
+        cursor, keys = redis_client.scan(cursor, match="student:*", count=200)
+        for key in keys:
+            raw = redis_client.get(key)
+            if not raw:
+                continue
+            try:
+                student = json.loads(raw)
+            except Exception:
+                continue
+
+            email = normalize_email(student.get("email"))
+            if not email:
+                skipped_missing_email += 1
+                continue
+            if email in seen:
+                continue
+
+            st_code = _student_institutional_code(student)
+            if normalized_codes and (
+                not st_code or st_code.strip().lower() not in normalized_codes
+            ):
+                skipped_filtered += 1
+                continue
+
+            st_license = license_to_code(
+                student.get("license") or student.get("education_level")
+            )
+            st_license = st_license.lower() if st_license else None
+            if license_filter and st_license != license_filter:
+                skipped_filtered += 1
+                continue
+
+            st_source = (student.get("source") or "").strip().lower()
+            if source_filter and st_source != source_filter:
+                skipped_filtered += 1
+                continue
+
+            recipients.append(email)
+            seen.add(email)
+
+        if cursor == 0:
+            break
+
+    if not recipients:
+        raise HTTPException(
+            status_code=400, detail="No students match the provided criteria"
+        )
+
+    sent = 0
+    failures: list[dict[str, str]] = []
+    for recipient in recipients:
+        try:
+            send_email(recipient, req.subject, req.body)
+            sent += 1
+        except Exception as exc:
+            failures.append({"email": recipient, "error": str(exc)})
+
+    log_entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": "email_blast",
+        "actor": current_user.get("sub"),
+        "filters": {
+            "institutional_codes": list(req.institutional_codes),
+            "license": req.license,
+            "source": req.source,
+        },
+        "matched": len(recipients),
+        "sent": sent,
+        "failed": len(failures),
+        "skipped_missing_email": skipped_missing_email,
+        "skipped_filtered": skipped_filtered,
+    }
+
+    try:
+        redis_client.rpush(ACTIVITY_LOG_KEY, json.dumps(log_entry))
+    except Exception as e:
+        logger.error("Failed to record email blast activity: %s", e)
+
+    return {
+        "matched": len(recipients),
+        "sent": sent,
+        "failed": len(failures),
+        "failures": failures,
+        "skipped_missing_email": skipped_missing_email,
+        "skipped_filtered": skipped_filtered,
+    }
+
 
 @app.get("/students/by-school")
 def students_by_school(

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -50,6 +50,111 @@
   box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
 }
 
+.blast-panel {
+  flex: 1;
+  max-width: 650px;
+  background-color: rgba(255, 255, 255, 0.95);
+  padding: 1.75rem;
+  border-radius: 12px;
+  color: #002244;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+.blast-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.blast-form h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.blast-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.blast-field label {
+  font-weight: 600;
+}
+
+.blast-field input,
+.blast-field textarea,
+.blast-field select {
+  padding: 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #c3c9d0;
+  font-size: 1rem;
+  color: #002244;
+  background: #fff;
+}
+
+.blast-field select[multiple] {
+  min-height: 140px;
+}
+
+.blast-field small {
+  font-size: 0.85rem;
+  color: #4a5a70;
+}
+
+.blast-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.blast-actions button {
+  background-color: #0074d9;
+  color: #fff;
+  border: none;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.blast-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.blast-actions button:not(:disabled):hover {
+  background-color: #005fa3;
+  transform: translateY(-1px);
+}
+
+.blast-feedback,
+.blast-error {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.blast-feedback {
+  background: #e6f7ef;
+  color: #1d7a43;
+}
+
+.blast-error {
+  background: #ffecec;
+  color: #b12626;
+}
+
+.blast-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 68, 136, 0.08);
+  border-radius: 10px;
+  color: #032c4d;
+  font-size: 0.95rem;
+}
+
 .post-job-form {
   display: flex;
   flex-direction: column;

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -42,6 +42,18 @@ function JobPosting() {
   const [previewingResumes, setPreviewingResumes] = useState({});
   const [activeTab, setActiveTab] = useState('jobs');
   const [licenses, setLicenses] = useState([]);
+  const [schoolCodes, setSchoolCodes] = useState([]);
+  const [blastForm, setBlastForm] = useState({
+    subject: '',
+    body: '',
+    institutionalCodes: [],
+    license: '',
+    source: ''
+  });
+  const [blastSubmitting, setBlastSubmitting] = useState(false);
+  const [blastFeedback, setBlastFeedback] = useState(null);
+  const [blastError, setBlastError] = useState(null);
+  const [blastStats, setBlastStats] = useState(null);
   const pollingIntervalsRef = useRef({});
   const pollingMetadataRef = useRef({});
   const isMountedRef = useRef(true);
@@ -84,16 +96,102 @@ function JobPosting() {
   }, [activeTab]);
 
   useEffect(() => {
-    const loadLicenses = async () => {
+    const loadLookups = async () => {
       try {
         const resp = await api.get('/licenses');
         setLicenses(resp.data.licenses || []);
       } catch (err) {
         console.error('Failed to fetch licenses', err);
       }
+
+      try {
+        const resp = await api.get('/school-codes');
+        setSchoolCodes(resp.data.codes || []);
+      } catch (err) {
+        console.error('Failed to fetch school codes', err);
+      }
     };
-    loadLicenses();
+    loadLookups();
   }, []);
+
+  const handleBlastFormChange = (event) => {
+    const { name, value, options } = event.target;
+    if (name === 'institutionalCodes') {
+      const selected = Array.from(options || [])
+        .filter((option) => option.selected)
+        .map((option) => option.value);
+      setBlastForm((prev) => ({ ...prev, institutionalCodes: selected }));
+      return;
+    }
+
+    setBlastForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleBlastSubmit = async (event) => {
+    event.preventDefault();
+    setBlastError(null);
+    setBlastFeedback(null);
+    setBlastStats(null);
+
+    const subject = blastForm.subject.trim();
+    const body = blastForm.body.trim();
+    const source = blastForm.source.trim();
+
+    if (!subject || !body) {
+      setBlastError('Subject and message are required.');
+      return;
+    }
+
+    const hasFilters =
+      (blastForm.institutionalCodes && blastForm.institutionalCodes.length > 0) ||
+      (blastForm.license && blastForm.license.trim()) ||
+      source;
+
+    if (!hasFilters) {
+      setBlastError('Select at least one recipient filter.');
+      return;
+    }
+
+    const payload = {
+      subject,
+      body,
+      institutional_codes: blastForm.institutionalCodes
+    };
+
+    if (blastForm.license) {
+      payload.license = blastForm.license;
+    }
+
+    if (source) {
+      payload.source = source;
+    }
+
+    setBlastSubmitting(true);
+
+    try {
+      const resp = await api.post('/email-blast', payload);
+      const data = resp.data || {};
+      setBlastStats(data);
+      const sent = data.sent ?? 0;
+      const matched = data.matched ?? sent;
+      const failed = data.failed ?? 0;
+      const suffix = matched === 1 ? '' : 's';
+      const failureSuffix = failed ? ` (${failed} failed)` : '';
+      setBlastFeedback(`Blast sent to ${sent} of ${matched} matched student${suffix}${failureSuffix}.`);
+      setBlastForm({
+        subject: '',
+        body: '',
+        institutionalCodes: [],
+        license: '',
+        source: ''
+      });
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setBlastError(detail || 'Failed to send email blast.');
+    } finally {
+      setBlastSubmitting(false);
+    }
+  };
 
   const token = localStorage.getItem('token');
   const decoded = token ? jwtDecode(token) : {};
@@ -1095,8 +1193,111 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
         >
           Post a Job
         </button>
+        <button
+          className={`tab ${activeTab === 'blast' ? 'active' : ''}`}
+          onClick={() => setActiveTab('blast')}
+        >
+          Email Blast
+        </button>
       </div>
       <div className="tab-content">
+        {activeTab === 'blast' && (
+          <div className="blast-panel">
+            <form className="blast-form" onSubmit={handleBlastSubmit}>
+              <h2>Email Blast</h2>
+              <div className="blast-field">
+                <label htmlFor="blast-subject">Subject</label>
+                <input
+                  id="blast-subject"
+                  name="subject"
+                  type="text"
+                  value={blastForm.subject}
+                  onChange={handleBlastFormChange}
+                  placeholder="Enter an email subject"
+                />
+              </div>
+              <div className="blast-field">
+                <label htmlFor="blast-body">Message</label>
+                <textarea
+                  id="blast-body"
+                  name="body"
+                  rows={8}
+                  value={blastForm.body}
+                  onChange={handleBlastFormChange}
+                  placeholder="Write the email you want to send"
+                ></textarea>
+              </div>
+              <div className="blast-field">
+                <label htmlFor="blast-institutional-codes">Institutional Codes</label>
+                <select
+                  id="blast-institutional-codes"
+                  name="institutionalCodes"
+                  multiple
+                  value={blastForm.institutionalCodes}
+                  onChange={handleBlastFormChange}
+                >
+                  {schoolCodes.map((code) => (
+                    <option key={code.code} value={code.code}>
+                      {code.code} — {code.label}
+                    </option>
+                  ))}
+                </select>
+                <small>Select one or more codes to target a specific school.</small>
+              </div>
+              <div className="blast-field">
+                <label htmlFor="blast-license">License</label>
+                <select
+                  id="blast-license"
+                  name="license"
+                  value={blastForm.license}
+                  onChange={handleBlastFormChange}
+                >
+                  <option value="">All Licenses</option>
+                  {licenses.map((l) => (
+                    <option key={l.code} value={l.code}>
+                      {l.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="blast-field">
+                <label htmlFor="blast-source">Source</label>
+                <input
+                  id="blast-source"
+                  name="source"
+                  type="text"
+                  value={blastForm.source}
+                  onChange={handleBlastFormChange}
+                  placeholder="Filter by student source (optional)"
+                />
+              </div>
+              <div className="blast-actions">
+                <button type="submit" disabled={blastSubmitting}>
+                  {blastSubmitting ? 'Sending…' : 'Send Email Blast'}
+                </button>
+              </div>
+              {blastFeedback && <div className="blast-feedback">{blastFeedback}</div>}
+              {blastError && <div className="blast-error">{blastError}</div>}
+              {blastStats && (
+                <div className="blast-stats">
+                  <div><strong>Matched:</strong> {blastStats.matched ?? 0}</div>
+                  <div><strong>Sent:</strong> {blastStats.sent ?? 0}</div>
+                  <div><strong>Failed:</strong> {blastStats.failed ?? 0}</div>
+                  {blastStats.skipped_missing_email ? (
+                    <div>
+                      <strong>Skipped (missing email):</strong> {blastStats.skipped_missing_email}
+                    </div>
+                  ) : null}
+                  {blastStats.skipped_filtered ? (
+                    <div>
+                      <strong>Skipped (filters):</strong> {blastStats.skipped_filtered}
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </form>
+          </div>
+        )}
         {activeTab === 'post' && (
           <div className="post-job-panel">
             <form onSubmit={handleSubmit} className="post-job-form">

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2913,6 +2913,130 @@ def test_weekly_summary_forbidden():
     assert resp.status_code == 403
 
 
+def test_email_blast_sends_to_matching_students(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    student = {
+        "first_name": "Sam",
+        "last_name": "Student",
+        "email": "sam@example.com",
+        "license": "lvn",
+        "institutional_code": "1001",
+        "student_id": "1"
+    }
+    other = {
+        "first_name": "Pat",
+        "last_name": "Student",
+        "email": "pat@example.com",
+        "license": "ma",
+        "institutional_code": "2002",
+        "student_id": "2"
+    }
+
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+    main_app.persist_student_record(
+        other["email"], other, other["institutional_code"], other["student_id"]
+    )
+
+    sent = []
+
+    def fake_send(recipient, subject, body, html_body=None, attachments=None, track_token=None):
+        sent.append((recipient, subject, body))
+
+    monkeypatch.setattr(main_app, "send_email", fake_send)
+
+    token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    resp = client.post(
+        "/email-blast",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "subject": "Important update",
+            "body": "Please review the latest opportunity.",
+            "institutional_codes": ["1001"],
+            "license": "lvn",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["matched"] == 1
+    assert data["sent"] == 1
+    assert data["failed"] == 0
+    assert sent == [("sam@example.com", "Important update", "Please review the latest opportunity.")]
+
+    raw_logs = main_app.redis_client.lists.get(main_app.ACTIVITY_LOG_KEY, [])
+    parsed_logs = [json.loads(item) for item in raw_logs]
+    blast_logs = [entry for entry in parsed_logs if entry.get("event") == "email_blast"]
+    assert blast_logs, f"Expected an email_blast entry in activity log, got: {parsed_logs}"
+    assert blast_logs[-1]["sent"] == 1
+    assert blast_logs[-1]["filters"]["institutional_codes"] == ["1001"]
+
+
+def test_email_blast_requires_admin_role():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    user = {
+        "email": "recruiter@example.com",
+        "first_name": "Rita",
+        "last_name": "Recruiter",
+        "school_code": "1001",
+        "password": "pass1234",
+        "role": "recruiter",
+    }
+    client.post("/register", json=user)
+    key = f"user:{user['email']}"
+    data = json.loads(main_app.redis_client.get(key))
+    data["approved"] = True
+    main_app.redis_client.set(key, json.dumps(data))
+
+    token = client.post(
+        "/login", json={"email": user["email"], "password": user["password"]}
+    ).json()["token"]
+
+    resp = client.post(
+        "/email-blast",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "subject": "Test",
+            "body": "Test",
+            "institutional_codes": ["1001"],
+        },
+    )
+
+    assert resp.status_code == 403
+
+
+def test_email_blast_no_matching_students(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    monkeypatch.setattr(main_app, "send_email", lambda *a, **k: None)
+
+    token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    resp = client.post(
+        "/email-blast",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "subject": "Hello",
+            "body": "No one should receive this",
+            "institutional_codes": ["9999"],
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "No students match the provided criteria"
+
+
 def test_match_metrics_increment(monkeypatch):
     main_app.redis_client.flushdb()
     job = {


### PR DESCRIPTION
## Summary
- add a validated EmailBlastRequest payload and POST /email-blast endpoint so admins can send targeted blasts
- extend the job posting UI with a new Email Blast tab that supports code/license/source filters and feedback messaging
- style the new blast form and add pytest coverage for success, authorization, and empty-result scenarios

## Testing
- pytest tests/test_main.py::test_email_blast_sends_to_matching_students tests/test_main.py::test_email_blast_requires_admin_role tests/test_main.py::test_email_blast_no_matching_students


------
https://chatgpt.com/codex/tasks/task_e_68d76d3e538c8333bebe15d509d90ba0