### PR TITLE
Allow career staff to manage their jobs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2280,6 +2280,8 @@ def create_job(job: JobRequest, current_user: dict = Depends(get_current_user)):
     data["required_license"] = license_to_code(data.get("required_license"))
     user_email = current_user.get("sub")
     user_role = current_user.get("role")
+    if user_role not in ADMIN_ROLES | {"recruiter"} | CAREER_STAFF_ROLES:
+        raise HTTPException(status_code=403, detail="Not authorized to create jobs")
     # Autopopulate source for recruiters if missing or blank
     if user_role == "recruiter" or not data.get("source"):
         raw_user = redis_client.get(f"user:{user_email}")
@@ -2732,7 +2734,9 @@ async def _perform_match_async(
         for chunk in chunked_pairs(resolved_student_keys, 500):
             chunk_keys = [key for _, key in chunk]
             raw_values = redis_client.mget(chunk_keys)
-            for (email, _), raw in zip(chunk, raw_values):
+            for (email, key), raw in zip(chunk, raw_values):
+                if not raw and hasattr(redis_client, "get"):
+                    raw = redis_client.get(key)
                 if not raw:
                     continue
                 student_hits += 1
@@ -2788,7 +2792,9 @@ async def _perform_match_async(
         for chunk in chunked_pairs(user_lookup_entries, 500):
             chunk_keys = [key for _, key in chunk]
             raw_values = redis_client.mget(chunk_keys)
-            for (candidate_index, _), raw in zip(chunk, raw_values):
+            for (candidate_index, key), raw in zip(chunk, raw_values):
+                if not raw and hasattr(redis_client, "get"):
+                    raw = redis_client.get(key)
                 if raw:
                     user_hits += 1
                 if raw:
@@ -3384,6 +3390,8 @@ def has_match_data(job_id: str):
 
 @app.get("/jobs")
 def list_jobs(current_user: dict = Depends(get_current_user)):
+    role = current_user.get("role")
+    user_email = current_user.get("sub")
     jobs = []
     for key in redis_client.scan_iter("job:*"):
         job_data = redis_client.get(key)
@@ -3395,6 +3403,9 @@ def list_jobs(current_user: dict = Depends(get_current_user)):
             job.setdefault("rejected_students", [])
             job.setdefault("student_notes", {})
             jobs.append(job)
+
+    if role not in ADMIN_ROLES:
+        jobs = [job for job in jobs if job.get("posted_by") == user_email]
 
     def _timestamp_value(job: dict[str, Any]) -> float:
         raw = job.get("timestamp")

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -45,6 +45,7 @@ function AdminMenu({ children }) {
             <>
               <Link to="/students">Student Profiles</Link>
               <Link to="/career-info">Career Staff Info</Link>
+              <Link to="/recruiter/jobs">Job Matching</Link>
             </>
           )}
           {children}

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -43,7 +43,7 @@ function Dashboard() {
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
             <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
-            <Link to="/recruiter/jobs" className="dashboard-tile">Jobs</Link>
+            <Link to="/recruiter/jobs" className="dashboard-tile">Job Matching</Link>
           </>
         )}
 

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -43,6 +43,7 @@ function Dashboard() {
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
             <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
+            <Link to="/recruiter/jobs" className="dashboard-tile">Jobs</Link>
           </>
         )}
 

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -324,6 +324,7 @@ function JobPosting() {
   const isAdmin = userRole === 'admin' || userRole === 'junior_admin';
   const isRecruiter = userRole === 'recruiter';
   const isCareer = userRole === 'career' || userRole === 'career_director';
+  const canUseBlast = isAdmin || isRecruiter;
   const canAccessJobsPage = isAdmin || isRecruiter || isCareer;
   const shouldRedirect = !canAccessJobsPage;
 
@@ -510,6 +511,12 @@ function JobPosting() {
     },
     [loadMatchResults, stopPollingJob, token]
   );
+
+  useEffect(() => {
+    if (!canUseBlast && activeTab === 'blast') {
+      setActiveTab('jobs');
+    }
+  }, [activeTab, canUseBlast]);
 
   useEffect(() => {
     return () => {
@@ -1321,15 +1328,17 @@ function JobPosting() {
         >
           Post a Job
         </button>
-        <button
-          className={`tab ${activeTab === 'blast' ? 'active' : ''}`}
-          onClick={() => setActiveTab('blast')}
-        >
-          Email Blast
-        </button>
+        {canUseBlast && (
+          <button
+            className={`tab ${activeTab === 'blast' ? 'active' : ''}`}
+            onClick={() => setActiveTab('blast')}
+          >
+            Email Blast
+          </button>
+        )}
       </div>
       <div className="tab-content">
-        {activeTab === 'blast' && (
+        {activeTab === 'blast' && canUseBlast && (
           <div className="blast-content">
             <div className="blast-panel">
               <form className="blast-form" onSubmit={handleBlastSubmit}>

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -320,9 +320,12 @@ function JobPosting() {
   const token = localStorage.getItem('token');
   const decoded = token ? jwtDecode(token) : {};
   const userRole = decoded?.role;
-const { sub: email } = decoded;
-const isRecruiter = userRole === 'recruiter';
-const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && userRole !== 'recruiter';
+  const { sub: email } = decoded;
+  const isAdmin = userRole === 'admin' || userRole === 'junior_admin';
+  const isRecruiter = userRole === 'recruiter';
+  const isCareer = userRole === 'career' || userRole === 'career_director';
+  const canAccessJobsPage = isAdmin || isRecruiter || isCareer;
+  const shouldRedirect = !canAccessJobsPage;
 
 
   const formatJobDate = (value) => {
@@ -353,10 +356,10 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
         headers: { Authorization: `Bearer ${token}` }
       });
       const allJobs = resp.data.jobs || [];
-      const filtered = isRecruiter
-        ? allJobs.filter((job) => job.posted_by === email)
-        : allJobs;
-      const sorted = [...filtered].sort((a, b) => {
+      const visibleJobs = isAdmin
+        ? allJobs
+        : allJobs.filter((job) => job.posted_by === email);
+      const sorted = [...visibleJobs].sort((a, b) => {
         const aTime = a?.timestamp ? new Date(a.timestamp).getTime() : 0;
         const bTime = b?.timestamp ? new Date(b.timestamp).getTime() : 0;
         const safeATime = Number.isNaN(aTime) ? 0 : aTime;
@@ -1274,6 +1277,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
     return codeMatch && titleMatch && sourceMatch && createdMatch;
   };
   const filteredJobs = jobs.filter(matchFilter);
+  const jobsTabLabel = isCareer ? 'My Jobs' : 'Jobs';
 
   return (
     <div className="job-posting-container job-matching-module">
@@ -1309,7 +1313,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
           className={`tab ${activeTab === 'jobs' ? 'active' : ''}`}
           onClick={() => setActiveTab('jobs')}
         >
-          Jobs
+          {jobsTabLabel}
         </button>
         <button
           className={`tab ${activeTab === 'post' ? 'active' : ''}`}
@@ -1768,7 +1772,7 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                         if (!isExpanded) {
                           setActiveSubtab((prev) => ({
                             ...prev,
-                            [job.job_code]: 'matches',
+                            [job.job_code]: isCareer ? 'details' : 'matches',
                           }));
                         }
                       }}
@@ -1837,24 +1841,57 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                     </td>
                   )}
                   <td>
-                    {(() => {
-                      const matchListLength = matches[job.job_code]?.length || 0;
-                      const hasMatchInRedis = matchPresence[job.job_code] === true;
-                      const assignedCount = job.assigned_students?.length || 0;
-                      const hasStoredMatches =
-                        hasMatchInRedis || matchListLength > 0 || assignedCount > 0;
-                      console.debug(
-                        `🧠 [debug] Job ${job.job_code} button render -> matchPresence: ${hasMatchInRedis}, stored length: ${matchListLength}. Showing ${hasStoredMatches ? 'View Matches + Match Again' : 'Match only'} buttons.`
-                      );
+                    {isCareer ? (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const isExpanded = expandedJob === job.job_code;
+                          setExpandedJob(isExpanded ? null : job.job_code);
+                          setActiveSubtab((prev) => ({
+                            ...prev,
+                            [job.job_code]: 'details',
+                          }));
+                        }}
+                      >
+                        View Details
+                      </button>
+                    ) : (
+                      (() => {
+                        const matchListLength = matches[job.job_code]?.length || 0;
+                        const hasMatchInRedis = matchPresence[job.job_code] === true;
+                        const assignedCount = job.assigned_students?.length || 0;
+                        const hasStoredMatches =
+                          hasMatchInRedis || matchListLength > 0 || assignedCount > 0;
+                        console.debug(
+                          `🧠 [debug] Job ${job.job_code} button render -> matchPresence: ${hasMatchInRedis}, stored length: ${matchListLength}. Showing ${hasStoredMatches ? 'View Matches + Match Again' : 'Match only'} buttons.`
+                        );
 
-                      return hasStoredMatches ? (
-                        <>
+                        return hasStoredMatches ? (
+                          <>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (hasMatchInRedis && !matches[job.job_code]) {
+                                  loadMatchResults(job.job_code);
+                                }
+                                setExpandedJob(job.job_code);
+                                setActiveSubtab((prev) => ({
+                                  ...prev,
+                                  [job.job_code]: 'matches',
+                                }));
+                              }}
+                            >
+                              View Matches
+                            </button>
+                            <button onClick={() => handleRematch(job.job_code)}>
+                              Match Again
+                            </button>
+                          </>
+                        ) : (
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              if (hasMatchInRedis && !matches[job.job_code]) {
-                                loadMatchResults(job.job_code);
-                              }
+                              handleMatch(job.job_code);
                               setExpandedJob(job.job_code);
                               setActiveSubtab((prev) => ({
                                 ...prev,
@@ -1862,28 +1899,11 @@ const shouldRedirect = userRole !== 'admin' && userRole !== 'junior_admin' && us
                               }));
                             }}
                           >
-                            View Matches
+                            Match
                           </button>
-                          <button onClick={() => handleRematch(job.job_code)}>
-                            Match Again
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleMatch(job.job_code);
-                            setExpandedJob(job.job_code);
-                            setActiveSubtab((prev) => ({
-                              ...prev,
-                              [job.job_code]: 'matches',
-                            }));
-                          }}
-                        >
-                          Match
-                        </button>
-                      );
-                    })()}
+                        );
+                      })()
+                    )}
                   </td>
                 </tr>
                 {expandedJob === job.job_code && (

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -48,7 +48,7 @@ class DummyRedis:
         return val
 
     def mget(self, keys):
-        return [self.store.get(k) for k in keys]
+        return [self.get(k) for k in keys]
 
     def smembers(self, key):
         return self.sets.get(key, set())
@@ -69,7 +69,7 @@ class DummyRedis:
         return val
 
     def mget(self, keys):
-        return [self.store.get(k) for k in keys]
+        return [self.get(k) for k in keys]
 
     def flushdb(self):
         self.store.clear()
@@ -87,10 +87,32 @@ client = TestClient(app)
 def setup_module():
     main_app.redis_client.flushdb()
     init_default_admin()
+    main_app.vector_emails.clear()
+    main_app.vector_index = None
+    main_app.EMBEDDING_DIM = None
 
 
 def login_admin():
     resp = client.post("/login", json={"email": "admin@example.com", "password": "admin123"})
+    return resp.json()["token"]
+
+
+def register_user(email: str, role: str = "career", school_code: str = "1001"):
+    user = {
+        "email": email,
+        "first_name": "Test",
+        "last_name": "User",
+        "school_code": school_code,
+        "password": "pw",
+        "role": role,
+    }
+    client.post("/register", json=user)
+    key = f"user:{email}"
+    data = json.loads(main_app.redis_client.get(key))
+    data["approved"] = True
+    data["role"] = role
+    main_app.redis_client.set(key, json.dumps(data))
+    resp = client.post("/login", json={"email": email, "password": "pw"})
     return resp.json()["token"]
 
 
@@ -1451,6 +1473,82 @@ def test_student_note_multiple_posts_unassigned(monkeypatch):
     assert len(notes) == 2
     assert notes[0]["text"] == note1
     assert notes[-1]["text"] == note2
+
+
+def test_career_can_create_jobs_and_jobs_are_owned():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    career_email = "career1@example.com"
+    career_token = register_user(career_email, role="career")
+
+    job_payload = {
+        "job_title": "Career Posted Role",
+        "job_description": "Posted by career services",
+        "desired_skills": ["skill"],
+        "source": "career board",
+        "min_pay": 10.0,
+        "max_pay": 20.0,
+        "city": "City",
+        "state": "ST",
+        "lat": 0.0,
+        "lng": 0.0,
+    }
+
+    resp = client.post("/jobs", json=job_payload, headers={"Authorization": f"Bearer {career_token}"})
+    assert resp.status_code == 200
+    job_code = resp.json()["job_code"]
+
+    stored = json.loads(main_app.redis_client.get(f"job:{job_code}"))
+    assert stored["posted_by"] == career_email
+
+
+def test_job_listing_scoped_by_owner_for_non_admins():
+    main_app.redis_client.flushdb()
+    init_default_admin()
+
+    career1_email = "career1@example.com"
+    career2_email = "career2@example.com"
+    career1_token = register_user(career1_email, role="career")
+    career2_token = register_user(career2_email, role="career", school_code="1002")
+
+    def make_job(title):
+        return {
+            "job_title": title,
+            "job_description": "desc",
+            "desired_skills": ["python"],
+            "source": "career board",
+            "min_pay": 1.0,
+            "max_pay": 2.0,
+            "city": "City",
+            "state": "ST",
+            "lat": 0.0,
+            "lng": 0.0,
+        }
+
+    job_code1 = client.post(
+        "/jobs", json=make_job("Role 1"), headers={"Authorization": f"Bearer {career1_token}"}
+    ).json()["job_code"]
+    job_code2 = client.post(
+        "/jobs", json=make_job("Role 2"), headers={"Authorization": f"Bearer {career2_token}"}
+    ).json()["job_code"]
+
+    resp_career1 = client.get("/jobs", headers={"Authorization": f"Bearer {career1_token}"})
+    jobs_career1 = resp_career1.json()["jobs"]
+    assert len(jobs_career1) == 1
+    assert jobs_career1[0]["job_code"] == job_code1
+    assert jobs_career1[0]["posted_by"] == career1_email
+
+    resp_career2 = client.get("/jobs", headers={"Authorization": f"Bearer {career2_token}"})
+    jobs_career2 = resp_career2.json()["jobs"]
+    assert len(jobs_career2) == 1
+    assert jobs_career2[0]["job_code"] == job_code2
+    assert jobs_career2[0]["posted_by"] == career2_email
+
+    admin_token = login_admin()
+    resp_admin = client.get("/jobs", headers={"Authorization": f"Bearer {admin_token}"})
+    admin_job_codes = {job["job_code"] for job in resp_admin.json()["jobs"]}
+    assert {job_code1, job_code2}.issubset(admin_job_codes)
 
 
 def test_recruiter_can_add_note_for_assigned_student():


### PR DESCRIPTION
## Summary
- expose the recruiter jobs UI to career and career_director users and tailor labels/actions
- allow career staff to post jobs and see only their own postings in the frontend
- update backend job endpoints to authorize career roles, scope queries by owner, and set posted_by server-side
- add tests covering career job creation and scoping plus redis fallback handling

## Testing
- pytest
- npm run build --prefix frontend


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944530e3ccc83338b153f5efd38fac4)