### PR TITLE
Add tracking and analytics for email blasts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -423,6 +423,10 @@ def rebuild_vector_index() -> None:
 ACTIVITY_LOG_KEY = "activity_logs"
 # Mapping of email tracking tokens to metadata
 EMAIL_OPEN_TOKENS_KEY = "email_open_tokens"
+EMAIL_BLAST_META_KEY = "email_blast:meta"
+EMAIL_BLAST_INDEX_KEY = "email_blast:index"
+EMAIL_BLAST_STATS_PREFIX = "email_blast:stats:"
+EMAIL_BLAST_RECIPIENTS_PREFIX = "email_blast:recipients:"
 # List key for student load time metrics
 STUDENT_LOAD_TIME_KEY = "metrics:student_load_time"
 # 1x1 transparent PNG
@@ -486,6 +490,82 @@ def send_email(
     except Exception as e:
         logger.error("[email] Failed to send email to %s: %s", recipient, e)
         raise
+
+
+def _blast_stats_key(blast_id: str) -> str:
+    return f"{EMAIL_BLAST_STATS_PREFIX}{blast_id}"
+
+
+def _blast_recipients_key(blast_id: str) -> str:
+    return f"{EMAIL_BLAST_RECIPIENTS_PREFIX}{blast_id}"
+
+
+def _plain_text_to_html(body: str) -> str:
+    lines = body.splitlines()
+    escaped_lines = [escape(line) for line in lines]
+    return "<br />".join(escaped_lines)
+
+
+def _safe_int(value: Any) -> int:
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _hash_set_mapping(name: str, mapping: dict[str, Any]) -> None:
+    try:
+        redis_client.hset(name, mapping=mapping)
+    except TypeError:
+        for field, value in mapping.items():
+            redis_client.hset(name, field, value)
+    except AttributeError:
+        if hasattr(redis_client, "hashes"):
+            redis_client.hashes.setdefault(name, {}).update(mapping)  # type: ignore[attr-defined]
+        else:
+            for field, value in mapping.items():
+                redis_client.hset(name, field, value)
+
+
+def _hash_incr(name: str, field: str, amount: int = 1) -> None:
+    try:
+        redis_client.hincrby(name, field, amount)
+    except AttributeError:
+        current = _safe_int(redis_client.hget(name, field))
+        redis_client.hset(name, field, current + amount)
+
+
+def _hash_getall(name: str) -> dict[str, Any]:
+    try:
+        data = redis_client.hgetall(name) or {}
+        return data
+    except AttributeError:
+        if hasattr(redis_client, "hashes"):
+            stored = redis_client.hashes.get(name, {})  # type: ignore[attr-defined]
+            return dict(stored)
+        return {}
+
+
+def _list_range(name: str, start: int, end: int) -> list[Any]:
+    try:
+        return redis_client.lrange(name, start, end) or []
+    except AttributeError:
+        if hasattr(redis_client, "lists"):
+            items = redis_client.lists.get(name, [])  # type: ignore[attr-defined]
+            if not items:
+                return []
+            length = len(items)
+            start_idx = start if start >= 0 else max(length + start, 0)
+            end_idx = end if end >= 0 else length + end
+            if end == -1:
+                end_idx = length - 1
+            end_idx = min(end_idx, length - 1)
+            if start_idx > end_idx:
+                return []
+            return items[start_idx : end_idx + 1]
+        return []
 
 async def get_driving_distance_miles(
     orig_lat: float | list[tuple[float, float]],
@@ -746,8 +826,47 @@ def track_open(token: str):
             info = json.loads(info_raw)
         except Exception:
             info = {}
+
+    now = datetime.now(timezone.utc)
+    timestamp = now.isoformat()
+
+    blast_id = info.get("blast_id") if isinstance(info, dict) else None
+    recipient = info.get("recipient") if isinstance(info, dict) else None
+    if blast_id and recipient:
+        stats_key = _blast_stats_key(blast_id)
+        recipients_key = _blast_recipients_key(blast_id)
+        try:
+            raw_state = redis_client.hget(recipients_key, recipient)
+            state = json.loads(raw_state) if raw_state else {"email": recipient}
+        except Exception:
+            state = {"email": recipient}
+        opens_val = state.get("opens")
+        try:
+            opens_count = int(opens_val)
+        except (TypeError, ValueError):
+            opens_count = 0
+        opens_count += 1
+        state["opens"] = opens_count
+        if not state.get("first_open"):
+            state["first_open"] = timestamp
+            try:
+                _hash_incr(stats_key, "unique_opens", 1)
+            except Exception as e:
+                logger.error("Failed to increment blast unique opens: %s", e)
+        state["last_open"] = timestamp
+        if state.get("status") != "opened":
+            state["status"] = "opened"
+        try:
+            redis_client.hset(recipients_key, recipient, json.dumps(state))
+        except Exception as e:
+            logger.error("Failed to persist blast recipient open state: %s", e)
+        try:
+            _hash_incr(stats_key, "total_opens", 1)
+        except Exception as e:
+            logger.error("Failed to increment blast total opens: %s", e)
+
     log_entry = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": timestamp,
         "event": "email_open",
         "token": token,
         **info,
@@ -4458,24 +4577,96 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
             status_code=400, detail="No students match the provided criteria"
         )
 
+    blast_id = str(uuid.uuid4())
+    blast_timestamp = datetime.now(timezone.utc).isoformat()
+    stats_key = _blast_stats_key(blast_id)
+    recipients_key = _blast_recipients_key(blast_id)
+    filters_payload = {
+        "institutional_codes": list(req.institutional_codes),
+        "license": req.license,
+        "source": req.source,
+    }
+    html_template = _plain_text_to_html(req.body)
+
+    try:
+        _hash_set_mapping(
+            stats_key,
+            {
+                "matched": len(recipients),
+                "sent": 0,
+                "failed": 0,
+                "unique_opens": 0,
+                "total_opens": 0,
+            },
+        )
+    except Exception as e:
+        logger.error("Failed to initialize blast stats: %s", e)
+
     sent = 0
     failures: list[dict[str, str]] = []
     for recipient in recipients:
+        token = str(uuid.uuid4())
+        sent_at = datetime.now(timezone.utc).isoformat()
+        token_payload = {
+            "blast_id": blast_id,
+            "recipient": recipient,
+            "subject": req.subject,
+            "filters": filters_payload,
+            "sent": sent_at,
+        }
         try:
-            send_email(recipient, req.subject, req.body)
+            redis_client.hset(
+                EMAIL_OPEN_TOKENS_KEY, token, json.dumps(token_payload)
+            )
+        except Exception as e:
+            logger.error("Failed to store blast tracking token: %s", e)
+
+        recipient_state = {
+            "email": recipient,
+            "token": token,
+            "sent_at": sent_at,
+            "status": "pending",
+            "opens": 0,
+            "first_open": None,
+            "last_open": None,
+        }
+
+        try:
+            send_email(
+                recipient,
+                req.subject,
+                req.body,
+                html_body=html_template,
+                track_token=token,
+            )
             sent += 1
+            recipient_state["status"] = "sent"
+            try:
+                _hash_incr(stats_key, "sent", 1)
+            except Exception as e:
+                logger.error("Failed to increment blast sent count: %s", e)
         except Exception as exc:
             failures.append({"email": recipient, "error": str(exc)})
+            recipient_state["status"] = "failed"
+            recipient_state["error"] = str(exc)
+            try:
+                _hash_incr(stats_key, "failed", 1)
+            except Exception as e:
+                logger.error("Failed to increment blast failure count: %s", e)
+        finally:
+            try:
+                redis_client.hset(
+                    recipients_key, recipient, json.dumps(recipient_state)
+                )
+            except Exception as e:
+                logger.error("Failed to store blast recipient state: %s", e)
 
     log_entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "event": "email_blast",
         "actor": current_user.get("sub"),
-        "filters": {
-            "institutional_codes": list(req.institutional_codes),
-            "license": req.license,
-            "source": req.source,
-        },
+        "blast_id": blast_id,
+        "filters": filters_payload,
         "matched": len(recipients),
         "sent": sent,
         "failed": len(failures),
@@ -4488,7 +4679,27 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
     except Exception as e:
         logger.error("Failed to record email blast activity: %s", e)
 
+    blast_record = {
+        "blast_id": blast_id,
+        "timestamp": blast_timestamp,
+        "subject": req.subject,
+        "body_preview": req.body[:200],
+        "filters": filters_payload,
+        "matched": len(recipients),
+        "sent": sent,
+        "failed": len(failures),
+        "skipped_missing_email": skipped_missing_email,
+        "skipped_filtered": skipped_filtered,
+    }
+
+    try:
+        redis_client.hset(EMAIL_BLAST_META_KEY, blast_id, json.dumps(blast_record))
+        redis_client.rpush(EMAIL_BLAST_INDEX_KEY, blast_id)
+    except Exception as e:
+        logger.error("Failed to persist blast metadata: %s", e)
+
     return {
+        "blast_id": blast_id,
         "matched": len(recipients),
         "sent": sent,
         "failed": len(failures),
@@ -4496,6 +4707,85 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
         "skipped_missing_email": skipped_missing_email,
         "skipped_filtered": skipped_filtered,
     }
+
+
+@app.get("/email-blasts")
+def list_email_blasts(
+    limit: int = 50, current_user: dict = Depends(get_current_user)
+):
+    if current_user.get("role") not in ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    if limit <= 0:
+        limit = 1
+
+    try:
+        ids = _list_range(EMAIL_BLAST_INDEX_KEY, -limit, -1)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to list blasts: {e}")
+
+    blasts: list[dict[str, Any]] = []
+    for raw_id in reversed(ids):
+        blast_id = raw_id if isinstance(raw_id, str) else str(raw_id)
+        try:
+            meta_raw = redis_client.hget(EMAIL_BLAST_META_KEY, blast_id)
+        except Exception as e:
+            logger.error("Failed to fetch blast metadata: %s", e)
+            continue
+        if not meta_raw:
+            continue
+        try:
+            meta = json.loads(meta_raw)
+        except Exception:
+            continue
+        stats_raw = _hash_getall(_blast_stats_key(blast_id))
+        stats = {key: _safe_int(value) for key, value in stats_raw.items()}
+        meta.setdefault("blast_id", blast_id)
+        meta["stats"] = stats
+        blasts.append(meta)
+
+    return {"blasts": blasts}
+
+
+@app.get("/email-blasts/{blast_id}")
+def get_email_blast(blast_id: str, current_user: dict = Depends(get_current_user)):
+    if current_user.get("role") not in ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    try:
+        meta_raw = redis_client.hget(EMAIL_BLAST_META_KEY, blast_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to load blast: {e}")
+
+    if not meta_raw:
+        raise HTTPException(status_code=404, detail="Blast not found")
+
+    try:
+        blast = json.loads(meta_raw)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Invalid blast metadata: {e}")
+
+    stats_raw = _hash_getall(_blast_stats_key(blast_id))
+    stats = {key: _safe_int(value) for key, value in stats_raw.items()}
+
+    try:
+        recipients_raw = _hash_getall(_blast_recipients_key(blast_id))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to load blast recipients: {e}")
+
+    recipients: list[dict[str, Any]] = []
+    for email, payload in recipients_raw.items():
+        try:
+            data = json.loads(payload) if payload else {"email": email}
+        except Exception:
+            data = {"email": email}
+        data.setdefault("email", email)
+        recipients.append(data)
+
+    recipients.sort(key=lambda item: item.get("email", ""))
+    blast.setdefault("blast_id", blast_id)
+
+    return {"blast": blast, "stats": stats, "recipients": recipients}
 
 
 @app.get("/students/by-school")

--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -50,14 +50,224 @@
   box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
 }
 
+.blast-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
 .blast-panel {
-  flex: 1;
-  max-width: 650px;
+  flex: 0 0 360px;
+  max-width: 420px;
   background-color: rgba(255, 255, 255, 0.95);
   padding: 1.75rem;
   border-radius: 12px;
   color: #002244;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+.blast-history {
+  flex: 1;
+  min-width: 360px;
+  background-color: rgba(255, 255, 255, 0.95);
+  padding: 1.5rem;
+  border-radius: 12px;
+  color: #002244;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+.blast-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.blast-history-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.blast-history-refresh {
+  background-color: #0074d9;
+  color: #fff;
+  border: none;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.blast-history-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.blast-history-refresh:not(:disabled):hover {
+  background-color: #005fa3;
+  transform: translateY(-1px);
+}
+
+.blast-history-table-wrapper {
+  max-height: 520px;
+  overflow-y: auto;
+  border-radius: 12px;
+  background: rgba(0, 35, 70, 0.04);
+  padding: 0.5rem;
+}
+
+.blast-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.blast-history-table th,
+.blast-history-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+}
+
+.blast-history-table th {
+  background-color: #003366;
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.blast-history-table tbody tr:nth-child(even) {
+  background-color: rgba(0, 51, 102, 0.04);
+}
+
+.blast-expand-cell {
+  width: 48px;
+}
+
+.blast-subject {
+  font-weight: 600;
+}
+
+.blast-metric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.blast-history-loading,
+.blast-history-empty,
+.blast-history-error {
+  text-align: center;
+  padding: 1.25rem;
+  color: #4a5a70;
+  font-weight: 500;
+}
+
+.blast-history-error {
+  color: #b12626;
+  background: #ffecec;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.blast-detail {
+  background: #f8fbff;
+  padding: 1.1rem;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgba(0, 51, 102, 0.08);
+}
+
+.blast-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.blast-detail-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.blast-detail-body {
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 51, 102, 0.08);
+}
+
+.blast-detail-body p {
+  margin: 0.5rem 0 0;
+  white-space: pre-wrap;
+}
+
+.blast-recipient-table-wrapper {
+  max-height: 260px;
+  overflow-y: auto;
+  border-radius: 10px;
+  background: rgba(0, 35, 70, 0.03);
+}
+
+.blast-recipient-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.blast-recipient-table th,
+.blast-recipient-table td {
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+}
+
+.blast-recipient-table thead th {
+  background: #002d62;
+  color: #fff;
+  position: sticky;
+  top: 0;
+}
+
+.blast-recipient-table tbody tr:nth-child(even) {
+  background: rgba(0, 35, 70, 0.05);
+}
+
+.blast-recipient-status {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.blast-recipient-status.status-opened {
+  color: #0f8b45;
+}
+
+.blast-recipient-status.status-failed {
+  color: #c62828;
+}
+
+.blast-recipient-status.status-sent {
+  color: #0a4f94;
+}
+
+.blast-recipient-status.status-pending {
+  color: #7a8899;
+}
+
+@media (max-width: 1024px) {
+  .blast-content {
+    flex-direction: column;
+  }
+
+  .blast-panel,
+  .blast-history {
+    flex: 1;
+    max-width: none;
+    width: 100%;
+  }
 }
 
 .blast-form {

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -54,6 +54,13 @@ function JobPosting() {
   const [blastFeedback, setBlastFeedback] = useState(null);
   const [blastError, setBlastError] = useState(null);
   const [blastStats, setBlastStats] = useState(null);
+  const [blastHistory, setBlastHistory] = useState([]);
+  const [blastHistoryLoading, setBlastHistoryLoading] = useState(false);
+  const [blastHistoryError, setBlastHistoryError] = useState(null);
+  const [expandedBlast, setExpandedBlast] = useState(null);
+  const [blastDetails, setBlastDetails] = useState({});
+  const [blastDetailsLoading, setBlastDetailsLoading] = useState({});
+  const [blastDetailsError, setBlastDetailsError] = useState({});
   const pollingIntervalsRef = useRef({});
   const pollingMetadataRef = useRef({});
   const isMountedRef = useRef(true);
@@ -63,6 +70,49 @@ function JobPosting() {
     return l ? l.label : code;
   };
   const [modalNotes, setModalNotes] = useState(null);
+
+  const formatDateTime = (value) => {
+    if (!value) {
+      return '—';
+    }
+    try {
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        return value;
+      }
+      return parsed.toLocaleString();
+    } catch (err) {
+      return value;
+    }
+  };
+
+  const calculateOpenRate = (stats = {}, fallbackSent = 0) => {
+    const sentCount = stats.sent ?? fallbackSent ?? 0;
+    const uniqueOpens = stats.unique_opens ?? 0;
+    if (!sentCount) {
+      return '0%';
+    }
+    const percent = Math.round((uniqueOpens / sentCount) * 1000) / 10;
+    return `${Number.isInteger(percent) ? percent.toFixed(0) : percent.toFixed(1)}%`;
+  };
+
+  const blastStatusLabel = (status) => {
+    if (!status) {
+      return 'Pending';
+    }
+    switch (status) {
+      case 'sent':
+        return 'Sent';
+      case 'failed':
+        return 'Failed';
+      case 'opened':
+        return 'Opened';
+      case 'pending':
+        return 'Pending';
+      default:
+        return status.charAt(0).toUpperCase() + status.slice(1);
+    }
+  };
 
   const locationRef = useRef(null);
 
@@ -127,6 +177,75 @@ function JobPosting() {
     setBlastForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  const loadBlastHistory = useCallback(async () => {
+    setBlastHistoryError(null);
+    setBlastHistoryLoading(true);
+    try {
+      const resp = await api.get('/email-blasts');
+      const history = resp?.data?.blasts || [];
+      if (isMountedRef.current) {
+        setBlastHistory(history);
+      }
+    } catch (err) {
+      console.error('Failed to load email blasts', err);
+      if (isMountedRef.current) {
+        setBlastHistoryError('Failed to load email blasts.');
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setBlastHistoryLoading(false);
+      }
+    }
+  }, []);
+
+  const loadBlastDetails = useCallback(
+    async (blastId) => {
+      if (!blastId) {
+        return;
+      }
+      setBlastDetailsError((prev) => ({ ...prev, [blastId]: null }));
+      setBlastDetailsLoading((prev) => ({ ...prev, [blastId]: true }));
+      try {
+        const resp = await api.get(`/email-blasts/${blastId}`);
+        if (isMountedRef.current) {
+          setBlastDetails((prev) => ({ ...prev, [blastId]: resp?.data || {} }));
+        }
+      } catch (err) {
+        console.error('Failed to load blast details', err);
+        if (isMountedRef.current) {
+          setBlastDetailsError((prev) => ({
+            ...prev,
+            [blastId]: 'Failed to load blast details.'
+          }));
+        }
+      } finally {
+        if (isMountedRef.current) {
+          setBlastDetailsLoading((prev) => ({ ...prev, [blastId]: false }));
+        }
+      }
+    },
+    []
+  );
+
+  const handleBlastToggle = useCallback(
+    (blastId) => {
+      setExpandedBlast((prev) => {
+        const next = prev === blastId ? null : blastId;
+        if (prev !== blastId && !blastDetails[blastId] && !blastDetailsLoading[blastId]) {
+          loadBlastDetails(blastId);
+        }
+        return next;
+      });
+    },
+    [blastDetails, blastDetailsLoading, loadBlastDetails]
+  );
+
+  useEffect(() => {
+    if (activeTab === 'blast') {
+      loadBlastHistory();
+    }
+  }, [activeTab, loadBlastHistory]);
+
   const handleBlastSubmit = async (event) => {
     event.preventDefault();
     setBlastError(null);
@@ -185,6 +304,11 @@ function JobPosting() {
         license: '',
         source: ''
       });
+      await loadBlastHistory();
+      if (data.blast_id) {
+        setExpandedBlast(data.blast_id);
+        loadBlastDetails(data.blast_id);
+      }
     } catch (err) {
       const detail = err?.response?.data?.detail;
       setBlastError(detail || 'Failed to send email blast.');
@@ -1202,100 +1326,243 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
       </div>
       <div className="tab-content">
         {activeTab === 'blast' && (
-          <div className="blast-panel">
-            <form className="blast-form" onSubmit={handleBlastSubmit}>
-              <h2>Email Blast</h2>
-              <div className="blast-field">
-                <label htmlFor="blast-subject">Subject</label>
-                <input
-                  id="blast-subject"
-                  name="subject"
-                  type="text"
-                  value={blastForm.subject}
-                  onChange={handleBlastFormChange}
-                  placeholder="Enter an email subject"
-                />
-              </div>
-              <div className="blast-field">
-                <label htmlFor="blast-body">Message</label>
-                <textarea
-                  id="blast-body"
-                  name="body"
-                  rows={8}
-                  value={blastForm.body}
-                  onChange={handleBlastFormChange}
-                  placeholder="Write the email you want to send"
-                ></textarea>
-              </div>
-              <div className="blast-field">
-                <label htmlFor="blast-institutional-codes">Institutional Codes</label>
-                <select
-                  id="blast-institutional-codes"
-                  name="institutionalCodes"
-                  multiple
-                  value={blastForm.institutionalCodes}
-                  onChange={handleBlastFormChange}
+          <div className="blast-content">
+            <div className="blast-panel">
+              <form className="blast-form" onSubmit={handleBlastSubmit}>
+                <h2>Email Blast</h2>
+                <div className="blast-field">
+                  <label htmlFor="blast-subject">Subject</label>
+                  <input
+                    id="blast-subject"
+                    name="subject"
+                    type="text"
+                    value={blastForm.subject}
+                    onChange={handleBlastFormChange}
+                    placeholder="Enter an email subject"
+                  />
+                </div>
+                <div className="blast-field">
+                  <label htmlFor="blast-body">Message</label>
+                  <textarea
+                    id="blast-body"
+                    name="body"
+                    rows={8}
+                    value={blastForm.body}
+                    onChange={handleBlastFormChange}
+                    placeholder="Write the email you want to send"
+                  ></textarea>
+                </div>
+                <div className="blast-field">
+                  <label htmlFor="blast-institutional-codes">Institutional Codes</label>
+                  <select
+                    id="blast-institutional-codes"
+                    name="institutionalCodes"
+                    multiple
+                    value={blastForm.institutionalCodes}
+                    onChange={handleBlastFormChange}
+                  >
+                    {schoolCodes.map((code) => (
+                      <option key={code.code} value={code.code}>
+                        {code.code} — {code.label}
+                      </option>
+                    ))}
+                  </select>
+                  <small>Select one or more codes to target a specific school.</small>
+                </div>
+                <div className="blast-field">
+                  <label htmlFor="blast-license">License</label>
+                  <select
+                    id="blast-license"
+                    name="license"
+                    value={blastForm.license}
+                    onChange={handleBlastFormChange}
+                  >
+                    <option value="">All Licenses</option>
+                    {licenses.map((l) => (
+                      <option key={l.code} value={l.code}>
+                        {l.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="blast-field">
+                  <label htmlFor="blast-source">Source</label>
+                  <input
+                    id="blast-source"
+                    name="source"
+                    type="text"
+                    value={blastForm.source}
+                    onChange={handleBlastFormChange}
+                    placeholder="Filter by student source (optional)"
+                  />
+                </div>
+                <div className="blast-actions">
+                  <button type="submit" disabled={blastSubmitting}>
+                    {blastSubmitting ? 'Sending…' : 'Send Email Blast'}
+                  </button>
+                </div>
+                {blastFeedback && <div className="blast-feedback">{blastFeedback}</div>}
+                {blastError && <div className="blast-error">{blastError}</div>}
+                {blastStats && (
+                  <div className="blast-stats">
+                    <div><strong>Matched:</strong> {blastStats.matched ?? 0}</div>
+                    <div><strong>Sent:</strong> {blastStats.sent ?? 0}</div>
+                    <div><strong>Failed:</strong> {blastStats.failed ?? 0}</div>
+                    {blastStats.skipped_missing_email ? (
+                      <div>
+                        <strong>Skipped (missing email):</strong> {blastStats.skipped_missing_email}
+                      </div>
+                    ) : null}
+                    {blastStats.skipped_filtered ? (
+                      <div>
+                        <strong>Skipped (filters):</strong> {blastStats.skipped_filtered}
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+              </form>
+            </div>
+            <div className="blast-history">
+              <div className="blast-history-header">
+                <h2>Blast History</h2>
+                <button
+                  type="button"
+                  onClick={loadBlastHistory}
+                  disabled={blastHistoryLoading}
+                  className="blast-history-refresh"
                 >
-                  {schoolCodes.map((code) => (
-                    <option key={code.code} value={code.code}>
-                      {code.code} — {code.label}
-                    </option>
-                  ))}
-                </select>
-                <small>Select one or more codes to target a specific school.</small>
-              </div>
-              <div className="blast-field">
-                <label htmlFor="blast-license">License</label>
-                <select
-                  id="blast-license"
-                  name="license"
-                  value={blastForm.license}
-                  onChange={handleBlastFormChange}
-                >
-                  <option value="">All Licenses</option>
-                  {licenses.map((l) => (
-                    <option key={l.code} value={l.code}>
-                      {l.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="blast-field">
-                <label htmlFor="blast-source">Source</label>
-                <input
-                  id="blast-source"
-                  name="source"
-                  type="text"
-                  value={blastForm.source}
-                  onChange={handleBlastFormChange}
-                  placeholder="Filter by student source (optional)"
-                />
-              </div>
-              <div className="blast-actions">
-                <button type="submit" disabled={blastSubmitting}>
-                  {blastSubmitting ? 'Sending…' : 'Send Email Blast'}
+                  {blastHistoryLoading ? 'Refreshing…' : 'Refresh'}
                 </button>
               </div>
-              {blastFeedback && <div className="blast-feedback">{blastFeedback}</div>}
-              {blastError && <div className="blast-error">{blastError}</div>}
-              {blastStats && (
-                <div className="blast-stats">
-                  <div><strong>Matched:</strong> {blastStats.matched ?? 0}</div>
-                  <div><strong>Sent:</strong> {blastStats.sent ?? 0}</div>
-                  <div><strong>Failed:</strong> {blastStats.failed ?? 0}</div>
-                  {blastStats.skipped_missing_email ? (
-                    <div>
-                      <strong>Skipped (missing email):</strong> {blastStats.skipped_missing_email}
-                    </div>
-                  ) : null}
-                  {blastStats.skipped_filtered ? (
-                    <div>
-                      <strong>Skipped (filters):</strong> {blastStats.skipped_filtered}
-                    </div>
-                  ) : null}
-                </div>
+              {blastHistoryError && (
+                <div className="blast-error blast-history-error">{blastHistoryError}</div>
               )}
-            </form>
+              <div className="blast-history-table-wrapper">
+                {blastHistoryLoading && blastHistory.length === 0 ? (
+                  <div className="blast-history-loading">Loading email blasts…</div>
+                ) : blastHistory.length === 0 ? (
+                  <div className="blast-history-empty">No email blasts have been sent yet.</div>
+                ) : (
+                  <table className="blast-history-table">
+                    <thead>
+                      <tr>
+                        <th></th>
+                        <th>Subject</th>
+                        <th>Sent</th>
+                        <th>Delivered</th>
+                        <th>Unique Opens</th>
+                        <th>Open Rate</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {blastHistory.map((blast) => {
+                        const stats = blast.stats || {};
+                        const sentCount = stats.sent ?? blast.sent ?? 0;
+                        const uniqueOpens = stats.unique_opens ?? 0;
+                        const isExpanded = expandedBlast === blast.blast_id;
+                        return (
+                          <React.Fragment key={blast.blast_id}>
+                            <tr className="blast-row">
+                              <td className="blast-expand-cell">
+                                <button
+                                  type="button"
+                                  className="expand-toggle"
+                                  onClick={() => handleBlastToggle(blast.blast_id)}
+                                  title={isExpanded ? 'Collapse' : 'Expand'}
+                                >
+                                  {isExpanded ? '–' : '+'}
+                                </button>
+                              </td>
+                              <td className="blast-subject">{blast.subject}</td>
+                              <td>{formatDateTime(blast.timestamp)}</td>
+                              <td className="blast-metric">{sentCount}</td>
+                              <td className="blast-metric">{uniqueOpens}</td>
+                              <td className="blast-metric">{calculateOpenRate(stats, blast.sent)}</td>
+                            </tr>
+                            {isExpanded && (
+                              <tr className="blast-detail-row">
+                                <td colSpan={6}>
+                                  {blastDetailsLoading[blast.blast_id] ? (
+                                    <div className="blast-history-loading">Loading details…</div>
+                                  ) : blastDetailsError[blast.blast_id] ? (
+                                    <div className="blast-error">{blastDetailsError[blast.blast_id]}</div>
+                                  ) : (
+                                    (() => {
+                                      const detail = blastDetails[blast.blast_id] || {};
+                                      const detailBlast = detail.blast || blast;
+                                      const detailStats = detail.stats || stats;
+                                      const recipients = detail.recipients || [];
+                                      const filters = detailBlast.filters || blast.filters || {};
+                                      return (
+                                        <div className="blast-detail">
+                                          <div className="blast-summary-grid">
+                                            <div><strong>Matched:</strong> {detailBlast.matched ?? blast.matched ?? 0}</div>
+                                            <div><strong>Sent:</strong> {detailStats.sent ?? detailBlast.sent ?? sentCount}</div>
+                                            <div><strong>Failed:</strong> {detailBlast.failed ?? blast.failed ?? 0}</div>
+                                            <div><strong>Unique Opens:</strong> {detailStats.unique_opens ?? uniqueOpens}</div>
+                                            <div><strong>Total Opens:</strong> {detailStats.total_opens ?? 0}</div>
+                                            <div><strong>Open Rate:</strong> {calculateOpenRate(detailStats, detailBlast.sent ?? sentCount)}</div>
+                                            <div><strong>Skipped (missing email):</strong> {detailBlast.skipped_missing_email ?? 0}</div>
+                                            <div><strong>Skipped (filters):</strong> {detailBlast.skipped_filtered ?? 0}</div>
+                                          </div>
+                                          <div className="blast-detail-filters">
+                                            <div><strong>Institutional Codes:</strong> {filters.institutional_codes && filters.institutional_codes.length ? filters.institutional_codes.join(', ') : 'All'}</div>
+                                            <div><strong>License:</strong> {filters.license || 'All'}</div>
+                                            <div><strong>Source:</strong> {filters.source || 'All'}</div>
+                                          </div>
+                                          {detailBlast.body_preview && (
+                                            <div className="blast-detail-body">
+                                              <strong>Message Preview:</strong>
+                                              <p>{detailBlast.body_preview}</p>
+                                            </div>
+                                          )}
+                                          <div className="blast-recipient-table-wrapper">
+                                            {recipients.length === 0 ? (
+                                              <div className="blast-history-empty">No recipient records found.</div>
+                                            ) : (
+                                              <table className="blast-recipient-table">
+                                                <thead>
+                                                  <tr>
+                                                    <th>Email</th>
+                                                    <th>Status</th>
+                                                    <th>Sent At</th>
+                                                    <th>First Open</th>
+                                                    <th>Last Open</th>
+                                                    <th>Opens</th>
+                                                  </tr>
+                                                </thead>
+                                                <tbody>
+                                                  {recipients.map((recipient) => (
+                                                    <tr key={recipient.email}>
+                                                      <td>{recipient.email}</td>
+                                                      <td className={`blast-recipient-status status-${recipient.status || 'pending'}`}>
+                                                        {blastStatusLabel(recipient.status)}
+                                                      </td>
+                                                      <td>{formatDateTime(recipient.sent_at)}</td>
+                                                      <td>{formatDateTime(recipient.first_open)}</td>
+                                                      <td>{formatDateTime(recipient.last_open)}</td>
+                                                      <td className="blast-metric">{recipient.opens ?? 0}</td>
+                                                    </tr>
+                                                  ))}
+                                                </tbody>
+                                              </table>
+                                            )}
+                                          </div>
+                                        </div>
+                                      );
+                                    })()
+                                  )}
+                                </td>
+                              </tr>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </div>
           </div>
         )}
         {activeTab === 'post' && (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2941,10 +2941,25 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
         other["email"], other, other["institutional_code"], other["student_id"]
     )
 
-    sent = []
+    sent: list[dict[str, str | None]] = []
 
-    def fake_send(recipient, subject, body, html_body=None, attachments=None, track_token=None):
-        sent.append((recipient, subject, body))
+    def fake_send(
+        recipient,
+        subject,
+        body,
+        html_body=None,
+        attachments=None,
+        track_token=None,
+    ):
+        sent.append(
+            {
+                "recipient": recipient,
+                "subject": subject,
+                "body": body,
+                "html_body": html_body,
+                "track_token": track_token,
+            }
+        )
 
     monkeypatch.setattr(main_app, "send_email", fake_send)
 
@@ -2968,7 +2983,32 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
     assert data["matched"] == 1
     assert data["sent"] == 1
     assert data["failed"] == 0
-    assert sent == [("sam@example.com", "Important update", "Please review the latest opportunity.")]
+    assert data["blast_id"]
+    assert len(sent) == 1
+    assert sent[0]["recipient"] == "sam@example.com"
+    assert sent[0]["track_token"]
+    assert sent[0]["html_body"] is not None
+
+    blast_id = data["blast_id"]
+    token_val = sent[0]["track_token"]
+
+    mapping_raw = main_app.redis_client.hget(main_app.EMAIL_OPEN_TOKENS_KEY, token_val)
+    assert mapping_raw is not None
+    mapping = json.loads(mapping_raw)
+    assert mapping["blast_id"] == blast_id
+    assert mapping["recipient"] == "sam@example.com"
+
+    recipient_state_raw = main_app.redis_client.hget(
+        main_app._blast_recipients_key(blast_id), "sam@example.com"
+    )
+    assert recipient_state_raw is not None
+    recipient_state = json.loads(recipient_state_raw)
+    assert recipient_state["status"] == "sent"
+    assert recipient_state["opens"] == 0
+
+    stats_raw = main_app._hash_getall(main_app._blast_stats_key(blast_id))
+    assert main_app._safe_int(stats_raw.get("sent")) == 1
+    assert main_app._safe_int(stats_raw.get("matched")) == 1
 
     raw_logs = main_app.redis_client.lists.get(main_app.ACTIVITY_LOG_KEY, [])
     parsed_logs = [json.loads(item) for item in raw_logs]
@@ -2976,6 +3016,37 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
     assert blast_logs, f"Expected an email_blast entry in activity log, got: {parsed_logs}"
     assert blast_logs[-1]["sent"] == 1
     assert blast_logs[-1]["filters"]["institutional_codes"] == ["1001"]
+
+    list_resp = client.get(
+        "/email-blasts", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert list_resp.status_code == 200
+    blasts = list_resp.json()["blasts"]
+    assert blasts and any(b["blast_id"] == blast_id for b in blasts)
+
+    detail_resp = client.get(
+        f"/email-blasts/{blast_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert detail_resp.status_code == 200
+    detail = detail_resp.json()
+    assert detail["blast"]["blast_id"] == blast_id
+    assert detail["stats"]["sent"] == 1
+    assert detail["stats"]["unique_opens"] == 0
+    assert len(detail["recipients"]) == 1
+    assert detail["recipients"][0]["status"] == "sent"
+
+    track_resp = client.get(f"/track/open/{token_val}.png")
+    assert track_resp.status_code == 200
+
+    detail_after_open = client.get(
+        f"/email-blasts/{blast_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert detail_after_open.status_code == 200
+    detail_payload = detail_after_open.json()
+    assert detail_payload["stats"]["unique_opens"] == 1
+    assert detail_payload["stats"]["total_opens"] == 1
+    assert detail_payload["recipients"][0]["opens"] == 1
+    assert detail_payload["recipients"][0]["status"] == "opened"
 
 
 def test_email_blast_requires_admin_role():


### PR DESCRIPTION
## Summary
- generate tracking tokens for each email blast recipient and persist blast metadata, stats, and recipient activity
- expose new endpoints to list blasts and fetch detailed analytics for the Email Blast UI
- refresh the Email Blast tab with a history panel, expandable analytics, and updated styling, plus extend tests for the new behaviour

## Testing
- pytest tests/test_main.py::test_email_blast_sends_to_matching_students tests/test_main.py::test_email_blast_requires_admin_role tests/test_main.py::test_email_blast_no_matching_students

------
https://chatgpt.com/codex/tasks/task_e_68d772ae751c833395b9deaa38fe463c