### PR TITLE
Allow career staff to match and assign their jobs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2389,6 +2389,18 @@ def match_job(
     """Launch a background matching job and return immediately."""
 
     job_id = str(uuid.uuid4())
+    job_key = f"job:{req.job_code}"
+    job_raw = redis_client.get(job_key)
+    if not job_raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    try:
+        job = json.loads(job_raw)
+    except Exception:
+        raise HTTPException(status_code=500, detail="Malformed job record")
+
+    role = current_user.get("role")
+    if role not in ADMIN_ROLES and job.get("posted_by") != current_user.get("sub"):
+        raise HTTPException(status_code=403, detail="Not authorized to match this job")
 
     enqueue_time = datetime.now().timestamp()
     request_id = getattr(request.state, "request_id", None)
@@ -2409,6 +2421,19 @@ def rematch_job(
     current_user: dict = Depends(get_current_user),
 ):
     """Queue a rematch computation without notifying students."""
+    job_key = f"job:{job_code}"
+    job_raw = redis_client.get(job_key)
+    if not job_raw:
+        raise HTTPException(status_code=404, detail="Job not found")
+    try:
+        job = json.loads(job_raw)
+    except Exception:
+        raise HTTPException(status_code=500, detail="Malformed job record")
+
+    role = current_user.get("role")
+    if role not in ADMIN_ROLES and job.get("posted_by") != current_user.get("sub"):
+        raise HTTPException(status_code=403, detail="Not authorized to rematch this job")
+
     enq_time = datetime.now().timestamp()
     job_id = str(uuid.uuid4())
     request_id = getattr(request.state, "request_id", None)

--- a/frontend/src/JobPosting.js
+++ b/frontend/src/JobPosting.js
@@ -324,6 +324,7 @@ function JobPosting() {
   const isAdmin = userRole === 'admin' || userRole === 'junior_admin';
   const isRecruiter = userRole === 'recruiter';
   const isCareer = userRole === 'career' || userRole === 'career_director';
+  const canMatchJobs = isAdmin || isRecruiter || isCareer;
   const canUseBlast = isAdmin || isRecruiter;
   const canAccessJobsPage = isAdmin || isRecruiter || isCareer;
   const shouldRedirect = !canAccessJobsPage;
@@ -832,7 +833,7 @@ function JobPosting() {
       jobCode: job.job_code,
       studentEmail: row.email,
       canAdd:
-        isRecruiter &&
+        (isAdmin || isRecruiter || isCareer) &&
         job.posted_by === email &&
         row.status === 'assigned',
       onSaved: (newNote) => {
@@ -1781,7 +1782,7 @@ function JobPosting() {
                         if (!isExpanded) {
                           setActiveSubtab((prev) => ({
                             ...prev,
-                            [job.job_code]: isCareer ? 'details' : 'matches',
+                            [job.job_code]: 'matches',
                           }));
                         }
                       }}
@@ -1850,21 +1851,7 @@ function JobPosting() {
                     </td>
                   )}
                   <td>
-                    {isCareer ? (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          const isExpanded = expandedJob === job.job_code;
-                          setExpandedJob(isExpanded ? null : job.job_code);
-                          setActiveSubtab((prev) => ({
-                            ...prev,
-                            [job.job_code]: 'details',
-                          }));
-                        }}
-                      >
-                        View Details
-                      </button>
-                    ) : (
+                    {canMatchJobs ? (
                       (() => {
                         const matchListLength = matches[job.job_code]?.length || 0;
                         const hasMatchInRedis = matchPresence[job.job_code] === true;
@@ -1912,6 +1899,20 @@ function JobPosting() {
                           </button>
                         );
                       })()
+                    ) : (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const isExpanded = expandedJob === job.job_code;
+                          setExpandedJob(isExpanded ? null : job.job_code);
+                          setActiveSubtab((prev) => ({
+                            ...prev,
+                            [job.job_code]: 'details',
+                          }));
+                        }}
+                      >
+                        View Details
+                      </button>
                     )}
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- authorize match/rematch requests only for the job owner or admins while keeping career-staff support
- let career staff run match/rematch and manage notes from the job matching module with the same controls as recruiters
- default job expansion into matches so career staff can immediately view and act on candidates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694495e4ae408333b25c66b2ec82fc2f)