### PR TITLE
Remove login prompts from welcome email

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -608,18 +608,10 @@ def build_welcome_email(
             f"The Career Services team at {institution} has already created your "
             "TalentMatch-AI profile to help you take the next step in your healthcare career.\n\n"
         )
-        action_line = (
-            "Log in anytime to explore personalized opportunities and stay informed "
-            "about the latest matches.\n\n"
-        )
     else:
         intro_line = (
             f"We're excited to share that TalentMatch-AI has partnered with {institution} "
             "to support you in taking the next step in your healthcare career.\n\n"
-        )
-        action_line = (
-            "To get started, log in and complete your profile. A stronger profile means "
-            "better matches and more opportunities.\n\n"
         )
 
     body = (
@@ -631,7 +623,6 @@ def build_welcome_email(
         "📚 Career Resources – resume tips, webinars, and guidance to help you succeed.\n\n"
         "👩‍⚕️ Support from Experienced RNs and LVNs – professional insight and mentorship "
         "to help you prepare with confidence.\n\n"
-        f"{action_line}"
         "We're here to support you every step of the way, alongside your Career Services team.\n\n"
         "Wishing you success,\n"
         "The TalentMatch-AI Team"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -770,7 +770,7 @@ def test_create_student_sends_welcome_email(monkeypatch):
     assert "Hi Stu" in captured["body"]
     assert "Unitek-Sacramento" in captured["body"]
     assert "1001-" not in captured["body"]
-    assert "Log in anytime to explore personalized opportunities" in captured["body"]
+    assert "Log in anytime to explore personalized opportunities" not in captured["body"]
     assert "log in and complete your profile" not in captured["body"]
 
 
@@ -853,7 +853,7 @@ def test_applicant_created_student_sends_welcome_email(monkeypatch):
     assert captured["recipient"] == profile["email"]
     assert captured["subject"] == "Welcome to TalentMatch-AI 🎉"
     assert "Hi App" in captured["body"]
-    assert "log in and complete your profile" in captured["body"]
+    assert "log in and complete your profile" not in captured["body"]
     assert "log in to review your profile" not in captured["body"]
 
 


### PR DESCRIPTION
## Summary
- remove the login call-to-action paragraphs from the student welcome email for both creation paths
- update welcome email tests to reflect the trimmed copy

## Testing
- pytest tests/test_main.py::test_create_student_sends_welcome_email tests/test_main.py::test_applicant_created_student_sends_welcome_email

------
https://chatgpt.com/codex/tasks/task_e_68d816d817088333b292584d19e69733