### PR TITLE
Add welcome email workflow for student profiles

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ import sys
 from email.message import EmailMessage
 from fastapi import (
     BackgroundTasks,
+    Body,
     Depends,
     FastAPI,
     File,
@@ -486,6 +487,134 @@ def send_email(
     except Exception as e:
         logger.error("[email] Failed to send email to %s: %s", recipient, e)
         raise
+
+
+def _clean_institution_label(label: str | None) -> str | None:
+    """Remove leading code prefixes from school labels."""
+
+    if not label:
+        return None
+    cleaned = label.strip()
+    if not cleaned:
+        return None
+    parts = cleaned.split("-", 1)
+    if len(parts) == 2 and parts[0].strip().isdigit():
+        return parts[1].strip()
+    return cleaned
+
+
+def build_welcome_email(first_name: str | None, institution_label: str | None) -> tuple[str, str]:
+    """Return the subject and body for the student welcome email."""
+
+    name = (first_name or "").strip()
+    if name:
+        name = name.split()[0]
+    else:
+        name = "there"
+
+    institution = _clean_institution_label(institution_label)
+    if not institution:
+        institution = "your institution"
+
+    subject = "Welcome to TalenMatch AI 🎉"
+    body = (
+        f"Hi {name},\n\n"
+        f"We're excited to share that TalenMatch AI has partnered with {institution} "
+        "to support you in taking the next step in your healthcare career.\n\n"
+        "As part of this partnership, you'll have access to:\n\n"
+        "✅ Personalized Job Matches – opportunities tailored to your profile.\n\n"
+        "🔔 Job Alerts – stay informed as soon as new positions open up in your area.\n\n"
+        "📚 Career Resources – resume tips, webinars, and guidance to help you succeed.\n\n"
+        "👩‍⚕️ Support from Experienced RNs and LVNs – professional insight and mentorship "
+        "to help you prepare with confidence.\n\n"
+        "To get started, log in and complete your profile. A stronger profile means better matches "
+        "and more opportunities.\n\n"
+        "We're here to support you every step of the way, alongside your Career Services team.\n\n"
+        "Wishing you success,\n"
+        "The TalenMatch-AI Team"
+    )
+    return subject, body
+
+
+def send_student_welcome_email(
+    student: dict,
+    *,
+    institution_code: str | None = None,
+) -> bool:
+    """Send the configured welcome email to a student if possible."""
+
+    if not isinstance(student, dict):
+        return False
+
+    email = student.get("email")
+    if not email:
+        return False
+
+    label = student.get("school_label")
+    if not label:
+        code = student.get("institutional_code") or student.get("institution_code") or institution_code
+        if code:
+            label = get_school_label(str(code))
+
+    subject, body = build_welcome_email(student.get("first_name"), label)
+    send_email(email, subject, body)
+    student["welcome_email_sent_at"] = datetime.now(timezone.utc).isoformat()
+    return True
+
+
+def send_welcome_email_for_key(student_key_value: str, *, force: bool = False) -> str:
+    """Send (or skip) the welcome email for a stored student record."""
+
+    raw = redis_client.get(student_key_value)
+    if not raw:
+        return "missing"
+
+    try:
+        student = json.loads(raw)
+    except Exception:
+        logger.exception("Failed to decode student record for %s", student_key_value)
+        return "failed"
+
+    email = student.get("email")
+    if not email:
+        logger.info("Skipping welcome email for %s: missing email", student_key_value)
+        return "skipped"
+
+    if not force and student.get("welcome_email_sent_at"):
+        return "skipped"
+
+    inst_code: str | None = None
+    student_id: str | None = None
+    parts = student_key_value.split(":", 2)
+    if len(parts) == 3:
+        _, inst_raw, student_id = parts
+        inst_code = None if inst_raw == "None" else inst_raw
+    else:
+        idx = redis_client.get(student_email_key(email))
+        if idx:
+            inst_raw, student_id = idx.split(":", 1)
+            inst_code = None if inst_raw == "None" else inst_raw
+
+    try:
+        sent = send_student_welcome_email(student, institution_code=inst_code)
+    except Exception:
+        logger.exception("Failed to send welcome email to %s", email)
+        return "failed"
+
+    if sent and student_id is not None:
+        persist_student_record(email, student, inst_code, student_id)
+
+    return "sent" if sent else "skipped"
+
+
+def queue_welcome_email(student_key_value: str) -> None:
+    """Background task wrapper for sending welcome emails."""
+
+    try:
+        status = send_welcome_email_for_key(student_key_value)
+        logger.info("Welcome email status for %s: %s", student_key_value, status)
+    except Exception:
+        logger.exception("Unexpected error sending welcome email for %s", student_key_value)
 
 async def get_driving_distance_miles(
     orig_lat: float | list[tuple[float, float]],
@@ -1439,8 +1568,14 @@ class SchoolCodeRequest(BaseModel):
     code: str
     label: str
 
+
 class UpdateSchoolCodeRequest(BaseModel):
     label: str
+
+
+class WelcomeEmailRequest(BaseModel):
+    resend: bool = False
+    limit: int | None = None
 
 
 @app.post("/admin/school-codes")
@@ -1578,7 +1713,11 @@ def delete_rss_feed(name: str, current_user: dict = Depends(get_current_user)):
     return {"message": "Feed deleted"}
 
 @app.post("/students")
-async def create_student(request: Request, current_user: dict = Depends(get_current_user)):
+async def create_student(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(get_current_user),
+):
     content_type = request.headers.get("content-type", "")
     resume_file: UploadFile | None = None
 
@@ -1711,6 +1850,8 @@ async def create_student(request: Request, current_user: dict = Depends(get_curr
     data["created_by"] = current_user.get("sub")
     data["created_at"] = datetime.now(timezone.utc).isoformat()
     persist_student_record(student_data.email, data, institution_code, student_id)
+    canonical_key = student_key(institution_code, student_id)
+    background_tasks.add_task(queue_welcome_email, canonical_key)
     logger.info(
         "POST /students success email=%s owner=%s",
         student_data.email,
@@ -4681,6 +4822,47 @@ def admin_test_weekly_summary(current_user: dict = Depends(get_current_user)):
 
     send_weekly_summary(current_user["sub"])
     return {"message": "Weekly summary sent"}
+
+
+@app.post("/admin/send-welcome-emails")
+def admin_send_welcome_emails(
+    payload: WelcomeEmailRequest = Body(default=None),
+    current_user: dict = Depends(get_current_user),
+):
+    """Send the welcome email to existing student profiles."""
+
+    if current_user.get("role") not in ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    if payload is None:
+        payload = WelcomeEmailRequest()
+
+    limit = payload.limit
+    resend = payload.resend
+
+    processed = 0
+    sent = 0
+    skipped = 0
+    failed = 0
+
+    for key in redis_client.scan_iter("student:*:*"):
+        if limit is not None and processed >= limit:
+            break
+        status = send_welcome_email_for_key(key, force=resend)
+        processed += 1
+        if status == "sent":
+            sent += 1
+        elif status == "failed":
+            failed += 1
+        else:
+            skipped += 1
+
+    return {
+        "processed": processed,
+        "sent": sent,
+        "skipped": skipped,
+        "failed": failed,
+    }
 
 
 @app.get("/activity-log")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -697,6 +697,81 @@ def test_student_creation_records_metadata(monkeypatch):
     assert stored2["created_at"] == stored["created_at"]
 
 
+def test_create_student_sends_welcome_email(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    login_resp = client.post(
+        "/login",
+        json={"email": "admin@example.com", "password": "admin123"},
+    )
+    token = login_resp.json()["token"]
+
+    admin_key = main_app.user_key("admin@example.com")
+    admin_raw = main_app.redis_client.get(admin_key)
+    admin_data = json.loads(admin_raw)
+    admin_data["institutional_code"] = "1001"
+    admin_data["school_label"] = main_app.get_school_label("1001")
+    main_app.redis_client.set(admin_key, json.dumps(admin_data))
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.0, 0.1]})]
+
+    def fake_create(input, model):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+    monkeypatch.setattr(main_app, "ensure_index", lambda dim: None)
+    monkeypatch.setattr(main_app, "rebuild_vector_index", lambda: None)
+    main_app.vector_index = None
+
+    captured: dict[str, str] = {}
+
+    def fake_send_email(
+        recipient, subject, body, html_body=None, attachments=None, track_token=None
+    ):
+        captured["recipient"] = recipient
+        captured["subject"] = subject
+        captured["body"] = body
+
+    monkeypatch.setattr(main_app, "send_email", fake_send_email)
+
+    profile = {
+        "first_name": "Stu",
+        "last_name": "Dent",
+        "email": "stud@example.com",
+        "phone": "123",
+        "license": "lvn",
+        "skills": ["python"],
+        "experience_summary": "summary",
+        "interests": "coding",
+        "city": "Town",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10,
+    }
+
+    resp = client.post(
+        "/students",
+        json=profile,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    skey = main_app.resolve_student_key(profile["email"])
+    stored = json.loads(main_app.redis_client.get(skey))
+    assert "welcome_email_sent_at" in stored
+    datetime.fromisoformat(stored["welcome_email_sent_at"])
+
+    assert captured["recipient"] == profile["email"]
+    assert captured["subject"] == "Welcome to TalenMatch AI 🎉"
+    assert "Hi Stu" in captured["body"]
+    assert "Unitek-Sacramento" in captured["body"]
+    assert "1001-" not in captured["body"]
+
+
 def test_create_student_returns_existing_for_same_user(monkeypatch):
     main_app.redis_client.flushdb()
     init_default_admin()
@@ -762,6 +837,62 @@ def test_create_student_returns_existing_for_same_user(monkeypatch):
     assert resp.status_code == 200
     returned = resp.json()["student"]
     assert returned["email"] == email
+
+
+def test_admin_send_welcome_emails_resend(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    sent_messages: list[tuple[str, str, str]] = []
+
+    def fake_send_email(recipient, subject, body, html_body=None, attachments=None, track_token=None):
+        sent_messages.append((recipient, subject, body))
+
+    monkeypatch.setattr(main_app, "send_email", fake_send_email)
+
+    student = {
+        "first_name": "Sam",
+        "email": "sam@example.com",
+        "institutional_code": "1001",
+        "student_id": "1",
+        "welcome_email_sent_at": datetime.utcnow().isoformat(),
+    }
+    main_app.persist_student_record(student["email"], student, "1001", "1")
+
+    login_resp = client.post(
+        "/login",
+        json={"email": "admin@example.com", "password": "admin123"},
+    )
+    admin_token = login_resp.json()["token"]
+
+    first_resp = client.post(
+        "/admin/send-welcome-emails",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert first_resp.status_code == 200
+    first_data = first_resp.json()
+    assert first_data["sent"] == 0
+    assert first_data["skipped"] >= 1
+    assert len(sent_messages) == 0
+
+    raw = main_app.redis_client.get(main_app.student_key("1001", "1"))
+    stored = json.loads(raw)
+    previous_ts = stored["welcome_email_sent_at"]
+
+    second_resp = client.post(
+        "/admin/send-welcome-emails",
+        json={"resend": True},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert second_resp.status_code == 200
+    second_data = second_resp.json()
+    assert second_data["sent"] == 1
+    assert len(sent_messages) == 1
+
+    updated_raw = main_app.redis_client.get(main_app.student_key("1001", "1"))
+    updated = json.loads(updated_raw)
+    assert updated["welcome_email_sent_at"] != previous_ts
+    assert sent_messages[0][1] == "Welcome to TalenMatch AI 🎉"
 
 
 def test_metrics_endpoint():


### PR DESCRIPTION
## Summary
- compose and queue a welcome email whenever a new student profile is created
- add an admin endpoint to send or resend the welcome email to existing student records
- add regression tests that cover email content and resend behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d76d7ce48c8333891edbc570ca7446