### PR TITLE
Linkify URLs in email blast HTML

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -502,10 +502,26 @@ def _blast_recipients_key(blast_id: str) -> str:
     return f"{EMAIL_BLAST_RECIPIENTS_PREFIX}{blast_id}"
 
 
+_URL_PATTERN = re.compile(r"(?P<url>(?:https?://|mailto:)[^\s<>\"']+)")
+
+
 def _plain_text_to_html(body: str) -> str:
+    def linkify(text: str) -> str:
+        parts: list[str] = []
+        last_index = 0
+        for match in _URL_PATTERN.finditer(text):
+            start, end = match.span()
+            parts.append(escape(text[last_index:start]))
+            url = match.group("url")
+            escaped_url = escape(url, quote=True)
+            parts.append(f'<a href="{escaped_url}">{escaped_url}</a>')
+            last_index = end
+        parts.append(escape(text[last_index:]))
+        return "".join(parts)
+
     lines = body.splitlines()
-    escaped_lines = [escape(line) for line in lines]
-    return "<br />".join(escaped_lines)
+    linkified_lines = [linkify(line) for line in lines]
+    return "<br />".join(linkified_lines)
 
 
 def _safe_int(value: Any) -> int:

--- a/tests/test_email_blast_html.py
+++ b/tests/test_email_blast_html.py
@@ -1,0 +1,13 @@
+import os
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from app.main import _plain_text_to_html
+
+
+def test_plain_text_to_html_linkification_and_escaping():
+    html = _plain_text_to_html("Visit https://example.com & stay <safe>")
+    assert '<a href="https://example.com">https://example.com</a>' in html
+    assert "&amp; stay" in html
+    assert "&lt;safe&gt;" in html


### PR DESCRIPTION
## Summary
- ensure `_plain_text_to_html` escapes content and linkifies http/https and mailto URLs
- add a regression test covering link creation and escaping behavior

## Testing
- pytest tests/test_email_blast_html.py

------
https://chatgpt.com/codex/tasks/task_e_68d8533d821c83338bc327934c348790