### PR TITLE
Tighten job matching tab layout

### DIFF
--- a/frontend/src/JobPosting.css
+++ b/frontend/src/JobPosting.css
@@ -772,6 +772,8 @@
 .tab-bar {
   display: flex;
   align-items: flex-end;
+  justify-content: flex-start;
+  gap: 0.5rem;
   margin-bottom: 0 !important;
   border-bottom: none !important;
   padding-left: 0.5rem;
@@ -784,10 +786,10 @@
   border: none !important;
   border-bottom: none !important;
   border-radius: 1.2rem 1.2rem 0 0 !important;
-  padding: 1rem 2.5rem 1.2rem 2.5rem !important;
-  margin-right: 0.3rem !important;
+  padding: 0.75rem 1.5rem 1rem 1.5rem !important;
+  margin-right: 0 !important;
   font-weight: 600 !important;
-  font-size: 1.1rem !important;
+  font-size: 1.05rem !important;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- left-align the job matching module tabs and give them consistent spacing
- reduce tab padding so the three controls sit closer together

## Testing
- npm start -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68d891c797648333b9f5c1c297fa8592