### PR TITLE
Update welcome email branding and messaging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -599,23 +599,22 @@ def build_welcome_email(
 
     institution = _clean_institution_label(institution_label)
     if not institution:
-        institution = "your institution"
+        institution = "your academic institution"
 
-    subject = "Welcome to TalenMatch AI 🎉"
+    subject = "Welcome to TalentMatch-AI 🎉"
 
     if staff_created:
         intro_line = (
             f"The Career Services team at {institution} has already created your "
-            "TalenMatch AI profile to help you take the next step in your healthcare career.\n\n"
+            "TalentMatch-AI profile to help you take the next step in your healthcare career.\n\n"
         )
         action_line = (
-            "To get started, log in to review your profile. Confirm your details, "
-            "complete any missing information, and keep everything up to date for the "
-            "best matches.\n\n"
+            "Log in anytime to explore personalized opportunities and stay informed "
+            "about the latest matches.\n\n"
         )
     else:
         intro_line = (
-            f"We're excited to share that TalenMatch AI has partnered with {institution} "
+            f"We're excited to share that TalentMatch-AI has partnered with {institution} "
             "to support you in taking the next step in your healthcare career.\n\n"
         )
         action_line = (
@@ -635,7 +634,7 @@ def build_welcome_email(
         f"{action_line}"
         "We're here to support you every step of the way, alongside your Career Services team.\n\n"
         "Wishing you success,\n"
-        "The TalenMatch-AI Team"
+        "The TalentMatch-AI Team"
     )
     return subject, body
 
@@ -655,10 +654,12 @@ def send_student_welcome_email(
         return False
 
     label = student.get("school_label")
+    label_from_code = False
     if not label:
         code = student.get("institutional_code") or student.get("institution_code") or institution_code
         if code:
             label = get_school_label(str(code))
+            label_from_code = True
 
     normalized_student_email = normalize_email(email)
 
@@ -682,7 +683,7 @@ def send_student_welcome_email(
 
     subject, body = build_welcome_email(
         student.get("first_name"),
-        label,
+        None if label_from_code else label,
         staff_created=staff_created,
     )
     send_email(email, subject, body)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -766,11 +766,11 @@ def test_create_student_sends_welcome_email(monkeypatch):
     datetime.fromisoformat(stored["welcome_email_sent_at"])
 
     assert captured["recipient"] == profile["email"]
-    assert captured["subject"] == "Welcome to TalenMatch AI 🎉"
+    assert captured["subject"] == "Welcome to TalentMatch-AI 🎉"
     assert "Hi Stu" in captured["body"]
     assert "Unitek-Sacramento" in captured["body"]
     assert "1001-" not in captured["body"]
-    assert "log in to review your profile" in captured["body"]
+    assert "Log in anytime to explore personalized opportunities" in captured["body"]
     assert "log in and complete your profile" not in captured["body"]
 
 
@@ -851,10 +851,37 @@ def test_applicant_created_student_sends_welcome_email(monkeypatch):
     datetime.fromisoformat(stored["welcome_email_sent_at"])
 
     assert captured["recipient"] == profile["email"]
-    assert captured["subject"] == "Welcome to TalenMatch AI 🎉"
+    assert captured["subject"] == "Welcome to TalentMatch-AI 🎉"
     assert "Hi App" in captured["body"]
     assert "log in and complete your profile" in captured["body"]
     assert "log in to review your profile" not in captured["body"]
+
+
+def test_welcome_email_generic_institution_when_label_missing(monkeypatch):
+    main_app.redis_client.flushdb()
+
+    captured: dict[str, str] = {}
+
+    def fake_send_email(recipient, subject, body, html_body=None, attachments=None, track_token=None):
+        captured["recipient"] = recipient
+        captured["subject"] = subject
+        captured["body"] = body
+
+    monkeypatch.setattr(main_app, "send_email", fake_send_email)
+    monkeypatch.setattr(main_app, "get_school_label", lambda code: "9999 - West Coast University")
+
+    student = {
+        "email": "generic@example.com",
+        "first_name": "Casey",
+        "institutional_code": "9999",
+    }
+
+    sent = main_app.send_student_welcome_email(student)
+
+    assert sent is True
+    assert captured["subject"] == "Welcome to TalentMatch-AI 🎉"
+    assert "your academic institution" in captured["body"]
+    assert "West Coast University" not in captured["body"]
 
 
 def test_create_student_returns_existing_for_same_user(monkeypatch):
@@ -977,7 +1004,7 @@ def test_admin_send_welcome_emails_resend(monkeypatch):
     updated_raw = main_app.redis_client.get(main_app.student_key("1001", "1"))
     updated = json.loads(updated_raw)
     assert updated["welcome_email_sent_at"] != previous_ts
-    assert sent_messages[0][1] == "Welcome to TalenMatch AI 🎉"
+    assert sent_messages[0][1] == "Welcome to TalentMatch-AI 🎉"
 
 
 def test_metrics_endpoint():


### PR DESCRIPTION
## Summary
- align the welcome email subject and copy to consistently use the TalentMatch-AI branding
- adjust the generic institution fallback and avoid displaying the lookup label when only an institutional code is known
- cover the new behavior with refreshed expectations and a new unit test

## Testing
- `pytest tests/test_main.py::test_create_student_sends_welcome_email tests/test_main.py::test_applicant_created_student_sends_welcome_email tests/test_main.py::test_welcome_email_generic_institution_when_label_missing`


------
https://chatgpt.com/codex/tasks/task_e_68d80ee97f488333b6705cbb20849ed2