### PR TITLE
Add first-name personalization to email blasts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -503,6 +503,17 @@ def _blast_recipients_key(blast_id: str) -> str:
 
 
 _URL_PATTERN = re.compile(r"(?P<url>(?:https?://|mailto:)[^\s<>\"']+)")
+_FIRST_NAME_TOKEN_PATTERN = re.compile(r"\{\{\s*first_name\s*\}\}")
+
+
+def _personalize_blast_body(
+    template: str, context: dict[str, Any], fallback: str = "there"
+) -> str:
+    """Replace supported personalization tokens within an email blast template."""
+
+    first_name = (context.get("first_name") or "").strip()
+    replacement = first_name or fallback
+    return _FIRST_NAME_TOKEN_PATTERN.sub(replacement, template)
 
 
 def _plain_text_to_html(body: str) -> str:
@@ -4719,7 +4730,7 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
     license_filter = license_filter.lower() if license_filter else None
     source_filter = req.source.lower() if req.source else None
 
-    recipients: list[str] = []
+    recipients: list[dict[str, str]] = []
     seen: set[str] = set()
     skipped_missing_email = 0
     skipped_filtered = 0
@@ -4763,7 +4774,12 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
                 skipped_filtered += 1
                 continue
 
-            recipients.append(email)
+            recipients.append(
+                {
+                    "email": email,
+                    "first_name": (student.get("first_name") or "").strip(),
+                }
+            )
             seen.add(email)
 
         if cursor == 0:
@@ -4783,8 +4799,6 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
         "license": req.license,
         "source": req.source,
     }
-    html_template = _plain_text_to_html(req.body)
-
     try:
         _hash_set_mapping(
             stats_key,
@@ -4802,11 +4816,14 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
     sent = 0
     failures: list[dict[str, str]] = []
     for recipient in recipients:
+        recipient_email = recipient["email"]
+        personalized_body = _personalize_blast_body(req.body, recipient)
+        personalized_html = _plain_text_to_html(personalized_body)
         token = str(uuid.uuid4())
         sent_at = datetime.now(timezone.utc).isoformat()
         token_payload = {
             "blast_id": blast_id,
-            "recipient": recipient,
+            "recipient": recipient_email,
             "subject": req.subject,
             "filters": filters_payload,
             "sent": sent_at,
@@ -4819,7 +4836,7 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
             logger.error("Failed to store blast tracking token: %s", e)
 
         recipient_state = {
-            "email": recipient,
+            "email": recipient_email,
             "token": token,
             "sent_at": sent_at,
             "status": "pending",
@@ -4830,10 +4847,10 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
 
         try:
             send_email(
-                recipient,
+                recipient_email,
                 req.subject,
-                req.body,
-                html_body=html_template,
+                personalized_body,
+                html_body=personalized_html,
                 track_token=token,
             )
             sent += 1
@@ -4843,7 +4860,7 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
             except Exception as e:
                 logger.error("Failed to increment blast sent count: %s", e)
         except Exception as exc:
-            failures.append({"email": recipient, "error": str(exc)})
+            failures.append({"email": recipient_email, "error": str(exc)})
             recipient_state["status"] = "failed"
             recipient_state["error"] = str(exc)
             try:
@@ -4853,7 +4870,7 @@ def send_email_blast(req: EmailBlastRequest, current_user: dict = Depends(get_cu
         finally:
             try:
                 redis_client.hset(
-                    recipients_key, recipient, json.dumps(recipient_state)
+                    recipients_key, recipient_email, json.dumps(recipient_state)
                 )
             except Exception as e:
                 logger.error("Failed to store blast recipient state: %s", e)

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -1351,6 +1351,10 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                     onChange={handleBlastFormChange}
                     placeholder="Write the email you want to send"
                   ></textarea>
+                  <small>
+                    Use <code>{'{{first_name}}'}</code> to insert a student's first name. If no
+                    name is available, the blast will say &quot;there&quot; instead.
+                  </small>
                 </div>
                 <div className="blast-field">
                   <label htmlFor="blast-institutional-codes">Institutional Codes</label>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3215,7 +3215,7 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
         headers={"Authorization": f"Bearer {token}"},
         json={
             "subject": "Important update",
-            "body": "Please review the latest opportunity.",
+            "body": "Hi {{first_name}}, please review the latest opportunity.",
             "institutional_codes": ["1001"],
             "license": "lvn",
         },
@@ -3230,7 +3230,8 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
     assert len(sent) == 1
     assert sent[0]["recipient"] == "sam@example.com"
     assert sent[0]["track_token"]
-    assert sent[0]["html_body"] is not None
+    assert sent[0]["html_body"] == "Hi Sam, please review the latest opportunity."
+    assert sent[0]["body"] == "Hi Sam, please review the latest opportunity."
 
     blast_id = data["blast_id"]
     token_val = sent[0]["track_token"]
@@ -3290,6 +3291,66 @@ def test_email_blast_sends_to_matching_students(monkeypatch):
     assert detail_payload["stats"]["total_opens"] == 1
     assert detail_payload["recipients"][0]["opens"] == 1
     assert detail_payload["recipients"][0]["status"] == "opened"
+
+
+def test_email_blast_first_name_fallback(monkeypatch):
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    student = {
+        "first_name": "",
+        "last_name": "Student",
+        "email": "no-name@example.com",
+        "license": "lvn",
+        "institutional_code": "1001",
+        "student_id": "2",
+    }
+
+    main_app.persist_student_record(
+        student["email"], student, student["institutional_code"], student["student_id"]
+    )
+
+    captured: dict[str, str] = {}
+
+    def fake_send(
+        recipient,
+        subject,
+        body,
+        html_body=None,
+        attachments=None,
+        track_token=None,
+    ):
+        captured.update(
+            {
+                "recipient": recipient,
+                "subject": subject,
+                "body": body,
+                "html_body": html_body,
+            }
+        )
+
+    monkeypatch.setattr(main_app, "send_email", fake_send)
+
+    token = client.post(
+        "/login", json={"email": "admin@example.com", "password": "admin123"}
+    ).json()["token"]
+
+    resp = client.post(
+        "/email-blast",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "subject": "Greetings",
+            "body": "Hello {{first_name}}, welcome aboard!",
+            "institutional_codes": ["1001"],
+            "license": "lvn",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["sent"] == 1
+    assert captured["recipient"] == student["email"]
+    assert captured["body"] == "Hello there, welcome aboard!"
+    assert captured["html_body"] == "Hello there, welcome aboard!"
 
 
 def test_email_blast_requires_admin_role():


### PR DESCRIPTION
## Summary
- personalize bulk blast delivery by replacing {{first_name}} tokens before sending
- explain the new placeholder in the admin email blast form
- cover personalized blasts and missing-name fallbacks in unit tests

## Testing
- pytest tests/test_main.py -k "email_blast" -q


------
https://chatgpt.com/codex/tasks/task_e_68da8ffc6a408333bbe57aa5258efd49