### PR TITLE
Send assignment notifications to students

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3956,14 +3956,42 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
     role = token_data.get("role")
     if role == "recruiter" and job.get("posted_by") != token_data.get("sub"):
         raise HTTPException(status_code=403, detail="Not authorized to modify this job")
-    if role not in ADMIN_ROLES | {"recruiter"}:
+    if role not in ADMIN_ROLES | {"recruiter"} | CAREER_STAFF_ROLES:
         raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    student_key_resolved = resolve_student_key(student_email)
+    student_raw = redis_client.get(student_key_resolved) if student_key_resolved else None
+    student: dict[str, Any] | None = None
+    if student_raw:
+        try:
+            student = json.loads(student_raw)
+        except Exception:
+            raise HTTPException(status_code=500, detail="Corrupted profile data")
+
+    if role in CAREER_STAFF_ROLES:
+        user_raw = redis_client.get(user_key(token_data.get("sub")))
+        if not user_raw:
+            raise HTTPException(status_code=404, detail="User not found")
+        try:
+            user = json.loads(user_raw)
+        except Exception:
+            raise HTTPException(status_code=500, detail="Corrupted user data")
+        codes = _extract_institutional_codes(user)
+        if not codes:
+            raise HTTPException(status_code=400, detail="Institutional code required")
+        st_code = _student_institutional_code(student)
+        if not st_code or st_code.lower() not in {code.lower() for code in codes}:
+            raise HTTPException(status_code=403, detail="Not authorized")
+        if role == "career" and student and student.get("created_by") != token_data.get("sub"):
+            raise HTTPException(status_code=403, detail="Not authorized")
     job.setdefault("assigned_students", [])
+    new_assignment = False
     if student_email not in job["assigned_students"]:
         job["assigned_students"].append(student_email)
         _add_student_job(student_email, job_code, "assigned")
         _remove_student_job(student_email, job_code, "rejected")
         _remove_student_job(student_email, job_code, "uninterested")
+        new_assignment = True
 
     if note is not None:
         note_obj = {
@@ -4000,6 +4028,14 @@ def assign_student(data: dict, token_data: dict = Depends(get_current_user)):
     resp = {"message": f"Assigned {student_email}"}
     if note is not None:
         resp["notes"] = job["student_notes"][student_email]
+    if new_assignment:
+        try:
+            _send_candidate_notification(job, student_email)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.error("Notification email failed: %s", exc)
+            raise HTTPException(status_code=500, detail="Failed to send notification email")
     return resp
 
 
@@ -4309,24 +4345,12 @@ def mark_not_interested(data: dict, token_data: dict = Depends(get_current_user)
     return {"message": "Not interested recorded"}
 
 
-@app.post("/notify-interest")
-def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
-    """Notify a student that a recruiter is interested and send them a job description."""
-    job_code = data.get("job_code")
-    student_email = data.get("student_email")
-    if not job_code or not student_email:
-        raise HTTPException(status_code=400, detail="Missing job_code or student_email")
+def _send_candidate_notification(job: dict, student_email: str) -> None:
+    job_code = job.get("job_code")
+    if not job_code:
+        raise HTTPException(status_code=400, detail="Job code missing")
 
-    key = f"job:{job_code}"
-    raw = redis_client.get(key)
-    if not raw:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    job = json.loads(raw)
-    if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
-        raise HTTPException(status_code=400, detail="Student not assigned to job")
-
-    desc_html, _ = generate_job_description_html(job_code, student_email)
+    generate_job_description_html(job_code, student_email)
 
     skey = resolve_student_key(student_email)
     student_raw = redis_client.get(skey) if skey else None
@@ -4399,9 +4423,29 @@ def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
             html_body=html_body,
             track_token=token,
         )
-    except Exception as e:
-        logger.error("Notification email failed: %s", e)
+    except Exception as exc:
+        logger.error("Notification email failed: %s", exc)
         raise HTTPException(status_code=500, detail="Failed to send notification email")
+
+
+@app.post("/notify-interest")
+def notify_interest(data: dict, token_data: dict = Depends(get_current_user)):
+    """Notify a student that a recruiter is interested and send them a job description."""
+    job_code = data.get("job_code")
+    student_email = data.get("student_email")
+    if not job_code or not student_email:
+        raise HTTPException(status_code=400, detail="Missing job_code or student_email")
+
+    key = f"job:{job_code}"
+    raw = redis_client.get(key)
+    if not raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = json.loads(raw)
+    if student_email not in job.get("assigned_students", []) and student_email not in job.get("placed_students", []):
+        raise HTTPException(status_code=400, detail="Student not assigned to job")
+
+    _send_candidate_notification(job, student_email)
 
     return {"message": "Notification sent"}
 

--- a/frontend/src/AdminMenu.js
+++ b/frontend/src/AdminMenu.js
@@ -45,6 +45,7 @@ function AdminMenu({ children }) {
             <>
               <Link to="/students">Student Profiles</Link>
               <Link to="/career-info">Career Staff Info</Link>
+              <Link to="/recruiter/jobs">Job Matching</Link>
             </>
           )}
           {children}


### PR DESCRIPTION
## Summary
- allow career staff to assign students with institutional checks
- send student notification email automatically on first assignment
- reuse a shared helper for notify-interest emails

## Testing
- pytest -q tests/test_main.py::test_notify_interest_missing_smtp


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694491b2f1c083338d86262e0be82f87)