### PR TITLE
Adjust welcome email copy for staff-created students

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -503,7 +503,12 @@ def _clean_institution_label(label: str | None) -> str | None:
     return cleaned
 
 
-def build_welcome_email(first_name: str | None, institution_label: str | None) -> tuple[str, str]:
+def build_welcome_email(
+    first_name: str | None,
+    institution_label: str | None,
+    *,
+    staff_created: bool = False,
+) -> tuple[str, str]:
     """Return the subject and body for the student welcome email."""
 
     name = (first_name or "").strip()
@@ -517,18 +522,37 @@ def build_welcome_email(first_name: str | None, institution_label: str | None) -
         institution = "your institution"
 
     subject = "Welcome to TalenMatch AI 🎉"
+
+    if staff_created:
+        intro_line = (
+            f"The Career Services team at {institution} has already created your "
+            "TalenMatch AI profile to help you take the next step in your healthcare career.\n\n"
+        )
+        action_line = (
+            "To get started, log in to review your profile. Confirm your details, "
+            "complete any missing information, and keep everything up to date for the "
+            "best matches.\n\n"
+        )
+    else:
+        intro_line = (
+            f"We're excited to share that TalenMatch AI has partnered with {institution} "
+            "to support you in taking the next step in your healthcare career.\n\n"
+        )
+        action_line = (
+            "To get started, log in and complete your profile. A stronger profile means "
+            "better matches and more opportunities.\n\n"
+        )
+
     body = (
         f"Hi {name},\n\n"
-        f"We're excited to share that TalenMatch AI has partnered with {institution} "
-        "to support you in taking the next step in your healthcare career.\n\n"
+        f"{intro_line}"
         "As part of this partnership, you'll have access to:\n\n"
         "✅ Personalized Job Matches – opportunities tailored to your profile.\n\n"
         "🔔 Job Alerts – stay informed as soon as new positions open up in your area.\n\n"
         "📚 Career Resources – resume tips, webinars, and guidance to help you succeed.\n\n"
         "👩‍⚕️ Support from Experienced RNs and LVNs – professional insight and mentorship "
         "to help you prepare with confidence.\n\n"
-        "To get started, log in and complete your profile. A stronger profile means better matches "
-        "and more opportunities.\n\n"
+        f"{action_line}"
         "We're here to support you every step of the way, alongside your Career Services team.\n\n"
         "Wishing you success,\n"
         "The TalenMatch-AI Team"
@@ -556,7 +580,31 @@ def send_student_welcome_email(
         if code:
             label = get_school_label(str(code))
 
-    subject, body = build_welcome_email(student.get("first_name"), label)
+    normalized_student_email = normalize_email(email)
+
+    def _normalize_owner(value: Any) -> str | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        owner_value = value
+        if owner_value.startswith("user:"):
+            owner_value = owner_value.split("user:", 1)[1]
+        return normalize_email(owner_value)
+
+    owner_emails = [
+        _normalize_owner(student.get("created_by")),
+        _normalize_owner(student.get("registered_by")),
+    ]
+    owner_emails = [email for email in owner_emails if email]
+
+    staff_created = False
+    if normalized_student_email and owner_emails:
+        staff_created = any(owner_email != normalized_student_email for owner_email in owner_emails)
+
+    subject, body = build_welcome_email(
+        student.get("first_name"),
+        label,
+        staff_created=staff_created,
+    )
     send_email(email, subject, body)
     student["welcome_email_sent_at"] = datetime.now(timezone.utc).isoformat()
     return True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -770,6 +770,91 @@ def test_create_student_sends_welcome_email(monkeypatch):
     assert "Hi Stu" in captured["body"]
     assert "Unitek-Sacramento" in captured["body"]
     assert "1001-" not in captured["body"]
+    assert "log in to review your profile" in captured["body"]
+    assert "log in and complete your profile" not in captured["body"]
+
+
+def test_applicant_created_student_sends_welcome_email(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    applicant = {
+        "email": "applicant@example.com",
+        "first_name": "App",
+        "last_name": "User",
+        "school_code": "1001",
+        "password": "pass123",
+        "role": "applicant",
+    }
+    client.post("/register", json=applicant)
+    user_key = f"user:{applicant['email']}"
+    stored_user = json.loads(main_app.redis_client.get(user_key))
+    stored_user["approved"] = True
+    main_app.redis_client.set(user_key, json.dumps(stored_user))
+
+    login_resp = client.post(
+        "/login",
+        json={"email": applicant["email"], "password": applicant["password"]},
+    )
+    token = login_resp.json()["token"]
+
+    class FakeResp:
+        def __init__(self):
+            self.data = [type("obj", (), {"embedding": [0.0, 0.1]})]
+
+    def fake_create(input, model):
+        return FakeResp()
+
+    monkeypatch.setattr(main_app.client.embeddings, "create", fake_create)
+    monkeypatch.setattr(main_app, "ensure_index", lambda dim: None)
+    monkeypatch.setattr(main_app, "rebuild_vector_index", lambda: None)
+    main_app.vector_index = None
+
+    captured: dict[str, str] = {}
+
+    def fake_send_email(
+        recipient, subject, body, html_body=None, attachments=None, track_token=None
+    ):
+        captured["recipient"] = recipient
+        captured["subject"] = subject
+        captured["body"] = body
+
+    monkeypatch.setattr(main_app, "send_email", fake_send_email)
+
+    profile = {
+        "first_name": "App",
+        "last_name": "User",
+        "email": applicant["email"],
+        "phone": "555-0000",
+        "license": "lvn",
+        "skills": ["python"],
+        "experience_summary": "summary",
+        "interests": "coding",
+        "city": "Town",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+        "max_travel": 10,
+    }
+
+    resp = client.post(
+        "/students",
+        json=profile,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    skey = main_app.resolve_student_key(profile["email"])
+    stored = json.loads(main_app.redis_client.get(skey))
+    assert stored.get("created_by") == applicant["email"]
+    assert "welcome_email_sent_at" in stored
+    datetime.fromisoformat(stored["welcome_email_sent_at"])
+
+    assert captured["recipient"] == profile["email"]
+    assert captured["subject"] == "Welcome to TalenMatch AI 🎉"
+    assert "Hi App" in captured["body"]
+    assert "log in and complete your profile" in captured["body"]
+    assert "log in to review your profile" not in captured["body"]
 
 
 def test_create_student_returns_existing_for_same_user(monkeypatch):


### PR DESCRIPTION
## Summary
- allow the welcome email builder to render alternate copy when staff authored the student record
- derive a staff-created flag in send_student_welcome_email by comparing ownership fields before composing the email
- extend welcome email tests to cover both staff-created and student-created profiles

## Testing
- pytest tests/test_main.py::test_create_student_sends_welcome_email tests/test_main.py::test_applicant_created_student_sends_welcome_email

------
https://chatgpt.com/codex/tasks/task_e_68d804a3e04483338938b55c7acfa750