### PR TITLE
Hide email blast for career staff and align job module naming

### DIFF
--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -43,7 +43,7 @@ function Dashboard() {
             <Link to="/students" className="dashboard-tile">Student Profiles</Link>
             <Link to="/metrics" className="dashboard-tile">School Metrics</Link>
             <Link to="/career-info" className="dashboard-tile">Career Staff Information</Link>
-            <Link to="/recruiter/jobs" className="dashboard-tile">Jobs</Link>
+            <Link to="/recruiter/jobs" className="dashboard-tile">Job Matching</Link>
           </>
         )}
 

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -324,6 +324,7 @@ function JobPosting() {
   const isAdmin = userRole === 'admin' || userRole === 'junior_admin';
   const isRecruiter = userRole === 'recruiter';
   const isCareer = userRole === 'career' || userRole === 'career_director';
+  const canUseBlast = isAdmin || isRecruiter;
   const canAccessJobsPage = isAdmin || isRecruiter || isCareer;
   const shouldRedirect = !canAccessJobsPage;
 
@@ -510,6 +511,12 @@ function JobPosting() {
     },
     [loadMatchResults, stopPollingJob, token]
   );
+
+  useEffect(() => {
+    if (!canUseBlast && activeTab === 'blast') {
+      setActiveTab('jobs');
+    }
+  }, [activeTab, canUseBlast]);
 
   useEffect(() => {
     return () => {
@@ -1321,15 +1328,17 @@ function JobPosting() {
         >
           Post a Job
         </button>
-        <button
-          className={`tab ${activeTab === 'blast' ? 'active' : ''}`}
-          onClick={() => setActiveTab('blast')}
-        >
-          Email Blast
-        </button>
+        {canUseBlast && (
+          <button
+            className={`tab ${activeTab === 'blast' ? 'active' : ''}`}
+            onClick={() => setActiveTab('blast')}
+          >
+            Email Blast
+          </button>
+        )}
       </div>
       <div className="tab-content">
-        {activeTab === 'blast' && (
+        {activeTab === 'blast' && canUseBlast && (
           <div className="blast-content">
             <div className="blast-panel">
               <form className="blast-form" onSubmit={handleBlastSubmit}>


### PR DESCRIPTION
## Summary
- hide the email blast tab and content for career roles while preventing navigation to it
- rename the career dashboard job tile to "Job Matching" to match recruiter-facing naming

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944901536908333b8ccb0dc6cfd8254)